### PR TITLE
Add a function for console logging in tests, to keep things cleaner

### DIFF
--- a/test/log.js
+++ b/test/log.js
@@ -1,0 +1,5 @@
+export function log(message, forceEnabled = false) {
+    if (process.env.DEBUG === 'true' || forceEnabled) {
+        console.log(message);
+    }
+}

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -295,19 +295,19 @@ describe('Sanity Queries', function () {
 
     test('fetchAll-GroupBy-Genre', async () => {
         let response = await fetchAll('drumeo', 'solo',{groupBy: 'genre'});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].web_url_path).toContain('/drumeo/genres/');
     });
 
     test('fetchAll-GroupBy-Artists', async () => {
         let response = await fetchAll('drumeo', 'song',{groupBy: 'artist'});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].web_url_path).toContain('/drumeo/artists/');
     });
 
     test('fetchAll-GroupBy-Instructors', async () => {
         let response = await fetchAll('drumeo', 'course',{groupBy: 'instructor'});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].web_url_path).toContain('/drumeo/coaches/');
     });
 });

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -1,4 +1,5 @@
 import {initializeService} from '../src/services/config.js';
+import {log} from './log.js';
 
 const {
     fetchSongById,
@@ -66,7 +67,7 @@ describe('Sanity Queries', function () {
 
     test('fetchSongArtistCount', async () => {
         const response = await fetchSongArtistCount('drumeo');
-        // console.log(response);
+        log(response);
         expect(response).toBeGreaterThan(1000);
     });
 
@@ -95,7 +96,7 @@ describe('Sanity Queries', function () {
 
     test('fetchAllSongs', async () => {
         const response = await fetchAllSongs('drumeo', {});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].soundslice).toBeDefined();
         expect(response.entity[0].artist_name).toBeDefined();
         expect(response.entity[0].instrumentless).toBeDefined();
@@ -111,20 +112,20 @@ describe('Sanity Queries', function () {
 
     test('fetchAllWorkouts', async () => {
         const response = await fetchAll('drumeo', 'workout',{});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].id).toBeDefined();
     });
 
     test('fetchAllInstructorField', async () => {
         const response = await fetchAll('drumeo', 'quick-tips',{searchTerm: 'Domino Santantonio'});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].id).toBeDefined();
         expect(response.entity[0].instructors).toBeTruthy();
     });
 
     test('fetchAllSortField', async () => {
         const response = await fetchAll('drumeo', 'rhythmic-adventures-of-captain-carson',{});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].id).toBeDefined();
         expect(response.entity[0].sort).toBeDefined();
     });
@@ -132,7 +133,7 @@ describe('Sanity Queries', function () {
 
     test('fetchAllChallenges', async () => {
         const response = await fetchAll('drumeo', 'challenge',{});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].registration_url).toBeDefined();
         expect(response.entity[0].enrollment_start_time).toBeDefined();
         expect(response.entity[0].enrollment_end_time).toBeDefined();
@@ -146,12 +147,12 @@ describe('Sanity Queries', function () {
 
     test('fetchAll-CustomFields', async () => {
         let response = await fetchAll('drumeo', 'challenge',{customFields:['garbage']});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].garbage).toBeDefined();
         expect(response.entity[0].id).toBeDefined();
 
         response = await fetchAll('drumeo', 'challenge',{useDefaultFields: false, customFields:['garbage']});
-        // console.log(response);
+        log(response);
         expect(response.entity[0].garbage).toBeDefined();
         expect.not.objectContaining(response.entity[0].id);
     });
@@ -177,8 +178,8 @@ describe('Sanity Queries', function () {
         const id = 191338; ////https://web-staging-one.musora.com/admin/studio/publishing/structure/play-along;play-along_191338
         const expectedChildID = 191492;
         const response = await fetchChildren(id);
-        // console.log('num children', response.length);
-        // console.log(response);
+        log('num children', response.length);
+        log(response);
         
         expect(response.length > 0).toBeTruthy();
         const foundExpectedChild = response.some((child) => {
@@ -209,15 +210,14 @@ describe('Sanity Queries', function () {
     });
 
     test('fetchMethod', async () => {
-        const response = await fetchMethod('drumeo', 'drumeo-method');
-        //console.log(response);
+        const response = await fetchMethod('drumeo', 'drumeo-method');log(response);
         expect(response).toBeDefined();
         expect(response.levels.length).toBeGreaterThan(0);
     });
 
     test('fetchMethods', async () => {
         const response = await fetchMethods('drumeo');
-        // console.log(response);
+        log(response);
         expect(response.length).toBeGreaterThan(0);
         expect(response[0].type).toBe('learning-path');
     });
@@ -250,15 +250,14 @@ describe('Sanity Queries', function () {
     });
 
     test('fetchFoundation', async () => {
-        const response = await fetchFoundation('foundations-2019');
-        //  console.log(response);
+        const response = await fetchFoundation('foundations-2019');log(response);
         expect(response.units.length).toBeGreaterThan(0);
         expect(response.type).toBe('foundation');
     });
 
     test('fetchPackAll', async () => {
         const response = await fetchPackAll(212899); //https://web-staging-one.musora.com/admin/studio/publishing/structure/pack;pack_212899%2Cinspect%3Don
-        // console.log(response);
+        log(response);
         expect(response.slug).toBe('creative-control');
     });
 


### PR DESCRIPTION
I think it's nicer to not have console logging when we run our tests, but wanted to make a quick and easy way to enable it when it's desired.