### PR TITLE
Add ability to exclude exports from the generated index files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ To install the package, use npm:
 npm install musora-content-services
 ```
 
+## Generating index.js and index.d.ts
+
+The `index.js` and `index.d.ts` files provide all exported functions from this package, and are generated automatically.
+Simply run `npm run build-index` to build these files. It works by running the `tools/generate-index.js` file, which simply 
+parses the files under the `src/services` directory and builds up the index files with any functions tagged with `export`.
+
+If you want to exclude any of your exported functions from the generated index files, be sure to add the function name to 
+the `excludeFromGeneratedIndex` array inside the service file.
+
 ## Publishing Package Updates
 
 To publish a new version to NPM run, 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,7 +19,6 @@ import {
 	fetchContentPageUserData,
 	fetchHandler,
 	fetchSongsInProgress,
-	fetchUserLikes,
 	fetchUserPermissions,
 	fetchVimeoData
 } from './services/railcontent.js';
@@ -120,7 +119,6 @@ declare module 'musora-content-services' {
 		fetchSongFilterOptions,
 		fetchSongsInProgress,
 		fetchUpcomingEvents,
-		fetchUserLikes,
 		fetchUserPermissions,
 		fetchVimeoData,
 		fetchWorkouts,

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,6 @@ import {
 	fetchContentPageUserData,
 	fetchHandler,
 	fetchSongsInProgress,
-	fetchUserLikes,
 	fetchUserPermissions,
 	fetchVimeoData
 } from './services/railcontent.js';
@@ -119,7 +118,6 @@ export {
 	fetchSongFilterOptions,
 	fetchSongsInProgress,
 	fetchUpcomingEvents,
-	fetchUserLikes,
 	fetchUserPermissions,
 	fetchVimeoData,
 	fetchWorkouts,

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -7,7 +7,14 @@ let globalConfig = {
     railcontentConfig: {},
     localStorage: null
   };
-  
+
+/**
+ * Exported functions that are excluded from index generation.
+ *
+ * @type {string[]}
+ */
+const excludeFromGeneratedIndex = [];
+
 /**
  * Initializes the service with the given configuration.
  * This function must be called before using any other functions in this library.

--- a/src/services/contentLikes.js
+++ b/src/services/contentLikes.js
@@ -1,6 +1,13 @@
 import {fetchUserLikes, postContentLiked, postContentUnliked} from "./railcontent";
 import {DataContext, ContentVersionKey} from "./dataContext";
 
+/**
+ * Exported functions that are excluded from index generation.
+ *
+ * @type {string[]}
+ */
+const excludeFromGeneratedIndex = [];
+
 export let dataContext = new DataContext(ContentVersionKey, fetchUserLikes);
 
 export async function isContentLiked(contentId) {

--- a/src/services/dataContext.js
+++ b/src/services/dataContext.js
@@ -1,5 +1,12 @@
 import {globalConfig} from "./config";
 
+/**
+ * Exported functions that are excluded from index generation.
+ *
+ * @type {string[]}
+ */
+const excludeFromGeneratedIndex = [];
+
 //These constants need to match MWP UserDataVersionKeyEnum enum
 export const ContentVersionKey = 0;
 

--- a/src/services/railcontent.js
+++ b/src/services/railcontent.js
@@ -4,6 +4,13 @@
 
 const {globalConfig} = require('./config');
 
+/**
+ * Exported functions that are excluded from index generation.
+ *
+ * @type {string[]}
+ */
+const excludeFromGeneratedIndex = ['fetchUserLikes', 'postContentLiked', 'postContentUnliked'];
+
 
 /**
  * Fetches the completion status of a specific lesson for the current user.

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -26,6 +26,12 @@ import { fetchUserPermissions, fetchAllCompletedStates, fetchCurrentSongComplete
 import {arrayToStringRepresentation, FilterBuilder} from "../filterBuilder";
 
 /**
+ * Exported functions that are excluded from index generation.
+ *
+ * @type {string[]}
+ */
+const excludeFromGeneratedIndex = [];
+/**
 * Fetch a song by its document ID from Sanity.
 *
 * @param {string} documentId - The ID of the document to fetch.

--- a/tools/generate-index.js
+++ b/tools/generate-index.js
@@ -11,7 +11,7 @@ const fileExports = {};
 /**
  * Helper function to extract function names from ES module and CommonJS exports
  *
- * @param filePath
+ * @param {string} filePath
  * @returns {string[]}
  */
 function extractExportedFunctions(filePath) {
@@ -30,9 +30,29 @@ function extractExportedFunctions(filePath) {
         matches = matches.concat(exportsList);
     }
 
+    const excludedFunctions = getExclusionList(fileContent);
+    matches = matches.filter(fn => !excludedFunctions.includes(fn));
+
     return matches.sort();
 }
 
+/**
+ * Helper function to find the list of exclusions from the file's exports
+ *
+ * @param {string} fileContent
+ * @returns {string[]}
+ */
+function getExclusionList(fileContent) {
+    const excludeRegex = /const\s+excludeFromGeneratedIndex\s*=\s*\[(.*?)\];/;
+    const excludeMatch = fileContent.match(excludeRegex);
+    let excludedFunctions = [];
+    if (excludeMatch) {
+        excludedFunctions = excludeMatch[1]
+            .split(',')
+            .map(name => name.trim().replace(/['"`]/g, ''));
+    }
+    return excludedFunctions;
+}
 
 // get all files in the services directory
 const servicesDir = path.join(__dirname, '../src/services');


### PR DESCRIPTION
As requested by @robwillems in [BE-341](https://musora.atlassian.net/browse/BE-341), this adds the ability to exclude exported functions from the generated index.js and index.d.ts files. 

I toyed around with the idea of using comment annotations instead, where you could tag a function like this
```js
/**
 * @excludeFromIndex
 */
function someFunction() {
    // 
}
```
but I felt like that would be more error-prone when parsing it, might complicate the generated docs (or maybe it would be better?), and would require devs to remember to do the comment and in the right way.

While I'm not crazy about relying on the array to exist in each file and for devs to update it (I would've loved to make an abstract class or something more like that if this was in a more structured language), I felt like it's the most obvious way for devs to see and work with it.