### PR TITLE
Improved null check on next content before fetching railcontent

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1116,7 +1116,7 @@ export async function fetchNextPreviousLesson(railcontentId) {
  */
 export async function jumpToContinueContent(railcontentId) {
     const nextContent = await fetchNextContentDataForParent(railcontentId);
-    if (!nextContent) {
+    if (!nextContent || !nextContent.id) {
         return null;
     }
     let next = await fetchByRailContentId(nextContent.id, nextContent.type);


### PR DESCRIPTION
[TP-577](https://musora.atlassian.net/browse/TP-577) this fixes the null check on the result of fetchNextContentDataForParent before calling fetchByRailContentId. Thanks @csillaj for the suggestion

I'll be away the next two days so if approved, please go ahead and merge this.

[TP-577]: https://musora.atlassian.net/browse/TP-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ