### PR TITLE
Fix group by genre on quick-tips

### DIFF
--- a/src/contentMetaData.js
+++ b/src/contentMetaData.js
@@ -153,6 +153,7 @@ const commonMetadata ={
             {
                 name: 'Genres',
                 short_name: 'Genres',
+                is_group_by: true,
                 value: 'genre',
             },
         ],


### PR DESCRIPTION
Fix group by genre on quick-tips: added 'is_group_by' to Genre tab in contentMetaData