### PR TITLE
BE-428: include global config in generated index

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 /*** This file was generated automatically. To recreate, please run `npm run build-index`. ***/
 
 import {
+	globalConfig,
 	initializeService
 } from './services/config.js';
 
@@ -243,6 +244,7 @@ declare module 'musora-content-services' {
 		getProgressStateByIds,
 		getResumeTimeSeconds,
 		getSortOrder,
+		globalConfig,
 		initializeService,
 		isContentLiked,
 		jumpToContinueContent,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /*** This file was generated automatically. To recreate, please run `npm run build-index`. ***/
 
 import {
+	globalConfig,
 	initializeService
 } from './services/config.js';
 
@@ -242,6 +243,7 @@ export {
 	getProgressStateByIds,
 	getResumeTimeSeconds,
 	getSortOrder,
+	globalConfig,
 	initializeService,
 	isContentLiked,
 	jumpToContinueContent,

--- a/test/contentProgress.test.js
+++ b/test/contentProgress.test.js
@@ -129,7 +129,7 @@ describe('contentProgressDataContext', function () {
         let progress241247 = await getProgressPercentage(241247);
         expect(progress241247).toBe(1);
 
-    });
+    }, 50000);
 
     // test('completedProgressNotOverwritten', async () => {
     //     const contentId = 241262;

--- a/tools/generate-index.cjs
+++ b/tools/generate-index.cjs
@@ -18,7 +18,7 @@ function extractExportedFunctions(filePath) {
     const fileContent = fs.readFileSync(filePath, 'utf-8');
 
     const exportFunctionRegex = /export\s+(async\s+)?function\s+(\w+)/g;
-    const exportVariableRegex = /export\s+(let|const|var)\s+(globalConfig)\s+/g;  // Corrected regex
+    const exportVariableRegex = /export\s+(let|const|var)\s+(globalConfig)\s+/g;
     const moduleExportsRegex = /module\.exports\s*=\s*{\s*([\s\S]+?)\s*};/g;
 
     let matches = [...fileContent.matchAll(exportFunctionRegex)].map(match => match[2]);

--- a/tools/generate-index.cjs
+++ b/tools/generate-index.cjs
@@ -17,10 +17,16 @@ const fileExports = {};
 function extractExportedFunctions(filePath) {
     const fileContent = fs.readFileSync(filePath, 'utf-8');
 
-    const exportRegex = /export\s+(async\s+)?function\s+(\w+)/g;
+    const exportFunctionRegex = /export\s+(async\s+)?function\s+(\w+)/g;
+    const exportVariableRegex = /export\s+(let|const|var)\s+(globalConfig)\s+/g;  // Corrected regex
     const moduleExportsRegex = /module\.exports\s*=\s*{\s*([\s\S]+?)\s*};/g;
 
-    let matches = [...fileContent.matchAll(exportRegex)].map(match => match[2]);
+    let matches = [...fileContent.matchAll(exportFunctionRegex)].map(match => match[2]);
+
+    // Match `globalConfig` variable
+    const variableMatches = [...fileContent.matchAll(exportVariableRegex)].map(match => match[2]);
+    matches = matches.concat(variableMatches);
+
 
     const moduleExportsMatch = moduleExportsRegex.exec(fileContent);
     if (moduleExportsMatch) {


### PR DESCRIPTION
[BE-428](https://musora.atlassian.net/browse/BE-428?atlOrigin=eyJpIjoiMWJhNDU4Y2VjZTk5NDdlNmFiMDIwYzBiNGZmNzQ0OGYiLCJwIjoiaiJ9)
Updated the generate-index script to correctly include globalConfig in the generated index files. This resolves the issue where globalConfig was missing, ensuring page loading in the FE.

[BE-428]: https://musora.atlassian.net/browse/BE-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ