### PR TITLE
Fix filter by creativity/essential/focus/genre/lifestyle/theory/topic

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -476,7 +476,7 @@ function filtersToGroq(filters, selectedFilters = []) {
                     return `bpm == ${value}`;
                 }
             } else if (['creativity', 'essential', 'focus', 'genre', 'lifestyle', 'theory', 'topic'].includes(key) && !selectedFilters.includes(key)) {
-                return `${key}[]->name match "${value}"`;
+                return `"${value}" in ${key}[]->name`;
             } else if (key === 'gear' && !selectedFilters.includes('gear')) {
                 return `gear match "${value}"`;
             } else if (key === 'instrumentless' && !selectedFilters.includes(key)) {

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -509,7 +509,7 @@ describe('Sanity Queries', function () {
     });
 
     test('fetchAll-IncludedFields-coaches-multiple-focus', async () => {
-        let response = await fetchAll('drumeo', 'instructor', {includedFields: ['focus,drumline', 'focus,recording']});
+        let response = await fetchAll('drumeo', 'instructor', {includedFields: ['focus,Drumline', 'focus,Recording']});
         log(response);
         expect(response.entity.length).toBeGreaterThan(0);
     });


### PR DESCRIPTION
[TP-582](https://musora.atlassian.net/browse/TP-582)

Instead of **match**, we should use **in** for selected creativity/essential/focus/genre/lifestyle/theory/topic filters

**match** check if we have documents that contain in creativity/essential/focus/genre/lifestyle/theory/topic name the selected filter value. If we use match and filter by ‘Rock', we will receive documents with 'Pop/Rock' genre also.

**in** will check if we have documents with 'Rock' genre name only   ( e.g.: "Rock" in genre[]->name)

[TP-582]: https://musora.atlassian.net/browse/TP-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ