### PR TITLE
Refactor fetch all to use buildEnitytAndTotal method

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -495,58 +495,145 @@ export async function fetchAll(brand, type, {
 
     // Determine the group by clause
     let query = "";
+    let entityFieldsString = "";
+    let filter = "";
     if (groupBy !== "" && isGroupByOneToOne) {
-        let webUrlPath = 'artists';
-        query = `
-        {
-            "total": count(*[_type == '${groupBy}' && count(*[brand == '${brand}' && ^._id == ${groupBy}._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id) > 0]),
-            "entity": *[_type == '${groupBy}' && count(*[brand == '${brand}' && ^._id == ${groupBy}._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id) > 0]
-            {
+        const webUrlPath = 'artists';
+        const lessonsFilter = `_type == '${type}' && brand == '${brand}' && ^._id == ${groupBy}._ref ${searchFilter} ${includedFieldsFilter} ${progressFilter}`;
+        entityFieldsString = `
                 'id': _id,
                 'type': _type,
                 name,
                 'head_shot_picture_url': thumbnail_url.asset->url,
                 'web_url_path': '/${brand}/${webUrlPath}/'+name+'?included_fieds[]=type,${type}',
-                'all_lessons_count': count(*[_type == '${type}' && brand == '${brand}' && ^._id == ${groupBy}._ref ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id),
-                'lessons': *[_type == '${type}' && brand == '${brand}' && ^._id == ${groupBy}._ref ${searchFilter} ${includedFieldsFilter} ${progressFilter}]{
+                'all_lessons_count': count(*[${lessonsFilter}]._id),
+                'lessons': *[${lessonsFilter}]{
                     ${fieldsString},
                     ${groupBy}
                 }[0...20]
-            }
-            |order(${sortOrder})
-            [${start}...${end}]
-        }`;
+        `;
+        filter = `_type == '${groupBy}' && count(*[brand == '${brand}' && ^._id == ${groupBy}._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id) > 0`;
     } else if (groupBy !== "") {
-        let webUrlPath = (groupBy == 'genre')?'/genres':'';
-        query = `
-        {
-            "total": count(*[_type == '${groupBy}' && count(*[brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id) > 0]),
-            "entity": *[_type == '${groupBy}' && count(*[brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id) > 0]
-            {
+        const webUrlPath = (groupBy == 'genre')?'/genres':'';
+        const lessonsFilter = `brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}`;
+        entityFieldsString = `
                 'id': _id,
                 'type': _type,
                 name,
                 'head_shot_picture_url': thumbnail_url.asset->url,
                 'web_url_path': select(defined(web_url_path)=> web_url_path +'?included_fieds[]=type,${type}',!defined(web_url_path)=> '/${brand}${webUrlPath}/'+name+'/${webUrlPathType}'),
-                'all_lessons_count': count(*[brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id),
-                'lessons': *[brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]{
+                'all_lessons_count': count(*[${lessonsFilter}]._id),
+                'lessons': *[${lessonsFilter}]{
+                    ${fieldsString},
+                    ${groupBy}
+                }[0...20]`;
+        filter = `_type == '${groupBy}' && count(*[brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id) > 0]`;
+    } else {
+        filter = `brand == "${brand}" ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}`
+        entityFieldsString = fieldsString;
+    }
+    query = buildEntityAndTotalQuery(
+        filter,
+        entityFieldsString,
+        {
+            sortOrder: sortOrder,
+            start: start,
+            end: end,
+        });
+
+    return fetchSanity(query, true);
+}
+
+export async function fetchAllOld(brand, type, {
+    page = 1,
+    limit = 10,
+    searchTerm = "",
+    sort = "-published_on",
+    includedFields = [],
+    groupBy = "",
+    progressIds = undefined,
+    useDefaultFields = true,
+    customFields = [],
+} = {}) {
+    let config = contentTypeConfig[type] ?? {};
+    let additionalFields = config?.fields ?? [];
+    let isGroupByOneToOne = (groupBy ? config?.relationships?.[groupBy]?.isOneToOne : false) ?? false;
+    let webUrlPathType = config?.slug ?? type;
+    const start = (page - 1) * limit;
+    const end = start + limit;
+
+    // Construct the type filter
+    const typeFilter = type ? `&& _type == '${type}'` : "";
+
+    // Construct the search filter
+    const searchFilter = searchTerm
+        ? groupBy !== "" ?
+            `&& (^.name match "${searchTerm}*" || title match "${searchTerm}*")`
+            : `&& (artist->name match "${searchTerm}*" || instructor[]->name match "${searchTerm}*" || title match "${searchTerm}*" || name match "${searchTerm}*")`
+        : "";
+
+    // Construct the included fields filter, replacing 'difficulty' with 'difficulty_string'
+    const includedFieldsFilter = includedFields.length > 0
+        ? filtersToGroq(includedFields)
+        : "";
+
+    // limits the results to supplied progressIds for started & completed filters
+    const progressFilter = progressIds !== undefined ?
+        `&& railcontent_id in [${progressIds.join(',')}]` : "";
+
+    // Determine the sort order
+    const sortOrder = getSortOrder(sort);
+
+    let fields = useDefaultFields ?  customFields.concat(DEFAULT_FIELDS, additionalFields) : customFields;
+    let fieldsString = fields.join(',');
+
+    // Determine the group by clause
+    let query = "";
+    let entityFieldsString = "";
+    let filter = "";
+    if (groupBy !== "" && isGroupByOneToOne) {
+        const webUrlPath = 'artists';
+        const lessonsFilter = `_type == '${type}' && brand == '${brand}' && ^._id == ${groupBy}._ref ${searchFilter} ${includedFieldsFilter} ${progressFilter}`;
+        entityFieldsString = `
+                'id': _id,
+                'type': _type,
+                name,
+                'head_shot_picture_url': thumbnail_url.asset->url,
+                'web_url_path': '/${brand}/${webUrlPath}/'+name+'?included_fieds[]=type,${type}',
+                'all_lessons_count': count(*[${lessonsFilter}]._id),
+                'lessons': *[${lessonsFilter}]{
                     ${fieldsString},
                     ${groupBy}
                 }[0...20]
-            }
-            |order(${sortOrder})
-            [${start}...${end}]
-        }`;
+        `;
+        filter = `_type == '${groupBy}' && count(*[brand == '${brand}' && ^._id == ${groupBy}._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id) > 0`;
+    } else if (groupBy !== "") {
+        const webUrlPath = (groupBy == 'genre')?'/genres':'';
+        const lessonsFilter = `brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}`;
+        entityFieldsString = `
+                'id': _id,
+                'type': _type,
+                name,
+                'head_shot_picture_url': thumbnail_url.asset->url,
+                'web_url_path': select(defined(web_url_path)=> web_url_path +'?included_fieds[]=type,${type}',!defined(web_url_path)=> '/${brand}${webUrlPath}/'+name+'/${webUrlPathType}'),
+                'all_lessons_count': count(*[${lessonsFilter}]._id),
+                'lessons': *[${lessonsFilter}]{
+                    ${fieldsString},
+                    ${groupBy}
+                }[0...20]`;
+        filter = `_type == '${groupBy}' && count(*[brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}]._id) > 0]`;
     } else {
-        query = `
-        {
-            "entity": *[brand == "${brand}" ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}] | order(${sortOrder}) [${start}...${end}] {
-                ${fieldsString},
-            },
-            "total": count(*[brand == "${brand}" ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}])
-        }
-    `;
+        filter = `brand == "${brand}" ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter}`
+        entityFieldsString = fieldsString;
     }
+    query = buildEntityAndTotalQuery(
+        filter,
+        entityFieldsString,
+        {
+            sortOrder: sortOrder,
+            start: start,
+            end: end,
+        });
 
     return fetchSanity(query, true);
 }
@@ -974,7 +1061,7 @@ export async function fetchAllPacks(brand, sort = "-published_on", searchTerm = 
   const query = buildQuery(
     filter,
     filterParams,
-    fields,
+    getFieldsForContentType('pack'),
     {
       logo_image_url: 'logo_image_url.asset->url',
       sortOrder: sortOrder,

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -354,7 +354,7 @@ describe('Sanity Queries', function () {
     });
 
     test('fetchAll-GroupBy-Instructors', async () => {
-        let response = await fetchAllOld('drumeo', 'course',{groupBy: 'instructor'});
+        let response = await fetchAll('drumeo', 'course',{groupBy: 'instructor'});
         log(response);
         expect(response.entity[0].web_url_path).toContain('/drumeo/coaches/');
     });
@@ -374,62 +374,6 @@ describe('Sanity Queries', function () {
     });
 
 });
-
-describe('FetchAllRefactor', function () {
-    beforeEach(() => {
-        const config = {
-            sanityConfig: {
-                token: process.env.SANITY_API_TOKEN,
-                projectId: process.env.SANITY_PROJECT_ID,
-                dataset: process.env.SANITY_DATASET,
-                useCachedAPI: process.env.SANITY_USE_CACHED_API === 'true' || true,
-                version: '2021-06-07',
-                debug: process.env.DEBUG === 'true' || false
-            }
-        };
-        initializeService(config);
-    });
-    test('fetchAll-Progress', async () => {
-        const ids = [410213, 305649];
-        await compareOldAndNew('drumeo', 'song', {
-            sort: 'slug',
-            progressIds: ids,
-        });
-    });
-
-    test('fetchAll-GroupBy-Artists', async () => {
-        await compareOldAndNew('drumeo', 'song',{groupBy: 'artist'});
-    });
-
-    test('fetchAll-IncludedFields', async () => {
-        await compareOldAndNew('drumeo', 'instructor',{includedFields: ['is_active']});
-    });
-
-    test('fetchAll-GroupBy-Instructors', async () => {
-        await compareOldAndNew('drumeo', 'course',{groupBy: 'instructor'});
-    });
-
-    test('fetchAll-CustomFields', async () => {
-        await compareOldAndNew('drumeo', 'challenge',{customFields:['garbage']});
-    });
-
-    test('fetchAllSortField', async () => {
-        await compareOldAndNew('drumeo', 'rhythmic-adventures-of-captain-carson',{});
-    });
-
-    test('fetchAll-GroupBy-Genre', async () => {
-        await compareOldAndNew('drumeo', 'solo', {groupBy: 'genre'});
-    });
-
-    async function compareOldAndNew(brand, type, params={}){
-        let response = await fetchAll(brand, type,params);
-        let response2 = await fetchAllOld(brand, type,params);
-        log(response);
-        log(response2);
-        expect(response).toStrictEqual(response2);
-    }
-});
-
 
 describe('Filter Builder', function () {
 

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -14,6 +14,7 @@ const {
     fetchByRailContentId,
     fetchByRailContentIds,
     fetchAll,
+    fetchAllOld,
     fetchAllFilterOptions,
     fetchFoundation,
     fetchMethods,
@@ -353,7 +354,7 @@ describe('Sanity Queries', function () {
     });
 
     test('fetchAll-GroupBy-Instructors', async () => {
-        let response = await fetchAll('drumeo', 'course',{groupBy: 'instructor'});
+        let response = await fetchAllOld('drumeo', 'course',{groupBy: 'instructor'});
         log(response);
         expect(response.entity[0].web_url_path).toContain('/drumeo/coaches/');
     });
@@ -373,6 +374,40 @@ describe('Sanity Queries', function () {
     });
 
 });
+
+describe('FetchAllRefactor', function () {
+    beforeEach(() => {
+        const config = {
+            sanityConfig: {
+                token: process.env.SANITY_API_TOKEN,
+                projectId: process.env.SANITY_PROJECT_ID,
+                dataset: process.env.SANITY_DATASET,
+                useCachedAPI: process.env.SANITY_USE_CACHED_API === 'true' || true,
+                version: '2021-06-07',
+                debug: process.env.DEBUG === 'true' || false
+            }
+        };
+        initializeService(config);
+    });
+    test('baseConstructor', async () => {
+        const ids = [410213, 305649];
+        let response = await fetchAll('drumeo', 'song', {
+            sort: 'slug',
+            progressIds: ids,
+        });
+
+        let response2 = await fetchAllOld('drumeo', 'song', {
+            sort: 'slug',
+            progressIds: ids,
+        });
+        log(response);
+        log(response2);
+        expect(response).toStrictEqual(response2);
+    });
+
+
+});
+
 
 describe('Filter Builder', function () {
 

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -389,23 +389,45 @@ describe('FetchAllRefactor', function () {
         };
         initializeService(config);
     });
-    test('baseConstructor', async () => {
+    test('fetchAll-Progress', async () => {
         const ids = [410213, 305649];
-        let response = await fetchAll('drumeo', 'song', {
+        await compareOldAndNew('drumeo', 'song', {
             sort: 'slug',
             progressIds: ids,
         });
+    });
 
-        let response2 = await fetchAllOld('drumeo', 'song', {
-            sort: 'slug',
-            progressIds: ids,
-        });
+    test('fetchAll-GroupBy-Artists', async () => {
+        await compareOldAndNew('drumeo', 'song',{groupBy: 'artist'});
+    });
+
+    test('fetchAll-IncludedFields', async () => {
+        await compareOldAndNew('drumeo', 'instructor',{includedFields: ['is_active']});
+    });
+
+    test('fetchAll-GroupBy-Instructors', async () => {
+        await compareOldAndNew('drumeo', 'course',{groupBy: 'instructor'});
+    });
+
+    test('fetchAll-CustomFields', async () => {
+        await compareOldAndNew('drumeo', 'challenge',{customFields:['garbage']});
+    });
+
+    test('fetchAllSortField', async () => {
+        await compareOldAndNew('drumeo', 'rhythmic-adventures-of-captain-carson',{});
+    });
+
+    test('fetchAll-GroupBy-Genre', async () => {
+        await compareOldAndNew('drumeo', 'solo', {groupBy: 'genre'});
+    });
+
+    async function compareOldAndNew(brand, type, params={}){
+        let response = await fetchAll(brand, type,params);
+        let response2 = await fetchAllOld(brand, type,params);
         log(response);
         log(response2);
         expect(response).toStrictEqual(response2);
-    });
-
-
+    }
 });
 
 


### PR DESCRIPTION
I need to cleanup this function to implement the new groupby methods for challenges (which are not included in this PR, this is a strict 1:1 refactor). It will need another refactor later to include the filterBuilder, but step by step.

**Testing**
- added a testsuite that compares the responses of the old and new method :) verify that they're strictly equal

Once this is approved, I will remove the `fetchAllOld` method and `FetchAllRefactor` testsuite.