### PR TITLE
TP-134 - Update is_solo_challenge field to is_solo

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -103,7 +103,7 @@ let contentTypeConfig = {
             '"gold_award": gold_award.asset->url',
             '"silver_award": silver_award.asset->url',
             '"bronze_award": bronze_award.asset->url',
-            'is_solo_challenge',
+            'is_solo',
             `"lessons": child[]->{
                     "id": railcontent_id,
                     title,


### PR DESCRIPTION
Challenges catalogue page should now show solo challenges as solo instead of everything as community.