### PR TITLE
TP-826 show resources on children content

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -24,7 +24,12 @@ const DEFAULT_FIELDS = [
 ];
 
 const descriptionField = 'description[0].children[0].text';
-const resourcesField = 'resource[]{resource_name, _key, "resource_url": coalesce(\'https://d3fzm1tzeyr5n3.cloudfront.net\'+string::split(resource_aws.asset->fileURL,\'https://s3.us-east-1.amazonaws.com/musora-web-platform\')[1], resource_url )}';
+// this pulls both any defined resources for the document as well as any resources in the parent document
+const resourcesField = `[
+          ... resource[]{resource_name, _key, "resource_url": coalesce('https://d3fzm1tzeyr5n3.cloudfront.net'+string::split(resource_aws.asset->fileURL,'https://s3.us-east-1.amazonaws.com/musora-web-platform')[1], resource_url )},
+          ... *[railcontent_id == ^.parent_content_data[0].id] [0].resource[]{resource_name, _key, "resource_url": coalesce('https://d3fzm1tzeyr5n3.cloudfront.net'+string::split(resource_aws.asset->fileURL,'https://s3.us-east-1.amazonaws.com/musora-web-platform')[1], resource_url )},
+          ]`;
+
 
 const assignmentsField = `"assignments":assignment[]{
     "id": railcontent_id,
@@ -92,8 +97,7 @@ let contentTypeConfig = {
     },
     'song-tutorial-children': {
         'fields': [
-            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
-            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
+            `"resources": ${resourcesField}`,
         ],
     },
     'challenge': {
@@ -218,7 +222,7 @@ let contentTypeConfig = {
             '"lesson_count": child_count',
             '"instructors": instructor[]->name',
             `"description": ${descriptionField}`,
-            `"resource": ${resourcesField}`,
+            `"resources": ${resourcesField}`,
             'xp',
             'total_xp',
             `"lessons": child[]->{
@@ -305,9 +309,7 @@ let contentTypeConfig = {
                 "description": ${descriptionField},
                 ${getFieldsForContentType()}
             }`,
-            `"resources_old": ${resourcesField}`,
-            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
-            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
+            `"resources": ${resourcesField}`,
             '"image": logo_image_url.asset->url',
             '"thumbnail": thumbnail.asset->url',
             '"light_logo": light_mode_logo_url.asset->url',
@@ -318,8 +320,7 @@ let contentTypeConfig = {
     },
     'pack-bundle-lesson': {
         'fields': [
-            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
-            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
+            `"resources": ${resourcesField}`,
         ],
     },
     'foundation': {
@@ -348,7 +349,7 @@ let contentTypeConfig = {
             '"lesson_count": child_count',
             '"instructors": instructor[]->name',
             `"description": ${descriptionField}`,
-            `"resource": ${resourcesField}`,
+            `"resources": ${resourcesField}`,
             'xp',
             'total_xp',
             `"lessons": child[]->{

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -92,7 +92,7 @@ let contentTypeConfig = {
     },
     'song-tutorial-children': {
         'fields': [
-            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourceField}`,
+            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourceField}`,
         ],
     },
     'challenge': {
@@ -315,7 +315,7 @@ let contentTypeConfig = {
     },
     'pack-bundle-lesson': {
         'fields': [
-            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourceField}`,
+            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourceField}`,
         ],
     },
     'foundation': {

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -543,6 +543,7 @@ function groupFilters(filters) {
 module.exports = {
     contentTypeConfig,
     descriptionField,
+    resourcesField,
     artistOrInstructorName,
     artistOrInstructorNameAsArray,
     getFieldsForContentType,

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -222,7 +222,7 @@ let contentTypeConfig = {
             '"lesson_count": child_count',
             '"instructors": instructor[]->name',
             `"description": ${descriptionField}`,
-            `"resources": ${resourcesField}`,
+            `"resource": ${resourcesField}`,
             'xp',
             'total_xp',
             `"lessons": child[]->{
@@ -349,7 +349,7 @@ let contentTypeConfig = {
             '"lesson_count": child_count',
             '"instructors": instructor[]->name',
             `"description": ${descriptionField}`,
-            `"resources": ${resourcesField}`,
+            `"resource": ${resourcesField}`,
             'xp',
             'total_xp',
             `"lessons": child[]->{

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -90,6 +90,11 @@ let contentTypeConfig = {
             }
         },
     },
+    'song-tutorial-children': {
+        'fields': [
+            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourceField}`,
+        ],
+    },
     'challenge': {
         'fields': [
             'enrollment_start_time',
@@ -307,6 +312,11 @@ let contentTypeConfig = {
             `"description": ${descriptionField}`,
             'total_xp',
         ]
+    },
+    'pack-bundle-lesson': {
+        'fields': [
+            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourceField}`,
+        ],
     },
     'foundation': {
         'fields': [

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -1,5 +1,6 @@
-import {AWSUrl, CloudFrontURl} from "./services/config";
-
+//import {AWSUrl, CloudFrontURl} from "./services/config";
+const AWSUrl = 'https://s3.us-east-1.amazonaws.com/musora-web-platform';
+const CloudFrontURl = 'https://d3fzm1tzeyr5n3.cloudfront.net';
 const DEFAULT_FIELDS = [
     "'sanity_id' : _id",
     "'id': railcontent_id",

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -93,6 +93,7 @@ let contentTypeConfig = {
     'song-tutorial-children': {
         'fields': [
             `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
+            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
         ],
     },
     'challenge': {
@@ -304,7 +305,9 @@ let contentTypeConfig = {
                 "description": ${descriptionField},
                 ${getFieldsForContentType()}
             }`,
-            `"resources": ${resourcesField}`,
+            `"resources_old": ${resourcesField}`,
+            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
+            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
             '"image": logo_image_url.asset->url',
             '"thumbnail": thumbnail.asset->url',
             '"light_logo": light_mode_logo_url.asset->url',
@@ -316,6 +319,7 @@ let contentTypeConfig = {
     'pack-bundle-lesson': {
         'fields': [
             `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
+            `"resource":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
         ],
     },
     'foundation': {

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -92,7 +92,7 @@ let contentTypeConfig = {
     },
     'song-tutorial-children': {
         'fields': [
-            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourceField}`,
+            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
         ],
     },
     'challenge': {
@@ -315,7 +315,7 @@ let contentTypeConfig = {
     },
     'pack-bundle-lesson': {
         'fields': [
-            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourceField}`,
+            `"resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField}`,
         ],
     },
     'foundation': {

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -1,3 +1,5 @@
+import {AWSUrl, CloudFrontURl} from "./services/config";
+
 const DEFAULT_FIELDS = [
     "'sanity_id' : _id",
     "'id': railcontent_id",
@@ -26,8 +28,8 @@ const DEFAULT_FIELDS = [
 const descriptionField = 'description[0].children[0].text';
 // this pulls both any defined resources for the document as well as any resources in the parent document
 const resourcesField = `[
-          ... resource[]{resource_name, _key, "resource_url": coalesce('https://d3fzm1tzeyr5n3.cloudfront.net'+string::split(resource_aws.asset->fileURL,'https://s3.us-east-1.amazonaws.com/musora-web-platform')[1], resource_url )},
-          ... *[railcontent_id == ^.parent_content_data[0].id] [0].resource[]{resource_name, _key, "resource_url": coalesce('https://d3fzm1tzeyr5n3.cloudfront.net'+string::split(resource_aws.asset->fileURL,'https://s3.us-east-1.amazonaws.com/musora-web-platform')[1], resource_url )},
+          ... resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )},
+          ... *[railcontent_id == ^.parent_content_data[0].id] [0].resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )},
           ]`;
 
 

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -17,6 +17,8 @@ let globalConfig = {
  */
 const excludeFromGeneratedIndex = [];
 
+const AWSUrl = 'https://s3.us-east-1.amazonaws.com/musora-web-platform';
+const CloudFrontURl = 'https://d3fzm1tzeyr5n3.cloudfront.net';
 /**
  * Initializes the service with the given configuration.
  * This function must be called before using any other functions in this library.
@@ -71,5 +73,7 @@ function initializeService(config) {
 // Export both the initialization function and the config object
 module.exports = {
     initializeService,
-    globalConfig
+    globalConfig,
+    AWSUrl,
+    CloudFrontURl,
 };

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -17,8 +17,7 @@ let globalConfig = {
  */
 const excludeFromGeneratedIndex = [];
 
-const AWSUrl = 'https://s3.us-east-1.amazonaws.com/musora-web-platform';
-const CloudFrontURl = 'https://d3fzm1tzeyr5n3.cloudfront.net';
+
 /**
  * Initializes the service with the given configuration.
  * This function must be called before using any other functions in this library.
@@ -74,6 +73,4 @@ function initializeService(config) {
 module.exports = {
     initializeService,
     globalConfig,
-    AWSUrl,
-    CloudFrontURl,
 };

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1217,6 +1217,7 @@ export async function fetchLessonContent(railContentId) {
 
 function processParentResourcesForLessonData(lessonDocument)
 {
+    console.log('lessonDocument', lesonDocument);
     let childResources = lessonDocument['resources'] ?? [];
     console.log('childResources', childResources);
     let allResources = childResources.concat(lessonDocument['parent_resources'] ?? []);

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -41,7 +41,7 @@ import {getAllCompleted, getAllStarted, getAllStartedOrCompleted} from "./conten
  *
  * @type {string[]}
  */
-const excludeFromGeneratedIndex = ['handleCustomFetchAll', 'processParentResourcesForLessonData'];
+const excludeFromGeneratedIndex = ['handleCustomFetchAll'];
 
 /**
  * Fetch a song by its document ID from Sanity.
@@ -1163,7 +1163,6 @@ export async function fetchLessonContent(railContentId) {
           published_on,
           "type":_type, 
           "resources": ${resourcesField},
-          "parent_resources":  *[railcontent_id == ^.parent_content_data[0].id] [0].${resourcesField},
           difficulty, 
           difficulty_string, 
           brand, 
@@ -1211,19 +1210,7 @@ export async function fetchLessonContent(railContentId) {
             isSingle: true,
         }
     );
-    return fetchSanity(query, false,
-        {customPostProcess: processParentResourcesForLessonData});
-}
-
-function processParentResourcesForLessonData(lessonDocument)
-{
-    console.log('lessonDocument', lessonDocument);
-    let childResources = lessonDocument['resources'] ?? [];
-    console.log('childResources', childResources);
-    let allResources = childResources.concat(lessonDocument['parent_resources'] ?? []);
-    console.log('allResources', allResources);
-    lessonDocument['resources'] = allResources;
-    return lessonDocument;
+    return fetchSanity(query, false);
 }
 
 /**

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -6,6 +6,7 @@ import {
     artistOrInstructorNameAsArray,
     assignmentsField,
     descriptionField,
+    resourcesField,
     contentTypeConfig,
     DEFAULT_FIELDS,
     getFieldsForContentType,
@@ -13,7 +14,7 @@ import {
     getUpcomingEventsTypes,
     showsTypes,
     getNewReleasesTypes,
-    coachLessonsTypes
+    coachLessonsTypes,
 } from "../contentTypeConfig";
 
 import {

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1217,7 +1217,7 @@ export async function fetchLessonContent(railContentId) {
 
 function processParentResourcesForLessonData(lessonDocument)
 {
-    console.log('lessonDocument', lesonDocument);
+    console.log('lessonDocument', lessonDocument);
     let childResources = lessonDocument['resources'] ?? [];
     console.log('childResources', childResources);
     let allResources = childResources.concat(lessonDocument['parent_resources'] ?? []);


### PR DESCRIPTION
[TP-826](https://musora.atlassian.net/browse/TP-826)

Resources should be inherited from parent object and combined with document.resources object.

This will also require a MWP update for challenges and playlist items, same format but in SanityGateway, that hasn't been implemented yet.

tested to make sure Course still works: https://dev.musora.com:8443/drumeo/courses/phil-collins-drummer-first/415264
This takes just items from the document, as there is no parent object.


**Testing:** 
both of these take from the parent, the document has no resources. 
- Pack-lesson-child: https://dev.musora.com:8443/pianote/packs/classical-piano-collection/411418/gymnopedie/411435/performance-regular-tempo/411961
- Song-tutorial-child: https://dev.musora.com:8443/pianote/song-tutorials/walking-in-memphis-tutorial/353569/learn-to-play-walking-in-memphis/353570

[TP-826]: https://musora.atlassian.net/browse/TP-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ