### PR TITLE
Add status filter for fetchRelatedSongs

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1560,13 +1560,13 @@ export async function fetchArtistLessons(brand, name, contentType, {
 
     // limits the results to supplied progressIds for started & completed filters
     const progressFilter = progressIds !== undefined ? `&& railcontent_id in [${progressIds.join(',')}]` : "";
-
+    const now = getSanityDate(new Date());
     const query = `{
     "entity": 
       *[_type == 'artist' && name == '${name}']
         {'type': _type, name, 'thumbnail_url':thumbnail_url.asset->url, 
         'lessons_count': count(*[${addType} brand == '${brand}' && references(^._id)]), 
-        'lessons': *[${addType} brand == '${brand}' && references(^._id) ${searchFilter} ${includedFieldsFilter} ${progressFilter}]{${fieldsString}}
+        'lessons': *[${addType} brand == '${brand}' && references(^._id) && (status in ['published'] || (status == 'scheduled' && defined(published_on) && published_on >= '${now}')) ${searchFilter} ${includedFieldsFilter} ${progressFilter}]{${fieldsString}}
       [${start}...${end}]}
       |order(${sortOrder})
   }`;
@@ -1610,13 +1610,13 @@ export async function fetchGenreLessons(brand, name, contentType, {
         : "";
     // limits the results to supplied progressIds for started & completed filters
     const progressFilter = progressIds !== undefined ? `&& railcontent_id in [${progressIds.join(',')}]` : "";
-
+    const now = getSanityDate(new Date());
     const query = `{
     "entity": 
       *[_type == 'genre' && name == '${name}']
         {'type': _type, name, 'thumbnail_url':thumbnail_url.asset->url, 
         'lessons_count': count(*[${addType} brand == '${brand}' && references(^._id)]), 
-        'lessons': *[${addType} brand == '${brand}' && references(^._id) ${searchFilter} ${includedFieldsFilter} ${progressFilter}]{${fieldsString}}
+        'lessons': *[${addType} brand == '${brand}' && references(^._id) && (status in ['published'] || (status == 'scheduled' && defined(published_on) && published_on >= '${now}')) ${searchFilter} ${includedFieldsFilter} ${progressFilter}]{${fieldsString}}
       [${start}...${end}]}
       |order(${sortOrder})
   }`;

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -115,10 +115,12 @@ export async function fetchPlayAlongsCount(brand) {
  *   .catch(error => console.error(error));
  */
 export async function fetchRelatedSongs(brand, songId) {
+    const now = getSanityDate(new Date());
     const query = `
       *[_type == "song" && railcontent_id == ${songId}]{
         "entity": array::unique([
-            ...(*[_type == "song" && brand == "${brand}" && railcontent_id != ${songId} && references(^.artist->_id)]{
+            ...(*[_type == "song" && brand == "${brand}" && railcontent_id != ${songId} && references(^.artist->_id)
+            && (status in ['published'] || (status == 'scheduled' && defined(published_on) && published_on >= '${now}'))]{
             "type": _type,
             "id": railcontent_id,
             "url": web_url_path,
@@ -144,7 +146,8 @@ export async function fetchRelatedSongs(brand, songId) {
               }
             ],
           }[0...10]),
-            ...(*[_type == "song" && brand == "${brand}" && railcontent_id != ${songId} && references(^.genre[]->_id)]{
+            ...(*[_type == "song" && brand == "${brand}" && railcontent_id != ${songId} && references(^.genre[]->_id)
+            && (status in ['published'] || (status == 'scheduled' && defined(published_on) && published_on >= '${now}'))]{
             "type": _type,
             "id": railcontent_id,
             "url": web_url_path,


### PR DESCRIPTION
[TP-775](https://musora.atlassian.net/browse/TP-775)

This adds the necessary status filtering to keep unpublished content from showing up in the results of fetching related songs.

A better solution is to use the filter builder, but this was a lot faster to implement.

[TP-775]: https://musora.atlassian.net/browse/TP-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ