### PR TITLE
Fix count for pack lessons

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -259,7 +259,7 @@ let contentTypeConfig = {
     },
     'pack': {
         'fields': [
-            '"lesson_count": child_count',
+            '"lesson_count": coalesce(count(child[]->.child[]->), 0)',
             'xp',
             `"description": ${descriptionField}`,
             '"instructors": instructor[]->name',


### PR DESCRIPTION
[TP-421](https://musora.atlassian.net/browse/TP-421),
Packs have one child which is a pack bundle. This leads to the current state where there's a child count of 1. This solution gets the counts of the grandchildren instead.

[TP-421]: https://musora.atlassian.net/browse/TP-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ