### PR TITLE
TP-558: Adding Query Functions for Quarter Removed/Published Content

### DIFF
--- a/src/filterBuilder.js
+++ b/src/filterBuilder.js
@@ -23,7 +23,8 @@ export class FilterBuilder {
             bypassPublishedDateRestriction = false,
             isSingle = false,
             allowsPullSongsContent = true,
-            isChildrenFilter = false
+            isChildrenFilter = false,
+            checkNullPublished = false
         } = {}) {
         this.availableContentStatuses = availableContentStatuses;
         this.bypassPermissions = bypassPermissions;
@@ -38,6 +39,7 @@ export class FilterBuilder {
         // this.debug = process.env.DEBUG === 'true' || false;
         this.debug = false;
         this.prefix =  isChildrenFilter ? '@->' : '';
+        this.checkNullPublished = checkNullPublished;
     }
 
 
@@ -118,7 +120,10 @@ export class FilterBuilder {
 
         now = roundedDate.toISOString();
 
-        if (this.getFutureContentOnly) {
+        if (this.checkNullPublished) {
+            this._andWhere(`(published_on >='${now}'`);
+            this._orWhere(`published_on == null)`);
+        } else if (this.getFutureContentOnly) {
             this._andWhere(`${this.prefix}published_on >= '${now}'`);
         } else if (!this.pullFutureContent) {
             this._andWhere(`${this.prefix}published_on <= '${now}'`);
@@ -127,8 +132,11 @@ export class FilterBuilder {
             // const theFuture = new Date(date.setMonth(date.getMonth() + 18));
             // this._andWhere(`published_on <= '${theFuture}'`);
         }
+
         return this;
     }
+    //if
+
 
     _andWhere(query) {
         const leadingAmpersand = this.filter ? ' && ' : '';

--- a/src/filterBuilder.js
+++ b/src/filterBuilder.js
@@ -1,15 +1,12 @@
-import {fetchUserPermissions} from "./services/userPermissions.js";
-import {
-    songAccessMembership
-} from "./contentTypeConfig.js";
+import { fetchUserPermissions } from './services/userPermissions.js'
+import { songAccessMembership } from './contentTypeConfig.js'
 
 export class FilterBuilder {
-
-    STATUS_SCHEDULED = 'scheduled';
-    STATUS_PUBLISHED = 'published';
-    STATUS_DRAFT = 'draft';
-    STATUS_ARCHIVED = 'archived';
-    STATUS_UNLISTED = 'unlisted';
+  STATUS_SCHEDULED = 'scheduled'
+  STATUS_PUBLISHED = 'published'
+  STATUS_DRAFT = 'draft'
+  STATUS_ARCHIVED = 'archived'
+  STATUS_UNLISTED = 'unlisted'
 
     constructor(
         filter = '',
@@ -26,142 +23,192 @@ export class FilterBuilder {
             isChildrenFilter = false,
             checkNullPublished = false
         } = {}) {
-        this.availableContentStatuses = availableContentStatuses;
-        this.bypassPermissions = bypassPermissions;
-        this.bypassStatuses = bypassStatuses;
-        this.bypassPublishedDateRestriction = bypassPublishedDateRestriction;
-        this.pullFutureContent = pullFutureContent;
-        this.getFutureContentOnly = getFutureContentOnly;
-        this.getFutureScheduledContentsOnly = getFutureScheduledContentsOnly;
-        this.isSingle = isSingle;
-        this.allowsPullSongsContent = allowsPullSongsContent;
-        this.filter = filter;
+        this.availableContentStatuses = availableContentStatuses
+        this.bypassPermissions = bypassPermissions
+        this.bypassStatuses = bypassStatuses
+        this.bypassPublishedDateRestriction = bypassPublishedDateRestriction
+        this.pullFutureContent = pullFutureContent
+        this.getFutureContentOnly = getFutureContentOnly
+        this.getFutureScheduledContentsOnly = getFutureScheduledContentsOnly
+        this.isSingle = isSingle
+        this.allowsPullSongsContent = allowsPullSongsContent
+        this.filter = filter
         // this.debug = process.env.DEBUG === 'true' || false;
-        this.debug = false;
-        this.prefix =  isChildrenFilter ? '@->' : '';
-        this.checkNullPublished = checkNullPublished;
+        this.debug = false
+        this.prefix =  isChildrenFilter ? '@->' : ''
+        this.checkNullPublished = checkNullPublished
     }
 
+  constructor(
+    filter = '',
+    {
+      availableContentStatuses = [],
+      bypassPermissions = false,
+      pullFutureContent = false,
+      getFutureContentOnly = false,
+      getFutureScheduledContentsOnly = false,
+      bypassStatuses = false,
+      bypassPublishedDateRestriction = false,
+      isSingle = false,
+      allowsPullSongsContent = true,
+      isChildrenFilter = false,
+    } = {}
+  ) {
+    this.availableContentStatuses = availableContentStatuses
+    this.bypassPermissions = bypassPermissions
+    this.bypassStatuses = bypassStatuses
+    this.bypassPublishedDateRestriction = bypassPublishedDateRestriction
+    this.pullFutureContent = pullFutureContent
+    this.getFutureContentOnly = getFutureContentOnly
+    this.getFutureScheduledContentsOnly = getFutureScheduledContentsOnly
+    this.isSingle = isSingle
+    this.allowsPullSongsContent = allowsPullSongsContent
+    this.filter = filter
+    // this.debug = process.env.DEBUG === 'true' || false;
+    this.debug = false
+    this.prefix = isChildrenFilter ? '@->' : ''
+  }
 
-    static withOnlyFilterAvailableStatuses(filter, availableContentStatuses, bypassPermissions) {
-        return new FilterBuilder(filter, {
-            availableContentStatuses,
-            bypassPermissions,
-        });
+  static withOnlyFilterAvailableStatuses(filter, availableContentStatuses, bypassPermissions) {
+    return new FilterBuilder(filter, {
+      availableContentStatuses,
+      bypassPermissions,
+    })
+  }
+
+  async buildFilter() {
+    this.userData = await fetchUserPermissions()
+    if (this.debug) console.log('baseFilter', this.filter)
+    const filter = this._applyContentStatuses()
+      ._applyPermissions()
+      ._applyPublishingDateRestrictions()
+      ._trimAmpersands().filter // just in case
+    if (this.debug) console.log('finalFilter', filter)
+    return filter
+  }
+
+  _applyContentStatuses() {
+    // This must be run before _applyPublishDateRestrictions()
+    if (this.bypassStatuses) return this
+    if (this.availableContentStatuses.length === 0) {
+      if (this.userData.isAdmin) {
+        this.availableContentStatuses = [
+          this.STATUS_DRAFT,
+          this.STATUS_SCHEDULED,
+          this.STATUS_PUBLISHED,
+          this.STATUS_ARCHIVED,
+          this.STATUS_UNLISTED,
+        ]
+        this.getFutureScheduledContentsOnly = true
+      } else if (this.isSingle) {
+        this.availableContentStatuses = [
+          this.STATUS_SCHEDULED,
+          this.STATUS_PUBLISHED,
+          this.STATUS_UNLISTED,
+          this.STATUS_ARCHIVED,
+        ]
+      } else {
+        this.availableContentStatuses = [this.STATUS_SCHEDULED, this.STATUS_PUBLISHED]
+        this.getFutureScheduledContentsOnly = true
+      }
     }
 
-    async buildFilter() {
-        this.userData = await fetchUserPermissions();
-        if (this.debug) console.log('baseFilter', this.filter);
-        const filter = this
-            ._applyContentStatuses()
-            ._applyPermissions()
-            ._applyPublishingDateRestrictions()
-            ._trimAmpersands() // just in case
-            .filter;
-        if (this.debug) console.log('finalFilter', filter);
-        return filter;
+    // I'm not sure if I'm 100% on this logic, but this is my intepretation of the ContentRepository logic
+    if (
+      this.getFutureScheduledContentsOnly &&
+      this.availableContentStatuses.includes(this.STATUS_SCHEDULED)
+    ) {
+      // we must pull in future content here, otherwise we'll restrict on content this is published in the past and remove any scheduled content
+      this.pullFutureContent = true
+      const now = new Date().toISOString()
+      let statuses = [...this.availableContentStatuses]
+      statuses.splice(statuses.indexOf(this.STATUS_SCHEDULED), 1)
+      this._andWhere(
+        `(${this.prefix}status in ${arrayToStringRepresentation(statuses)} || (${this.prefix}status == '${this.STATUS_SCHEDULED}' && defined(${this.prefix}published_on) && ${this.prefix}published_on >= '${now}'))`
+      )
+    } else {
+      this._andWhere(
+        `${this.prefix}status in ${arrayToStringRepresentation(this.availableContentStatuses)}`
+      )
     }
+    return this
+  }
 
-    _applyContentStatuses() {
-        // This must be run before _applyPublishDateRestrictions()
-        if(this.bypassStatuses) return this;
-        if (this.availableContentStatuses.length === 0) {
-            if (this.userData.isAdmin) {
-                this.availableContentStatuses = [this.STATUS_DRAFT, this.STATUS_SCHEDULED, this.STATUS_PUBLISHED, this.STATUS_ARCHIVED, this.STATUS_UNLISTED];
-                this.getFutureScheduledContentsOnly = true;
-            } else if(this.isSingle){
-                this.availableContentStatuses = [this.STATUS_SCHEDULED, this.STATUS_PUBLISHED, this.STATUS_UNLISTED, this.STATUS_ARCHIVED];
-            } else{
-                this.availableContentStatuses = [this.STATUS_SCHEDULED, this.STATUS_PUBLISHED];
-                this.getFutureScheduledContentsOnly = true;
-            }
-        }
-
-        // I'm not sure if I'm 100% on this logic, but this is my intepretation of the ContentRepository logic
-        if (this.getFutureScheduledContentsOnly && this.availableContentStatuses.includes(this.STATUS_SCHEDULED)) {
-            // we must pull in future content here, otherwise we'll restrict on content this is published in the past and remove any scheduled content
-            this.pullFutureContent = true;
-            const now = new Date().toISOString();
-            let statuses = [...this.availableContentStatuses];
-            statuses.splice(statuses.indexOf(this.STATUS_SCHEDULED), 1);
-            this._andWhere(`(${this.prefix}status in ${arrayToStringRepresentation(statuses)} || (${this.prefix}status == '${this.STATUS_SCHEDULED}' && defined(${this.prefix}published_on) && ${this.prefix}published_on >= '${now}'))`)
-
-        } else {
-            this._andWhere(`${this.prefix}status in ${arrayToStringRepresentation(this.availableContentStatuses)}`);
-        }
-        return this;
+  _applyPermissions() {
+    if (this.bypassPermissions || this.userData.isAdmin) return this
+    let requiredPermissions = this._getUserPermissions()
+    if (this.userData.isABasicMember && this.allowsPullSongsContent) {
+      requiredPermissions = [...requiredPermissions, songAccessMembership]
     }
+    this._andWhere(
+      `(!defined(permission) || references(*[_type == 'permission' && railcontent_id in ${arrayToRawRepresentation(requiredPermissions)}]._id))`
+    )
+    return this
+  }
 
-    _applyPermissions() {
-        if (this.bypassPermissions || this.userData.isAdmin) return this;
-        let requiredPermissions = this._getUserPermissions();
-        if(this.userData.isABasicMember && this.allowsPullSongsContent){
-            requiredPermissions = [...requiredPermissions, songAccessMembership];
-        }
-        this._andWhere(`(!defined(permission) || references(*[_type == 'permission' && railcontent_id in ${arrayToRawRepresentation(requiredPermissions)}]._id))`);
-        return this;
-    }
+  _getUserPermissions() {
+    return this.userData.permissions
+  }
 
-    _getUserPermissions() {
-        return this.userData.permissions;
-    }
+  _applyPublishingDateRestrictions() {
+    if (this.bypassPublishedDateRestriction) return this
+    let now = new Date()
 
-    _applyPublishingDateRestrictions() {
-        if(this.bypassPublishedDateRestriction) return this;
-        let now = new Date();
+    // We need to set the published on filter date to be a round time so that it doesn't bypass the query cache
+    // with every request by changing the filter date every second. I've set it to one minute past the current hour
+    // because publishing usually publishes content on the hour exactly which means it should still skip the cache
+    // when the new content is available.
+    // Round to the start of the current hour
+    const roundedDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours())
 
-        // We need to set the published on filter date to be a round time so that it doesn't bypass the query cache
-        // with every request by changing the filter date every second. I've set it to one minute past the current hour
-        // because publishing usually publishes content on the hour exactly which means it should still skip the cache
-        // when the new content is available.
-        // Round to the start of the current hour
-        const roundedDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours());
-
-        now = roundedDate.toISOString();
+    now = roundedDate.toISOString()
 
         if (this.checkNullPublished) {
-            this._andWhere(`(published_on >='${now}'`);
-            this._orWhere(`published_on == null)`);
+            this._andWhere(`(published_on >='${now}'`)
+            this._orWhere(`published_on == null)`)
         } else if (this.getFutureContentOnly) {
-            this._andWhere(`${this.prefix}published_on >= '${now}'`);
+            this._andWhere(`${this.prefix}published_on >= '${now}'`)
         } else if (!this.pullFutureContent) {
-            this._andWhere(`${this.prefix}published_on <= '${now}'`);
+            this._andWhere(`${this.prefix}published_on <= '${now}'`)
         } else {
             // const date = new Date();
             // const theFuture = new Date(date.setMonth(date.getMonth() + 18));
             // this._andWhere(`published_on <= '${theFuture}'`);
         }
 
-        return this;
+        return this
     }
     //if
 
 
-    _andWhere(query) {
-        const leadingAmpersand = this.filter ? ' && ' : '';
-        this.filter += leadingAmpersand + query;
-    }
+  _andWhere(query) {
+    const leadingAmpersand = this.filter ? ' && ' : ''
+    this.filter += leadingAmpersand + query
+  }
 
-    _orWhere(query) {
-        if (!this.filter) throw new Error("invalid query, _orWhere needs to be called on an existing query");
-        this.filter += ` || (${query})`;
-    }
+  _orWhere(query) {
+    if (!this.filter)
+      throw new Error('invalid query, _orWhere needs to be called on an existing query')
+    this.filter += ` || (${query})`
+  }
 
-    _trimAmpersands() {
-        this.filter = this.filter.trim();
-        while (this.filter.charAt(0) === '&' || this.filter.charAt(0) === ' ') this.filter = this.filter.substring(1);
-        while (this.filter.charAt(this.filter.length) === '&' || this.filter.charAt(this.filter.length) === ' ') this.filter = this.filter.slice(-1);
-        return this;
-    }
-
-
+  _trimAmpersands() {
+    this.filter = this.filter.trim()
+    while (this.filter.charAt(0) === '&' || this.filter.charAt(0) === ' ')
+      this.filter = this.filter.substring(1)
+    while (
+      this.filter.charAt(this.filter.length) === '&' ||
+      this.filter.charAt(this.filter.length) === ' '
+    )
+      this.filter = this.filter.slice(-1)
+    return this
+  }
 }
 
 export function arrayToStringRepresentation(arr) {
-    return '[' + arr.map(item => `'${item}'`).join(',') + ']';
+  return '[' + arr.map((item) => `'${item}'`).join(',') + ']'
 }
 
 export function arrayToRawRepresentation(arr) {
-    return '[' + arr.map(item => `${item}`).join(',') + ']';
+  return '[' + arr.map((item) => `${item}`).join(',') + ']'
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -113,6 +113,8 @@ import {
 	fetchPackData,
 	fetchParentForDownload,
 	fetchPlayAlongsCount,
+	fetchQuarterPublished,
+	fetchQuarterRemoved,
 	fetchRelatedLessons,
 	fetchRelatedSongs,
 	fetchSanity,
@@ -122,6 +124,7 @@ import {
 	fetchSongById,
 	fetchTopLevelParentId,
 	fetchUpcomingEvents,
+	getNextAndPreviousQuarterDates,
 	getSortOrder,
 	jumpToContinueContent
 } from './services/sanity.js';
@@ -190,6 +193,8 @@ declare module 'musora-content-services' {
 		fetchPlaylist,
 		fetchPlaylistItem,
 		fetchPlaylistItems,
+		fetchQuarterPublished,
+		fetchQuarterRemoved,
 		fetchRelatedLessons,
 		fetchRelatedSongs,
 		fetchSanity,
@@ -210,6 +215,7 @@ declare module 'musora-content-services' {
 		getAllCompleted,
 		getAllStarted,
 		getAllStartedOrCompleted,
+		getNextAndPreviousQuarterDates,
 		getProgressPercentage,
 		getProgressPercentageByIds,
 		getProgressState,

--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,8 @@ import {
 	fetchPackData,
 	fetchParentForDownload,
 	fetchPlayAlongsCount,
+	fetchQuarterPublished,
+	fetchQuarterRemoved,
 	fetchRelatedLessons,
 	fetchRelatedSongs,
 	fetchSanity,
@@ -122,6 +124,7 @@ import {
 	fetchSongById,
 	fetchTopLevelParentId,
 	fetchUpcomingEvents,
+	getNextAndPreviousQuarterDates,
 	getSortOrder,
 	jumpToContinueContent
 } from './services/sanity.js';
@@ -189,6 +192,8 @@ export {
 	fetchPlaylist,
 	fetchPlaylistItem,
 	fetchPlaylistItems,
+	fetchQuarterPublished,
+	fetchQuarterRemoved,
 	fetchRelatedLessons,
 	fetchRelatedSongs,
 	fetchSanity,
@@ -209,6 +214,7 @@ export {
 	getAllCompleted,
 	getAllStarted,
 	getAllStartedOrCompleted,
+	getNextAndPreviousQuarterDates,
 	getProgressPercentage,
 	getProgressPercentageByIds,
 	getProgressState,

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -2,45 +2,42 @@
  * @module Sanity-Services
  */
 import {
-    artistOrInstructorName,
-    artistOrInstructorNameAsArray,
-    assignmentsField,
-    descriptionField,
-    resourcesField,
-    contentTypeConfig,
-    DEFAULT_FIELDS,
-    getFieldsForContentType,
-    filtersToGroq,
-    getUpcomingEventsTypes,
-    showsTypes,
-    getNewReleasesTypes,
-    coachLessonsTypes
-} from "../contentTypeConfig.js";
+  artistOrInstructorName,
+  artistOrInstructorNameAsArray,
+  assignmentsField,
+  descriptionField,
+  resourcesField,
+  contentTypeConfig,
+  DEFAULT_FIELDS,
+  getFieldsForContentType,
+  filtersToGroq,
+  getUpcomingEventsTypes,
+  showsTypes,
+  getNewReleasesTypes,
+  coachLessonsTypes,
+} from '../contentTypeConfig.js'
+
+import { processMetadata, typeWithSortOrder } from '../contentMetaData.js'
+
+import { globalConfig } from './config.js'
 
 import {
-    processMetadata,
-    typeWithSortOrder
-} from "../contentMetaData.js";
-
-import {globalConfig} from "./config.js";
-
-import {
-    fetchAllCompletedStates,
-    fetchCompletedChallenges,
-    fetchOwnedChallenges,
-    fetchNextContentDataForParent,
-    fetchHandler,
-} from './railcontent.js';
-import {arrayToStringRepresentation, FilterBuilder} from "../filterBuilder.js";
-import {fetchUserPermissions} from "./userPermissions.js";
-import {getAllCompleted, getAllStarted, getAllStartedOrCompleted} from "./contentProgress.js";
+  fetchAllCompletedStates,
+  fetchCompletedChallenges,
+  fetchOwnedChallenges,
+  fetchNextContentDataForParent,
+  fetchHandler,
+} from './railcontent.js'
+import { arrayToStringRepresentation, FilterBuilder } from '../filterBuilder.js'
+import { fetchUserPermissions } from './userPermissions.js'
+import { getAllCompleted, getAllStarted, getAllStartedOrCompleted } from './contentProgress.js'
 
 /**
  * Exported functions that are excluded from index generation.
  *
  * @type {string[]}
  */
-const excludeFromGeneratedIndex = ['handleCustomFetchAll'];
+const excludeFromGeneratedIndex = ['handleCustomFetchAll']
 
 /**
  * Fetch a song by its document ID from Sanity.
@@ -54,16 +51,17 @@ const excludeFromGeneratedIndex = ['handleCustomFetchAll'];
  *   .catch(error => console.error(error));
  */
 export async function fetchSongById(documentId) {
-    const fields = getFieldsForContentType('song');
-    const filterParams = {};
-    const query = await buildQuery(
-        `_type == "song" && railcontent_id == ${documentId}`,
-        filterParams,
-        fields,
-        {
-            isSingle: true,
-        });
-    return fetchSanity(query, false);
+  const fields = getFieldsForContentType('song')
+  const filterParams = {}
+  const query = await buildQuery(
+    `_type == "song" && railcontent_id == ${documentId}`,
+    filterParams,
+    fields,
+    {
+      isSingle: true,
+    }
+  )
+  return fetchSanity(query, false)
 }
 
 /**
@@ -140,13 +138,16 @@ export function getNextAndPreviousQuarterDates() {
  *   .catch(error => console.error(error));
  */
 export async function fetchArtists(brand) {
-    const filter = await new FilterBuilder(`_type == "song" && brand == "${brand}" && references(^._id)`, {bypassPermissions: true}).buildFilter();
-    const query = `
+  const filter = await new FilterBuilder(
+    `_type == "song" && brand == "${brand}" && references(^._id)`,
+    { bypassPermissions: true }
+  ).buildFilter()
+  const query = `
   *[_type == "artist"]{
     name,
     "lessonsCount": count(*[${filter}])
-  }[lessonsCount > 0]`;
-    return fetchSanity(query, true, {processNeedAccess: false});
+  }[lessonsCount > 0] |order(lower(name)) `
+  return fetchSanity(query, true, { processNeedAccess: false })
 }
 
 /**
@@ -155,13 +156,33 @@ export async function fetchArtists(brand) {
  * @returns {Promise<int|null>} - The fetched count of artists.
  */
 export async function fetchSongArtistCount(brand) {
-    const query = `count(*[_type == 'artist']{'lessonsCount': count(*[_type == 'song' && brand == '${brand}' && references(^._id)]._id)}[lessonsCount > 0])`;
-    return fetchSanity(query, true, {processNeedAccess: false});
+  const filter = await new FilterBuilder(
+      `_type == "song" && brand == "${brand}" && references(^._id)`,
+      { bypassPermissions: true }
+  ).buildFilter()
+  const query = `
+  count(*[_type == "artist"]{
+    name,
+    "lessonsCount": count(*[${filter}])
+  }[lessonsCount > 0])`
+  return fetchSanity(query, true, { processNeedAccess: false })
 }
 
-export async function fetchPlayAlongsCount(brand) {
-    const query = `count(*[brand == '${brand}' && _type == "play-along"]) `
-    return fetchSanity(query, true, {processNeedAccess: false});
+export async function fetchPlayAlongsCount(brand, {
+  searchTerm,
+  includedFields,
+  progressIds,
+  progress,
+}) {
+  const searchFilter = searchTerm ? `&& (artist->name match "${searchTerm}*" || instructor[]->name match "${searchTerm}*" || title match "${searchTerm}*" || name match "${searchTerm}*")` :'';
+
+  // Construct the included fields filter, replacing 'difficulty' with 'difficulty_string'
+  const includedFieldsFilter = includedFields.length > 0 ? filtersToGroq(includedFields) : ''
+
+  // limits the results to supplied progressIds for started & completed filters
+  const progressFilter = await getProgressFilter(progress, progressIds)
+  const query = `count(*[brand == '${brand}' && _type == "play-along" ${searchFilter} ${includedFieldsFilter} ${progressFilter} ]) `
+  return fetchSanity(query, true, { processNeedAccess: false })
 }
 
 /**
@@ -177,8 +198,8 @@ export async function fetchPlayAlongsCount(brand) {
  *   .catch(error => console.error(error));
  */
 export async function fetchRelatedSongs(brand, songId) {
-    const now = getSanityDate(new Date());
-    const query = `
+  const now = getSanityDate(new Date())
+  const query = `
       *[_type == "song" && railcontent_id == ${songId}]{
         "entity": array::unique([
             ...(*[_type == "song" && brand == "${brand}" && railcontent_id != ${songId} && references(^.artist->_id)
@@ -239,10 +260,10 @@ export async function fetchRelatedSongs(brand, songId) {
             }]
           }[0...10])
         ])[0...10]
-    }`;
+    }`
 
-    // Fetch the related songs data
-    return fetchSanity(query, false);
+  // Fetch the related songs data
+  return fetchSanity(query, false)
 }
 
 /**
@@ -250,14 +271,17 @@ export async function fetchRelatedSongs(brand, songId) {
  * @param {string} brand - The brand for which to fetch new releases.
  * @returns {Promise<Object|null>} - The fetched new releases data or null if not found.
  */
-export async function fetchNewReleases(brand, {page = 1, limit = 20, sort = "-published_on"} = {}) {
-    const newTypes = getNewReleasesTypes(brand);
-    const typesString = arrayToStringRepresentation(newTypes);
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const sortOrder = getSortOrder(sort, brand);
-    const filter = `_type in ${typesString} && brand == '${brand}' && show_in_new_feed == true`;
-    const fields = `
+export async function fetchNewReleases(
+  brand,
+  { page = 1, limit = 20, sort = '-published_on' } = {}
+) {
+  const newTypes = getNewReleasesTypes(brand)
+  const typesString = arrayToStringRepresentation(newTypes)
+  const start = (page - 1) * limit
+  const end = start + limit
+  const sortOrder = getSortOrder(sort, brand)
+  const filter = `_type in ${typesString} && brand == '${brand}' && show_in_new_feed == true`
+  const fields = `
      "id": railcontent_id,
       title,
       "image": thumbnail.asset->url,
@@ -270,20 +294,15 @@ export async function fetchNewReleases(brand, {page = 1, limit = 20, sort = "-pu
       "type": _type,
       web_url_path,
       "permission_id": permission[]->railcontent_id,
-      `;
-    const filterParams = {allowsPullSongsContent: false};
-    const query = await buildQuery(
-        filter,
-        filterParams,
-        fields,
-        {
-            sortOrder: sortOrder,
-            start,
-            end: end,
-        });
-    return fetchSanity(query, true);
+      `
+  const filterParams = { allowsPullSongsContent: false }
+  const query = await buildQuery(filter, filterParams, fields, {
+    sortOrder: sortOrder,
+    start,
+    end: end,
+  })
+  return fetchSanity(query, true)
 }
-
 
 /**
  * Fetch upcoming events for a specific brand.
@@ -299,13 +318,13 @@ export async function fetchNewReleases(brand, {page = 1, limit = 20, sort = "-pu
  *   .then(events => console.log(events))
  *   .catch(error => console.error(error));
  */
-export async function fetchUpcomingEvents(brand, {page = 1, limit = 10} = {}) {
-    const liveTypes = getUpcomingEventsTypes(brand);
-    const typesString = arrayToStringRepresentation(liveTypes);
-    const now = getSanityDate(new Date());
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const fields = `
+export async function fetchUpcomingEvents(brand, { page = 1, limit = 10 } = {}) {
+  const liveTypes = getUpcomingEventsTypes(brand)
+  const typesString = arrayToStringRepresentation(liveTypes)
+  const now = getSanityDate(new Date())
+  const start = (page - 1) * limit
+  const end = start + limit
+  const fields = `
         "id": railcontent_id,
         title,
         "image": thumbnail.asset->url,
@@ -317,17 +336,17 @@ export async function fetchUpcomingEvents(brand, {page = 1, limit = 10} = {}) {
         published_on,
         "type": _type,
         web_url_path,
-        "permission_id": permission[]->railcontent_id,`;
-    const query = buildRawQuery(
-        `_type in ${typesString} && brand == '${brand}' && published_on > '${now}' && status == 'scheduled'`,
-        fields,
-        {
-            sortOrder: 'published_on asc',
-            start: start,
-            end: end,
-        },
-    );
-    return fetchSanity(query, true);
+        "permission_id": permission[]->railcontent_id,`
+  const query = buildRawQuery(
+    `_type in ${typesString} && brand == '${brand}' && published_on > '${now}' && status == 'scheduled'`,
+    fields,
+    {
+      sortOrder: 'published_on asc',
+      start: start,
+      end: end,
+    }
+  )
+  return fetchSanity(query, true)
 }
 
 /**
@@ -344,16 +363,16 @@ export async function fetchUpcomingEvents(brand, {page = 1, limit = 10} = {}) {
  *   .then(content => console.log(content))
  *   .catch(error => console.error(error));
  */
-export async function fetchScheduledReleases(brand, {page = 1, limit = 10}) {
-    const upcomingTypes = getUpcomingEventsTypes(brand);
-    const newTypes = getNewReleasesTypes(brand);
+export async function fetchScheduledReleases(brand, { page = 1, limit = 10 }) {
+  const upcomingTypes = getUpcomingEventsTypes(brand)
+  const newTypes = getNewReleasesTypes(brand)
 
-    const scheduledTypes = merge(upcomingTypes, newTypes)
-    const typesString = arrayJoinWithQuotes(scheduledTypes);
-    const now = getSanityDate(new Date());
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const query = `*[_type in [${typesString}] && brand == '${brand}' && status in ['published','scheduled'] && published_on > '${now}']{
+  const scheduledTypes = merge(upcomingTypes, newTypes)
+  const typesString = arrayJoinWithQuotes(scheduledTypes)
+  const now = getSanityDate(new Date())
+  const start = (page - 1) * limit
+  const end = start + limit
+  const query = `*[_type in [${typesString}] && brand == '${brand}' && status in ['published','scheduled'] && published_on > '${now}']{
       "id": railcontent_id,
       title,
       "image": thumbnail.asset->url,
@@ -366,8 +385,8 @@ export async function fetchScheduledReleases(brand, {page = 1, limit = 10}) {
       "type": _type,
       web_url_path,
       "permission_id": permission[]->railcontent_id,
-  } | order(published_on asc)[${start}...${end}]`;
-    return fetchSanity(query, true);
+  } | order(published_on asc)[${start}...${end}]`
+  return fetchSanity(query, true)
 }
 
 /**
@@ -383,9 +402,9 @@ export async function fetchScheduledReleases(brand, {page = 1, limit = 10}) {
  *   .catch(error => console.error(error));
  */
 export async function fetchByRailContentId(id, contentType) {
-    const fields = getFieldsForContentType(contentType);
-    const childrenFilter = await new FilterBuilder(``, {isChildrenFilter: true} ).buildFilter();
-    const entityFieldsString = ` ${fields}
+  const fields = getFieldsForContentType(contentType)
+  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
+  const entityFieldsString = ` ${fields}
                                     'child_count': coalesce(count(child[${childrenFilter}]->), 0) ,
                                     "lessons": child[${childrenFilter}]->{
                                         "id": railcontent_id,
@@ -401,17 +420,17 @@ export async function fetchByRailContentId(id, contentType) {
         )
       ),
       length_in_seconds
-    ),`;
+    ),`
 
-    const query = buildRawQuery(
-        `railcontent_id == ${id} && _type == '${contentType}'`,
-        entityFieldsString,
-        {
-            isSingle: true,
-        },
-    );
+  const query = buildRawQuery(
+    `railcontent_id == ${id} && _type == '${contentType}'`,
+    entityFieldsString,
+    {
+      isSingle: true,
+    }
+  )
 
-    return fetchSanity(query, false);
+  return fetchSanity(query, false)
 }
 
 /**
@@ -427,25 +446,25 @@ export async function fetchByRailContentId(id, contentType) {
  *   .catch(error => console.error(error));
  */
 export async function fetchByRailContentIds(ids, contentType = undefined) {
-    const idsString = ids.join(',');
+  const idsString = ids.join(',')
 
-    const query = `*[railcontent_id in [${idsString}]]{
+  const query = `*[railcontent_id in [${idsString}]]{
         ${getFieldsForContentType(contentType)}
       }`
-    const results = await fetchSanity(query, true);
+  const results = await fetchSanity(query, true)
 
-   const sortFuction = function compare(a,b){
-       const indexA = ids.indexOf(a['id']);
-       const indexB = ids.indexOf(b['id'])
-        if(indexA === indexB) return 0;
-        if(indexA > indexB) return 1;
-        return -1;
-    }
+  const sortFuction = function compare(a, b) {
+    const indexA = ids.indexOf(a['id'])
+    const indexB = ids.indexOf(b['id'])
+    if (indexA === indexB) return 0
+    if (indexA > indexB) return 1
+    return -1
+  }
 
-    // Sort results to match the order of the input IDs
-    const sortedResults = results.sort(sortFuction);
+  // Sort results to match the order of the input IDs
+  const sortedResults = results.sort(sortFuction)
 
-    return sortedResults;
+  return sortedResults
 }
 
 /**
@@ -480,87 +499,96 @@ export async function fetchByRailContentIds(ids, contentType = undefined) {
  *   .then(content => console.log(content))
  *   .catch(error => console.error(error));
  */
-export async function fetchAll(brand, type, {
+export async function fetchAll(
+  brand,
+  type,
+  {
     page = 1,
     limit = 10,
-    searchTerm = "",
-    sort = "-published_on",
+    searchTerm = '',
+    sort = '-published_on',
     includedFields = [],
-    groupBy = "",
+    groupBy = '',
     progressIds = undefined,
     useDefaultFields = true,
     customFields = [],
-    progress = "all"
-} = {}) {
-    let customResults = await handleCustomFetchAll(brand, type, {
-        page,
-        limit,
-        searchTerm,
-        sort,
-        includedFields,
-        groupBy,
-        progressIds,
-        useDefaultFields,
-        customFields,
-        progress
-    });
-    if (customResults) {
-        return customResults;
-    }
-    let config = contentTypeConfig[type] ?? {};
-    let additionalFields = config?.fields ?? [];
-    let isGroupByOneToOne = (groupBy ? config?.relationships?.[groupBy]?.isOneToOne : false) ?? false;
-    let webUrlPathType = config?.slug ?? type;
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    let bypassStatusAndPublishedValidation = (type == 'instructor' || groupBy == 'artist' || groupBy == 'genre' || groupBy == 'instructor');
-    let bypassPermissions = bypassStatusAndPublishedValidation;
-    // Construct the type filter
-    let typeFilter;
+    progress = 'all',
+  } = {}
+) {
+  let customResults = await handleCustomFetchAll(brand, type, {
+    page,
+    limit,
+    searchTerm,
+    sort,
+    includedFields,
+    groupBy,
+    progressIds,
+    useDefaultFields,
+    customFields,
+    progress,
+  })
+  if (customResults) {
+    return customResults
+  }
+  let config = contentTypeConfig[type] ?? {}
+  let additionalFields = config?.fields ?? []
+  let isGroupByOneToOne = (groupBy ? config?.relationships?.[groupBy]?.isOneToOne : false) ?? false
+  let webUrlPathType = config?.slug ?? type
+  const start = (page - 1) * limit
+  const end = start + limit
+  let bypassStatusAndPublishedValidation =
+    type == 'instructor' || groupBy == 'artist' || groupBy == 'genre' || groupBy == 'instructor'
+  let bypassPermissions = bypassStatusAndPublishedValidation
+  // Construct the type filter
+  let typeFilter
 
-    if (type === 'archives') {
-        typeFilter = `&& status == "archived"`;
-        bypassStatusAndPublishedValidation = true;
-    } else if(type === 'pack'){
-        typeFilter = `&& (_type == 'pack' || _type == 'semester-pack')`;
-    } else {
-        typeFilter = type ? `&& _type == '${type}'` : progress === 'in progress' || progress === 'completed' ? " && (_type != 'challenge-part' && _type != 'challenge')" : "";  
-    }
+  if (type === 'archives') {
+    typeFilter = `&& status == "archived"`
+    bypassStatusAndPublishedValidation = true
+  } else if (type === 'pack') {
+    typeFilter = `&& (_type == 'pack' || _type == 'semester-pack')`
+  } else {
+    typeFilter = type
+      ? `&& _type == '${type}'`
+      : progress === 'in progress' || progress === 'completed'
+        ? " && (_type != 'challenge-part' && _type != 'challenge')"
+        : ''
+  }
 
-    // Construct the search filter
-    const searchFilter = searchTerm
-        ? groupBy !== "" ?
-            `&& (^.name match "${searchTerm}*" || title match "${searchTerm}*")`
-            : `&& (artist->name match "${searchTerm}*" || instructor[]->name match "${searchTerm}*" || title match "${searchTerm}*" || name match "${searchTerm}*")`
-        : "";
+  // Construct the search filter
+  const searchFilter = searchTerm
+    ? groupBy !== ''
+      ? `&& (^.name match "${searchTerm}*" || title match "${searchTerm}*")`
+      : `&& (artist->name match "${searchTerm}*" || instructor[]->name match "${searchTerm}*" || title match "${searchTerm}*" || name match "${searchTerm}*")`
+    : ''
 
-    // Construct the included fields filter, replacing 'difficulty' with 'difficulty_string'
-    const includedFieldsFilter = includedFields.length > 0
-        ? filtersToGroq(includedFields)
-        : "";
+  // Construct the included fields filter, replacing 'difficulty' with 'difficulty_string'
+  const includedFieldsFilter = includedFields.length > 0 ? filtersToGroq(includedFields) : ''
 
-    // limits the results to supplied progressIds for started & completed filters
-    const progressFilter = await getProgressFilter(progress, progressIds);
+  // limits the results to supplied progressIds for started & completed filters
+  const progressFilter = await getProgressFilter(progress, progressIds)
 
-    // Determine the sort order
-    const sortOrder = getSortOrder(sort, brand, groupBy);
+  // Determine the sort order
+  const sortOrder = getSortOrder(sort, brand, groupBy)
 
-    let fields = useDefaultFields ? customFields.concat(DEFAULT_FIELDS, additionalFields) : customFields;
-    let fieldsString = fields.join(',');
+  let fields = useDefaultFields
+    ? customFields.concat(DEFAULT_FIELDS, additionalFields)
+    : customFields
+  let fieldsString = fields.join(',')
 
-    let customFilter = '';
-    if (type == 'instructor') {
-        customFilter = '&& coach_card_image != null'
-    }
-    // Determine the group by clause
-    let query = "";
-    let entityFieldsString = "";
-    let filter = "";
-    if (groupBy !== "" && isGroupByOneToOne) {
-        const webUrlPath = 'artists';
-        const lessonsFilter = `_type == '${type}' && brand == '${brand}' && ^._id == ${groupBy}._ref ${searchFilter} ${includedFieldsFilter} ${progressFilter} ${customFilter}`;
-        const lessonsFilterWithRestrictions = await new FilterBuilder(lessonsFilter).buildFilter();
-        entityFieldsString = `
+  let customFilter = ''
+  if (type == 'instructor') {
+    customFilter = '&& coach_card_image != null'
+  }
+  // Determine the group by clause
+  let query = ''
+  let entityFieldsString = ''
+  let filter = ''
+  if (groupBy !== '' && isGroupByOneToOne) {
+    const webUrlPath = 'artists'
+    const lessonsFilter = `_type == '${type}' && brand == '${brand}' && ^._id == ${groupBy}._ref ${searchFilter} ${includedFieldsFilter} ${progressFilter} ${customFilter}`
+    const lessonsFilterWithRestrictions = await new FilterBuilder(lessonsFilter).buildFilter()
+    entityFieldsString = `
                 'id': railcontent_id,
                 'type': _type,
                 name,
@@ -571,16 +599,16 @@ export async function fetchAll(brand, type, {
                     ${fieldsString},
                     ${groupBy}
                 }[0...20]
-        `;
-        filter = `_type == '${groupBy}' && count(*[${lessonsFilterWithRestrictions}]._id) > 0`;
-    } else if (groupBy !== "") {
-        const childrenFilter = await new FilterBuilder(``, {isChildrenFilter: true} ).buildFilter();
+        `
+    filter = `_type == '${groupBy}' && count(*[${lessonsFilterWithRestrictions}]._id) > 0`
+  } else if (groupBy !== '') {
+    const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
 
-        const webUrlPath = (groupBy == 'genre') ? '/genres' : '';
-        const lessonsFilter = `brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter} ${customFilter}`;
-        const lessonsFilterWithRestrictions = await new FilterBuilder(lessonsFilter).buildFilter();
+    const webUrlPath = groupBy == 'genre' ? '/genres' : ''
+    const lessonsFilter = `brand == '${brand}' && ^._id in ${groupBy}[]._ref ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter} ${customFilter}`
+    const lessonsFilterWithRestrictions = await new FilterBuilder(lessonsFilter).buildFilter()
 
-        entityFieldsString = `
+    entityFieldsString = `
                 'id': railcontent_id,
                 'type': _type,
                 name,
@@ -591,12 +619,12 @@ export async function fetchAll(brand, type, {
                     ${fieldsString},
                      'lesson_count': coalesce(count(child[${childrenFilter}]->), 0) ,
                     ${groupBy}
-                }[0...20]`;
-        filter = `_type == '${groupBy}' && count(*[${lessonsFilterWithRestrictions}]._id) > 0`;
-    } else {
-        filter = `brand == "${brand}" ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter} ${customFilter}`
-        const childrenFilter = await new FilterBuilder(``, {isChildrenFilter: true} ).buildFilter();
-        entityFieldsString = ` ${fieldsString},
+                }[0...20]`
+    filter = `_type == '${groupBy}' && count(*[${lessonsFilterWithRestrictions}]._id) > 0`
+  } else {
+    filter = `brand == "${brand}" ${typeFilter} ${searchFilter} ${includedFieldsFilter} ${progressFilter} ${customFilter}`
+    const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
+    entityFieldsString = ` ${fieldsString},
                                     'lesson_count': coalesce(count(child[${childrenFilter}]->), 0) ,
                                     'length_in_seconds': coalesce(
       math::sum(
@@ -605,24 +633,21 @@ export async function fetchAll(brand, type, {
         )
       ),
       length_in_seconds
-    ),`;
-    }
+    ),`
+  }
 
-    const filterWithRestrictions = await new FilterBuilder(filter, {
-        bypassStatuses: bypassStatusAndPublishedValidation,
-        bypassPermissions: bypassPermissions,
-        bypassPublishedDateRestriction: bypassStatusAndPublishedValidation
-    }).buildFilter();
-    query = buildEntityAndTotalQuery(
-        filterWithRestrictions,
-        entityFieldsString,
-        {
-            sortOrder: sortOrder,
-            start: start,
-            end: end,
-        });
+  const filterWithRestrictions = await new FilterBuilder(filter, {
+    bypassStatuses: bypassStatusAndPublishedValidation,
+    bypassPermissions: bypassPermissions,
+    bypassPublishedDateRestriction: bypassStatusAndPublishedValidation,
+  }).buildFilter()
+  query = buildEntityAndTotalQuery(filterWithRestrictions, entityFieldsString, {
+    sortOrder: sortOrder,
+    start: start,
+    end: end,
+  })
 
-    return fetchSanity(query, true);
+  return fetchSanity(query, true)
 }
 
 /**
@@ -642,83 +667,110 @@ export async function fetchAll(brand, type, {
  * @param {string} [params.progress="all"] - An string representing which progress filter to use ("all", "in progress", "complete", "not started").
  * @returns {Promise<Object|null>} - The fetched content data or null if not found.
  */
-async function handleCustomFetchAll(brand, type, {
+async function handleCustomFetchAll(
+  brand,
+  type,
+  {
     page = 1,
     limit = 10,
-    searchTerm = "",
-    sort = "-published_on",
+    searchTerm = '',
+    sort = '-published_on',
     includedFields = [],
-    groupBy = "",
+    groupBy = '',
     progressIds = undefined,
     useDefaultFields = true,
     customFields = [],
-    progress = "all"
-} = {}) {
-    if (type === 'challenge') {
-        if (groupBy === 'completed') {
-            const completedIds = await fetchCompletedChallenges(brand, page, limit);
-            return fetchAll(brand, type,
-                {
-                    page,
-                    limit,
-                    searchTerm,
-                    sort,
-                    includedFields,
-                    groupBy: '',
-                    progressIds: completedIds,
-                    useDefaultFields,
-                    customFields,
-                    progress
-                });
-        } else if (groupBy === 'owned') {
-            const ownedIds = await fetchOwnedChallenges(brand, page, limit);
-            return fetchAll(brand, type,
-                {
-                    page,
-                    limit,
-                    searchTerm,
-                    sort,
-                    includedFields,
-                    groupBy: '',
-                    progressIds: ownedIds,
-                    useDefaultFields,
-                    customFields,
-                    progress
-                });
-        } else if (groupBy === 'difficulty_string') {
-            return fetchChallengesByDifficulty(brand, type, page, limit, searchTerm, sort, includedFields, groupBy, progressIds, useDefaultFields, customFields, progress);
-        }
+    progress = 'all',
+  } = {}
+) {
+  if (type === 'challenge') {
+    if (groupBy === 'completed') {
+      const completedIds = await fetchCompletedChallenges(brand, page, limit)
+      return fetchAll(brand, type, {
+        page,
+        limit,
+        searchTerm,
+        sort,
+        includedFields,
+        groupBy: '',
+        progressIds: completedIds,
+        useDefaultFields,
+        customFields,
+        progress,
+      })
+    } else if (groupBy === 'owned') {
+      const ownedIds = await fetchOwnedChallenges(brand, page, limit)
+      return fetchAll(brand, type, {
+        page,
+        limit,
+        searchTerm,
+        sort,
+        includedFields,
+        groupBy: '',
+        progressIds: ownedIds,
+        useDefaultFields,
+        customFields,
+        progress,
+      })
+    } else if (groupBy === 'difficulty_string') {
+      return fetchChallengesByDifficulty(
+        brand,
+        type,
+        page,
+        limit,
+        searchTerm,
+        sort,
+        includedFields,
+        groupBy,
+        progressIds,
+        useDefaultFields,
+        customFields,
+        progress
+      )
     }
-    return null;
+  }
+  return null
 }
 
-async function fetchChallengesByDifficulty(brand, type, page, limit, searchTerm, sort, includedFields, groupBy, progressIds, useDefaultFields, customFields, progress) {
-    let config = contentTypeConfig['challenge'] ?? {};
-    let additionalFields = config?.fields ?? [];
+async function fetchChallengesByDifficulty(
+  brand,
+  type,
+  page,
+  limit,
+  searchTerm,
+  sort,
+  includedFields,
+  groupBy,
+  progressIds,
+  useDefaultFields,
+  customFields,
+  progress
+) {
+  let config = contentTypeConfig['challenge'] ?? {}
+  let additionalFields = config?.fields ?? []
 
-    // Construct the search filter
-    const searchFilter = searchTerm
-        ? groupBy !== "" ?
-            `&& (^.name match "${searchTerm}*" || title match "${searchTerm}*")`
-            : `&& (artist->name match "${searchTerm}*" || instructor[]->name match "${searchTerm}*" || title match "${searchTerm}*" || name match "${searchTerm}*")`
-        : "";
+  // Construct the search filter
+  const searchFilter = searchTerm
+    ? groupBy !== ''
+      ? `&& (^.name match "${searchTerm}*" || title match "${searchTerm}*")`
+      : `&& (artist->name match "${searchTerm}*" || instructor[]->name match "${searchTerm}*" || title match "${searchTerm}*" || name match "${searchTerm}*")`
+    : ''
 
-    // Construct the included fields filter, replacing 'difficulty' with 'difficulty_string'
-    const includedFieldsFilter = includedFields.length > 0
-        ? filtersToGroq(includedFields)
-        : "";
+  // Construct the included fields filter, replacing 'difficulty' with 'difficulty_string'
+  const includedFieldsFilter = includedFields.length > 0 ? filtersToGroq(includedFields) : ''
 
-    // limits the results to supplied progressIds for started & completed filters
-    const progressFilter = await getProgressFilter(progress, progressIds);
+  // limits the results to supplied progressIds for started & completed filters
+  const progressFilter = await getProgressFilter(progress, progressIds)
 
-    let fields = useDefaultFields ? customFields.concat(DEFAULT_FIELDS, additionalFields) : customFields;
-    let fieldsString = fields.join(',');
+  let fields = useDefaultFields
+    ? customFields.concat(DEFAULT_FIELDS, additionalFields)
+    : customFields
+  let fieldsString = fields.join(',')
 
+  const lessonsFilter = `_type == 'challenge' && brand == '${brand}' && ^.name == difficulty_string ${searchFilter} ${includedFieldsFilter} ${progressFilter}`
+  const lessonsFilterWithRestrictions = await new FilterBuilder(lessonsFilter).buildFilter()
 
-    const lessonsFilter = `_type == 'challenge' && brand == '${brand}' && ^.name == difficulty_string ${searchFilter} ${includedFieldsFilter} ${progressFilter}`;
-    const lessonsFilterWithRestrictions = await new FilterBuilder(lessonsFilter).buildFilter();
-
-    const query = `{
+  const query = `{
       "entity": [
         {"name": "All"},
         {"name": "Novice"},
@@ -736,62 +788,61 @@ async function fetchChallengesByDifficulty(brand, type, page, limit, searchTerm,
             }[0...20]
           },
           "total": 0
-        }`;
-    let data = await fetchSanity(query, true);
-    data.entity = data.entity.filter(function (difficulty) {
-        return difficulty.lessons.length > 0;
-    });
-    return data;
+        }`
+  let data = await fetchSanity(query, true)
+  data.entity = data.entity.filter(function (difficulty) {
+    return difficulty.lessons.length > 0
+  })
+  return data
 }
 
 async function getProgressFilter(progress, progressIds) {
-    switch (progress) {
-        case "all":
-            return progressIds !== undefined ?
-                `&& railcontent_id in [${progressIds.join(',')}]` : "";
-        case "in progress": {
-            const ids = await getAllStarted();
-            return `&& railcontent_id in [${ids.join(',')}]`;
-        }
-        case "completed": {
-            const ids = await getAllCompleted();
-            return `&& railcontent_id in [${ids.join(',')}]`;
-        }
-        case "not started": {
-            const ids = await getAllStartedOrCompleted();
-            return `&& !(railcontent_id in [${ids.join(',')}])`;
-        }
-        default:
-            throw new Error(`'${progress}' progress option not implemented`);
+  switch (progress) {
+    case 'all':
+      return progressIds !== undefined ? `&& railcontent_id in [${progressIds.join(',')}]` : ''
+    case 'in progress': {
+      const ids = await getAllStarted()
+      return `&& railcontent_id in [${ids.join(',')}]`
     }
+    case 'completed': {
+      const ids = await getAllCompleted()
+      return `&& railcontent_id in [${ids.join(',')}]`
+    }
+    case 'not started': {
+      const ids = await getAllStartedOrCompleted()
+      return `&& !(railcontent_id in [${ids.join(',')}])`
+    }
+    default:
+      throw new Error(`'${progress}' progress option not implemented`)
+  }
 }
 
 export function getSortOrder(sort = '-published_on', brand, groupBy) {
-    // Determine the sort order
-    let sortOrder = '';
-    const isDesc = sort.startsWith('-');
-    sort = isDesc ? sort.substring(1) : sort;
-    switch (sort) {
-        case "slug":
-            sortOrder = groupBy ? 'name' : "title";
-            break;
-        case "name":
-            sortOrder = sort;
-            break;
-        case "popularity":
-            if (groupBy == "artist" || groupBy == "genre") {
-                sortOrder = isDesc ? `coalesce(popularity.${brand}, -1)` : "popularity";
-            } else {
-                sortOrder = isDesc ? "coalesce(popularity, -1)" : "popularity";
-            }
-            break;
-        case "published_on":
-        default:
-            sortOrder = "published_on";
-            break;
-    }
-    sortOrder += isDesc ? ' desc' : ' asc';
-    return sortOrder;
+  // Determine the sort order
+  let sortOrder = ''
+  const isDesc = sort.startsWith('-')
+  sort = isDesc ? sort.substring(1) : sort
+  switch (sort) {
+    case 'slug':
+      sortOrder = groupBy ? 'name' : 'title'
+      break
+    case 'name':
+      sortOrder = sort
+      break
+    case 'popularity':
+      if (groupBy == 'artist' || groupBy == 'genre') {
+        sortOrder = isDesc ? `coalesce(popularity.${brand}, -1)` : 'popularity'
+      } else {
+        sortOrder = isDesc ? 'coalesce(popularity, -1)' : 'popularity'
+      }
+      break
+    case 'published_on':
+    default:
+      sortOrder = 'published_on'
+      break
+  }
+  sortOrder += isDesc ? ' desc' : ' asc'
+  return sortOrder
 }
 
 /**
@@ -826,42 +877,48 @@ export function getSortOrder(sort = '-published_on', brand, groupBy) {
  *   .catch(error => console.error(error));
  */
 export async function fetchAllFilterOptions(
-    brand,
-    filters = [],
-    style,
-    artist,
-    contentType,
-    term,
-    progressIds,
-    coachId,
-    includeTabs = false,
+  brand,
+  filters = [],
+  style,
+  artist,
+  contentType,
+  term,
+  progressIds,
+  coachId,
+  includeTabs = false
 ) {
-    if (coachId && contentType !== 'coach-lessons') {
-        throw new Error(`Invalid contentType: '${contentType}' for coachId. It must be 'coach-lessons'.`);
-    }
+  if (coachId && contentType !== 'coach-lessons') {
+    throw new Error(
+      `Invalid contentType: '${contentType}' for coachId. It must be 'coach-lessons'.`
+    )
+  }
 
-    const includedFieldsFilter = filters?.length ? filtersToGroq(filters) : undefined;
-    const progressFilter = progressIds ? `&& railcontent_id in [${progressIds.join(',')}]` : "";
-    const isAdmin = (await fetchUserPermissions()).isAdmin;
+  const includedFieldsFilter = filters?.length ? filtersToGroq(filters) : undefined
+  const progressFilter = progressIds ? `&& railcontent_id in [${progressIds.join(',')}]` : ''
+  const isAdmin = (await fetchUserPermissions()).isAdmin
 
-    const constructCommonFilter = (excludeFilter) => {
-        const filterWithoutOption = excludeFilter ? filtersToGroq(filters, excludeFilter) : includedFieldsFilter;
-        const statusFilter = ' && status == "published"';
-        const includeStatusFilter = !isAdmin && !['instructor', 'artist', 'genre'].includes(contentType);
+  const constructCommonFilter = (excludeFilter) => {
+    const filterWithoutOption = excludeFilter
+      ? filtersToGroq(filters, excludeFilter)
+      : includedFieldsFilter
+    const statusFilter = ' && status == "published"'
+    const includeStatusFilter = !isAdmin && !['instructor', 'artist', 'genre'].includes(contentType)
 
-        return coachId
-            ? `brand == '${brand}' && status == "published" && references(*[_type=='instructor' && railcontent_id == ${coachId}]._id) ${filterWithoutOption || ''} ${term ? ` && (title match "${term}" || album match "${term}" || artist->name match "${term}" || genre[]->name match "${term}")` : ''}`
-            : `_type == '${contentType}' && brand == "${brand}"${includeStatusFilter ? statusFilter : ''}${style && excludeFilter !== "style" ? ` && '${style}' in genre[]->name` : ''}${artist && excludeFilter !== "artist" ? ` && artist->name == '${artist}'` : ''} ${progressFilter} ${filterWithoutOption || ''} ${term ? ` && (title match "${term}" || album match "${term}" || artist->name match "${term}" || genre[]->name match "${term}")` : ''}`;
-    };
+    return coachId
+      ? `brand == '${brand}' && status == "published" && references(*[_type=='instructor' && railcontent_id == ${coachId}]._id) ${filterWithoutOption || ''} ${term ? ` && (title match "${term}" || album match "${term}" || artist->name match "${term}" || genre[]->name match "${term}")` : ''}`
+      : `_type == '${contentType}' && brand == "${brand}"${includeStatusFilter ? statusFilter : ''}${style && excludeFilter !== 'style' ? ` && '${style}' in genre[]->name` : ''}${artist && excludeFilter !== 'artist' ? ` && artist->name == '${artist}'` : ''} ${progressFilter} ${filterWithoutOption || ''} ${term ? ` && (title match "${term}" || album match "${term}" || artist->name match "${term}" || genre[]->name match "${term}")` : ''}`
+  }
 
-    const metaData = processMetadata(brand, contentType, true);
-    const allowableFilters = metaData?.allowableFilters || [];
-    const tabs = metaData?.tabs || [];
-    const catalogName = metaData?.shortname || metaData?.name;
+  const metaData = processMetadata(brand, contentType, true)
+  const allowableFilters = metaData?.allowableFilters || []
+  const tabs = metaData?.tabs || []
+  const catalogName = metaData?.shortname || metaData?.name
 
-    const dynamicFilterOptions = allowableFilters.map(filter => getFilterOptions(filter, constructCommonFilter(filter), contentType, brand)).join(' ');
+  const dynamicFilterOptions = allowableFilters
+    .map((filter) => getFilterOptions(filter, constructCommonFilter(filter), contentType, brand))
+    .join(' ')
 
-    const query = `
+  const query = `
       {
         "meta": {
           "totalResults": count(*[${constructCommonFilter()}
@@ -870,11 +927,11 @@ export async function fetchAllFilterOptions(
             ${dynamicFilterOptions}
           }
       }
-    }`;
+    }`
 
-    const results = await fetchSanity(query, true, {processNeedAccess: false});
+  const results = await fetchSanity(query, true, { processNeedAccess: false })
 
-    return includeTabs ? {...results, tabs, catalogName} : results;
+  return includeTabs ? { ...results, tabs, catalogName } : results
 }
 
 /**
@@ -883,17 +940,17 @@ export async function fetchAllFilterOptions(
  * @returns {Promise<Object|null>} - The fetched foundation data or null if not found.
  */
 export async function fetchFoundation(slug) {
-    const filterParams = {};
-    const query = await buildQuery(
-        `_type == 'foundation' && slug.current == "${slug}"`,
-        filterParams,
-        getFieldsForContentType('foundation'),
-        {
-            sortOrder: 'published_on asc',
-            isSingle: true,
-        }
-    );
-    return fetchSanity(query, false);
+  const filterParams = {}
+  const query = await buildQuery(
+    `_type == 'foundation' && slug.current == "${slug}"`,
+    filterParams,
+    getFieldsForContentType('foundation'),
+    {
+      sortOrder: 'published_on asc',
+      isSingle: true,
+    }
+  )
+  return fetchSanity(query, false)
 }
 
 /**
@@ -903,9 +960,9 @@ export async function fetchFoundation(slug) {
  * @returns {Promise<Object|null>} - The fetched methods data or null if not found.
  */
 export async function fetchMethod(brand, slug) {
-    const childrenFilter = await new FilterBuilder(``, {isChildrenFilter: true} ).buildFilter();
+  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
 
-    const query = `*[_type == 'learning-path' && brand == "${brand}" && slug.current == "${slug}"] {
+  const query = `*[_type == 'learning-path' && brand == "${brand}" && slug.current == "${slug}"] {
     "description": ${descriptionField},
     "instructors":instructor[]->name,
     published_on,
@@ -942,7 +999,7 @@ export async function fetchMethod(brand, slug) {
         total_xp
       }
   } | order(published_on asc)`
-    return fetchSanity(query, false);
+  return fetchSanity(query, false)
 }
 
 /**
@@ -951,9 +1008,9 @@ export async function fetchMethod(brand, slug) {
  * @returns {Promise<Object|null>} - The fetched next lesson data or null if not found.
  */
 export async function fetchMethodChildren(railcontentId) {
-    const childrenFilter = await new FilterBuilder(``, {isChildrenFilter: true} ).buildFilter();
+  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
 
-    const query = `*[railcontent_id == ${railcontentId}]{
+  const query = `*[railcontent_id == ${railcontentId}]{
     "child_count":coalesce(count(child[${childrenFilter}]->), 0),
     "id": railcontent_id,
     "description": ${descriptionField},
@@ -971,8 +1028,8 @@ export async function fetchMethodChildren(railcontentId) {
     'children': child[(${childrenFilter})]->{
         ${getFieldsForContentType('method')}
     },
-  }[0..1]`;
-    return fetchSanity(query, true);
+  }[0..1]`
+  return fetchSanity(query, true)
 }
 
 /**
@@ -986,21 +1043,21 @@ export async function fetchMethodChildren(railcontentId) {
  *  .catch(error => console.error(error));
  */
 export async function fetchMethodPreviousNextLesson(railcontentId, methodId) {
-    const sortedChildren = await fetchMethodChildrenIds(methodId);
-    const index = sortedChildren.indexOf(Number(railcontentId));
-    let nextId = sortedChildren[index + 1];
-    let previousId = sortedChildren[index - 1];
-    let ids = [];
-    if (nextId) ids.push(nextId);
-    if (previousId) ids.push(previousId);
-    let nextPrev = await fetchByRailContentIds(ids);
-    const nextLesson = nextPrev.find((elem) => {
-        return elem['id'] === nextId
-    });
-    const prevLesson = nextPrev.find((elem) => {
-        return elem['id'] === previousId
-    });
-    return {nextLesson, prevLesson};
+  const sortedChildren = await fetchMethodChildrenIds(methodId)
+  const index = sortedChildren.indexOf(Number(railcontentId))
+  let nextId = sortedChildren[index + 1]
+  let previousId = sortedChildren[index - 1]
+  let ids = []
+  if (nextId) ids.push(nextId)
+  if (previousId) ids.push(previousId)
+  let nextPrev = await fetchByRailContentIds(ids)
+  const nextLesson = nextPrev.find((elem) => {
+    return elem['id'] === nextId
+  })
+  const prevLesson = nextPrev.find((elem) => {
+    return elem['id'] === previousId
+  })
+  return { nextLesson, prevLesson }
 }
 
 /**
@@ -1009,9 +1066,9 @@ export async function fetchMethodPreviousNextLesson(railcontentId, methodId) {
  * @returns {Promise<Array<Object>|null>} - The fetched children data or null if not found.
  */
 export async function fetchMethodChildrenIds(railcontentId) {
-    const childrenFilter = await new FilterBuilder(``, {isChildrenFilter: true} ).buildFilter();
+  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
 
-    const query = `*[ railcontent_id == ${railcontentId}]{
+  const query = `*[ railcontent_id == ${railcontentId}]{
     'children': child[${childrenFilter}]-> {
         'id': railcontent_id,
         'type' : _type,
@@ -1024,22 +1081,22 @@ export async function fetchMethodChildrenIds(railcontentId) {
             }
         }
     }
-}`;
-    let allChildren = await fetchSanity(query, false);
-    return getChildrenToDepth(allChildren, 4);
+}`
+  let allChildren = await fetchSanity(query, false)
+  return getChildrenToDepth(allChildren, 4)
 }
 
 function getChildrenToDepth(parent, depth = 1) {
-    let allChildrenIds = [];
-    if (parent && parent['children'] && depth > 0) {
-        parent['children'].forEach((child) => {
-            if (!child['children']) {
-                allChildrenIds.push(child['id']);
-            }
-            allChildrenIds = allChildrenIds.concat(getChildrenToDepth(child, depth - 1));
-        })
-    }
-    return allChildrenIds;
+  let allChildrenIds = []
+  if (parent && parent['children'] && depth > 0) {
+    parent['children'].forEach((child) => {
+      if (!child['children']) {
+        allChildrenIds.push(child['id'])
+      }
+      allChildrenIds = allChildrenIds.concat(getChildrenToDepth(child, depth - 1))
+    })
+  }
+  return allChildrenIds
 }
 
 /**
@@ -1048,31 +1105,31 @@ function getChildrenToDepth(parent, depth = 1) {
  * @returns {Promise<Object|null>} - The fetched next and previous lesson data or null if found.
  */
 export async function fetchNextPreviousLesson(railcontentId) {
-    const document = await fetchLessonContent(railcontentId);
-    if (document.parent_content_data && document.parent_content_data.length > 0) {
-        const lastElement = document.parent_content_data[document.parent_content_data.length - 1];
-        const results = await fetchMethodPreviousNextLesson(railcontentId, lastElement.id);
-        return results;
-    }
-    const processedData = processMetadata(document.brand, document.type, true);
-    let sortBy = processedData?.sortBy ?? 'published_on';
-    const isDesc = sortBy.startsWith('-');
-    sortBy = isDesc ? sortBy.substring(1) : sortBy;
-    let sortValue = document[sortBy];
-    if (sortValue == null) {
-        sortBy = 'railcontent_id';
-        sortValue = document['railcontent_id'];
-    }
-    const isNumeric = !isNaN(sortValue);
-    let prevComparison = isNumeric ? `${sortBy} <= ${sortValue}` : `${sortBy} <= "${sortValue}"`;
-    let nextComparison = isNumeric ? `${sortBy} >= ${sortValue}` : `${sortBy} >= "${sortValue}"`;
-    const fields = getFieldsForContentType(document.type);
-    const query = `{
+  const document = await fetchLessonContent(railcontentId)
+  if (document.parent_content_data && document.parent_content_data.length > 0) {
+    const lastElement = document.parent_content_data[document.parent_content_data.length - 1]
+    const results = await fetchMethodPreviousNextLesson(railcontentId, lastElement.id)
+    return results
+  }
+  const processedData = processMetadata(document.brand, document.type, true)
+  let sortBy = processedData?.sortBy ?? 'published_on'
+  const isDesc = sortBy.startsWith('-')
+  sortBy = isDesc ? sortBy.substring(1) : sortBy
+  let sortValue = document[sortBy]
+  if (sortValue == null) {
+    sortBy = 'railcontent_id'
+    sortValue = document['railcontent_id']
+  }
+  const isNumeric = !isNaN(sortValue)
+  let prevComparison = isNumeric ? `${sortBy} <= ${sortValue}` : `${sortBy} <= "${sortValue}"`
+  let nextComparison = isNumeric ? `${sortBy} >= ${sortValue}` : `${sortBy} >= "${sortValue}"`
+  const fields = getFieldsForContentType(document.type)
+  const query = `{
       "prevLesson": *[brand == "${document.brand}" && status == "${document.status}" && _type == "${document.type}" && ${prevComparison} && railcontent_id != ${railcontentId}] | order(${sortBy} desc){${fields}}[0...1][0],
       "nextLesson": *[brand == "${document.brand}" && status == "${document.status}" && _type == "${document.type}" && ${nextComparison} && railcontent_id != ${railcontentId}] | order(${sortBy} asc){${fields}}[0...1][0]
-    }`;
+    }`
 
-    return await fetchSanity(query, true);
+  return await fetchSanity(query, true)
 }
 
 /**
@@ -1085,12 +1142,12 @@ export async function fetchNextPreviousLesson(railcontentId) {
  *  .catch(error => console.error(error));
  */
 export async function jumpToContinueContent(railcontentId) {
-    const nextContent = await fetchNextContentDataForParent(railcontentId);
-    if (!nextContent || !nextContent.id) {
-        return null;
-    }
-    let next = await fetchByRailContentId(nextContent.id, nextContent.type);
-    return {next};
+  const nextContent = await fetchNextContentDataForParent(railcontentId)
+  if (!nextContent || !nextContent.id) {
+    return null
+  }
+  let next = await fetchByRailContentId(nextContent.id, nextContent.type)
+  return { next }
 }
 
 /**
@@ -1104,11 +1161,11 @@ export async function jumpToContinueContent(railcontentId) {
  *   .catch(error => console.error(error));
  */
 export async function fetchLessonContent(railContentId) {
-    const filterParams = {isSingle: true, pullFutureContent: true};
-    // Format changes made to the `fields` object may also need to be reflected in Musora-web-platform SanityGateway.php $fields object
-    // Currently only for challenges and challenge lessons
-    // If you're unsure, message Adrian, or just add them.
-    const fields = `title, 
+  const filterParams = { isSingle: true, pullFutureContent: true }
+  // Format changes made to the `fields` object may also need to be reflected in Musora-web-platform SanityGateway.php $fields object
+  // Currently only for challenges and challenge lessons
+  // If you're unsure, message Adrian, or just add them.
+  const fields = `title, 
           published_on,
           "type":_type, 
           "resources": ${resourcesField},
@@ -1156,16 +1213,11 @@ export async function fetchLessonContent(railContentId) {
             "type": *[railcontent_id == ^.id][0]._type,
           },
           sort,
-          xp`;
-    const query = await buildQuery(
-        `railcontent_id == ${railContentId}`,
-        filterParams,
-        fields,
-        {
-            isSingle: true,
-        }
-    );
-    return fetchSanity(query, false);
+          xp`
+  const query = await buildQuery(`railcontent_id == ${railContentId}`, filterParams, fields, {
+    isSingle: true,
+  })
+  return fetchSanity(query, false)
 }
 
 /**
@@ -1175,14 +1227,22 @@ export async function fetchLessonContent(railContentId) {
  * @returns {Promise<Array<Object>|null>} - The fetched related lessons data or null if not found.
  */
 export async function fetchRelatedLessons(railContentId, brand) {
-    const filterSameTypeAndSortOrder = await new FilterBuilder(`_type==^._type &&  _type in ${JSON.stringify(typeWithSortOrder)} && brand == "${brand}" && railcontent_id !=${railContentId}`).buildFilter();
-    const filterSameType = await new FilterBuilder(`_type==^._type && !(_type in ${JSON.stringify(typeWithSortOrder)}) && !(defined(parent_type)) && brand == "${brand}" && railcontent_id !=${railContentId}`).buildFilter();
-    const filterSongSameArtist = await new FilterBuilder(`_type=="song" && _type==^._type && brand == "${brand}" && references(^.artist->_id) && railcontent_id !=${railContentId}`).buildFilter();
-    const filterSongSameGenre = await new FilterBuilder(`_type=="song" && _type==^._type && brand == "${brand}" && references(^.genre[]->_id) && railcontent_id !=${railContentId}`).buildFilter();
-    const filterNeighbouringSiblings = await new FilterBuilder(`references(^._id)`).buildFilter();
-    const childrenFilter = await new FilterBuilder(``, {isChildrenFilter: true} ).buildFilter();
+  const filterSameTypeAndSortOrder = await new FilterBuilder(
+    `_type==^._type &&  _type in ${JSON.stringify(typeWithSortOrder)} && brand == "${brand}" && railcontent_id !=${railContentId}`
+  ).buildFilter()
+  const filterSameType = await new FilterBuilder(
+    `_type==^._type && !(_type in ${JSON.stringify(typeWithSortOrder)}) && !(defined(parent_type)) && brand == "${brand}" && railcontent_id !=${railContentId}`
+  ).buildFilter()
+  const filterSongSameArtist = await new FilterBuilder(
+    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.artist->_id) && railcontent_id !=${railContentId}`
+  ).buildFilter()
+  const filterSongSameGenre = await new FilterBuilder(
+    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.genre[]->_id) && railcontent_id !=${railContentId}`
+  ).buildFilter()
+  const filterNeighbouringSiblings = await new FilterBuilder(`references(^._id)`).buildFilter()
+  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
 
-    const query = `*[railcontent_id == ${railContentId} && brand == "${brand}" && (!defined(permission) || references(*[_type=='permission']._id))]{
+  const query = `*[railcontent_id == ${railContentId} && brand == "${brand}" && (!defined(permission) || references(*[_type=='permission']._id))]{
    _type, parent_type, railcontent_id,
     "related_lessons" : array::unique([
       ...(*[${filterNeighbouringSiblings}][0].child[${childrenFilter}]->{_id, "id":railcontent_id, published_on, "instructor": instructor[0]->name, title, "thumbnail_url":thumbnail.asset->url, length_in_seconds, web_url_path, "type": _type, difficulty, difficulty_string, railcontent_id, artist->,"permission_id": permission[]->railcontent_id,_type}),
@@ -1191,8 +1251,8 @@ export async function fetchRelatedLessons(railContentId, brand) {
       ...(*[${filterSameTypeAndSortOrder}]{_id, "id":railcontent_id, published_on, "instructor": instructor[0]->name, title, "thumbnail_url":thumbnail.asset->url, length_in_seconds, web_url_path, "type": _type, difficulty, difficulty_string, railcontent_id, artist->,"permission_id": permission[]->railcontent_id,_type, sort}|order(sort asc, title asc)[0...10]),
       ...(*[${filterSameType}]{_id, "id":railcontent_id, published_on, "instructor": instructor[0]->name, title, "thumbnail_url":thumbnail.asset->url, length_in_seconds, web_url_path, "type": _type, difficulty, difficulty_string, railcontent_id, artist->,"permission_id": permission[]->railcontent_id,_type}|order(published_on desc, title asc)[0...10])
       ,
-      ])[0...10]}`;
-    return fetchSanity(query, false);
+      ])[0...10]}`
+  return fetchSanity(query, false)
 }
 
 /**
@@ -1204,26 +1264,27 @@ export async function fetchRelatedLessons(railContentId, brand) {
  * @param {number} [params.limit=10] - The number of items per page.
  * @returns {Promise<Array<Object>|null>} - The fetched pack content data or null if not found.
  */
-export async function fetchAllPacks(brand, sort = "-published_on", searchTerm = "", page = 1, limit = 10) {
-    const sortOrder = getSortOrder(sort, brand);
-    const filter = `(_type == 'pack' || _type == 'semester-pack') && brand == '${brand}' && title match "${searchTerm}*"`
-    const filterParams = {};
-    const fields = getFieldsForContentType('pack');
-    const start = (page - 1) * limit;
-    const end = start + limit;
+export async function fetchAllPacks(
+  brand,
+  sort = '-published_on',
+  searchTerm = '',
+  page = 1,
+  limit = 10
+) {
+  const sortOrder = getSortOrder(sort, brand)
+  const filter = `(_type == 'pack' || _type == 'semester-pack') && brand == '${brand}' && title match "${searchTerm}*"`
+  const filterParams = {}
+  const fields = getFieldsForContentType('pack')
+  const start = (page - 1) * limit
+  const end = start + limit
 
-    const query = await buildQuery(
-        filter,
-        filterParams,
-        getFieldsForContentType('pack'),
-        {
-            logo_image_url: 'logo_image_url.asset->url',
-            sortOrder: sortOrder,
-            start,
-            end
-        }
-    );
-    return fetchSanity(query, true);
+  const query = await buildQuery(filter, filterParams, getFieldsForContentType('pack'), {
+    logo_image_url: 'logo_image_url.asset->url',
+    sortOrder: sortOrder,
+    start,
+    end,
+  })
+  return fetchSanity(query, true)
 }
 
 /**
@@ -1232,38 +1293,38 @@ export async function fetchAllPacks(brand, sort = "-published_on", searchTerm = 
  * @returns {Promise<Array<Object>|null>} - The fetched pack content data or null if not found.
  */
 export async function fetchPackAll(railcontentId, type = 'pack') {
-    return fetchByRailContentId(railcontentId, type);
+  return fetchByRailContentId(railcontentId, type)
 }
 
 export async function fetchLiveEvent(brand) {
-    //calendarIDs taken from addevent.php
-    // TODO import instructor calendars to Sanity
-    let defaultCalendarID = '';
-    switch (brand) {
-        case ('drumeo'):
-            defaultCalendarID = 'GP142387';
-            break;
-        case ('pianote'):
-            defaultCalendarID = 'be142408';
-            break;
-        case ('guitareo'):
-            defaultCalendarID = 'IJ142407';
-            break;
-        case ('singeo'):
-            defaultCalendarID = 'bk354284';
-            break;
-        default:
-            break;
-    }
-    let startDateTemp = new Date();
-    let endDateTemp = new Date();
-    startDateTemp=  new Date (startDateTemp.setMinutes(startDateTemp.getMinutes() + 15));
-    endDateTemp = new Date(endDateTemp.setMinutes(endDateTemp.getMinutes() - 15));
+  //calendarIDs taken from addevent.php
+  // TODO import instructor calendars to Sanity
+  let defaultCalendarID = ''
+  switch (brand) {
+    case 'drumeo':
+      defaultCalendarID = 'GP142387'
+      break
+    case 'pianote':
+      defaultCalendarID = 'be142408'
+      break
+    case 'guitareo':
+      defaultCalendarID = 'IJ142407'
+      break
+    case 'singeo':
+      defaultCalendarID = 'bk354284'
+      break
+    default:
+      break
+  }
+  let startDateTemp = new Date()
+  let endDateTemp = new Date()
+  startDateTemp = new Date(startDateTemp.setMinutes(startDateTemp.getMinutes() + 15))
+  endDateTemp = new Date(endDateTemp.setMinutes(endDateTemp.getMinutes() - 15))
 
-    // See LiveStreamEventService.getCurrentOrNextLiveEvent for some nice complicated logic which I don't think is actually importart
-    // this has some +- on times
-    // But this query just finds the first scheduled event (sorted by start_time) that ends after now()
-    const query = `*[status == 'scheduled' && brand == '${brand}' && defined(live_event_start_time) && live_event_start_time <= '${getSanityDate(startDateTemp, false)}' && live_event_end_time >= '${getSanityDate(endDateTemp, false)}']{
+  // See LiveStreamEventService.getCurrentOrNextLiveEvent for some nice complicated logic which I don't think is actually importart
+  // this has some +- on times
+  // But this query just finds the first scheduled event (sorted by start_time) that ends after now()
+  const query = `*[status == 'scheduled' && brand == '${brand}' && defined(live_event_start_time) && live_event_start_time <= '${getSanityDate(startDateTemp, false)}' && live_event_end_time >= '${getSanityDate(endDateTemp, false)}']{
       'slug': slug.current,
       'id': railcontent_id,
       live_event_start_time,
@@ -1280,8 +1341,8 @@ export async function fetchLiveEvent(brand) {
             web_url_path,
           },
       'videoId': coalesce(live_event_youtube_id, video.external_id),
-    } | order(live_event_start_time)[0...1]`;
-    return await fetchSanity(query, false, {processNeedAccess: false});
+    } | order(live_event_start_time)[0...1]`
+  return await fetchSanity(query, false, { processNeedAccess: false })
 }
 
 /**
@@ -1295,10 +1356,10 @@ export async function fetchLiveEvent(brand) {
  *   .catch(error => console.error(error));
  */
 export async function fetchPackData(id) {
-    const query = `*[railcontent_id == ${id}]{
-    ${getFieldsForContentType("pack")}
-  } [0...1]`;
-    return fetchSanity(query, false);
+  const query = `*[railcontent_id == ${id}]{
+    ${getFieldsForContentType('pack')}
+  } [0...1]`
+  return fetchSanity(query, false)
 }
 
 /**
@@ -1318,34 +1379,26 @@ export async function fetchPackData(id) {
  *   .then(lessons => console.log(lessons))
  *   .catch(error => console.error(error));
  */
-export async function fetchCoachLessons(brand, id, {
-    sortOrder = '-published_on',
-    searchTerm = '',
-    page = 1,
-    limit = 20,
-    includedFields = [],
-} = {}) {
-    const fieldsString = getFieldsForContentType();
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const searchFilter = searchTerm ? `&& title match "${searchTerm}*"` : ''
-    const includedFieldsFilter = includedFields.length > 0
-        ? filtersToGroq(includedFields)
-        : "";
-    const filter = `brand == '${brand}' ${searchFilter} ${includedFieldsFilter} && references(*[_type=='instructor' && railcontent_id == ${id}]._id)`;
-    const filterWithRestrictions = await new FilterBuilder(filter).buildFilter();
+export async function fetchCoachLessons(
+  brand,
+  id,
+  { sortOrder = '-published_on', searchTerm = '', page = 1, limit = 20, includedFields = [] } = {}
+) {
+  const fieldsString = getFieldsForContentType()
+  const start = (page - 1) * limit
+  const end = start + limit
+  const searchFilter = searchTerm ? `&& title match "${searchTerm}*"` : ''
+  const includedFieldsFilter = includedFields.length > 0 ? filtersToGroq(includedFields) : ''
+  const filter = `brand == '${brand}' ${searchFilter} ${includedFieldsFilter} && references(*[_type=='instructor' && railcontent_id == ${id}]._id)`
+  const filterWithRestrictions = await new FilterBuilder(filter).buildFilter()
 
-    sortOrder = getSortOrder(sortOrder, brand);
-    const query = buildEntityAndTotalQuery(
-        filterWithRestrictions,
-        fieldsString,
-        {
-            sortOrder: sortOrder,
-            start: start,
-            end: end,
-        },
-    );
-    return fetchSanity(query, true);
+  sortOrder = getSortOrder(sortOrder, brand)
+  const query = buildEntityAndTotalQuery(filterWithRestrictions, fieldsString, {
+    sortOrder: sortOrder,
+    start: start,
+    end: end,
+  })
+  return fetchSanity(query, true)
 }
 
 /**
@@ -1359,15 +1412,15 @@ export async function fetchCoachLessons(brand, id, {
  *   .catch(error => console.error(error));
  */
 export async function fetchParentForDownload(id) {
-    const query = buildRawQuery(
-        `railcontent_id == ${id}`,
-        getFieldsForContentType('parent-download'),
-        {
-            isSingle: true,
-        },
-    );
+  const query = buildRawQuery(
+    `railcontent_id == ${id}`,
+    getFieldsForContentType('parent-download'),
+    {
+      isSingle: true,
+    }
+  )
 
-    return fetchSanity(query, false);
+  return fetchSanity(query, false)
 }
 
 /**
@@ -1381,33 +1434,24 @@ export async function fetchParentForDownload(id) {
  *   .then(lessons => console.log(lessons))
  *   .catch(error => console.error(error));
  */
-export async function fetchByReference(brand, {
-    sortOrder = '-published_on',
-    searchTerm = '',
-    page = 1,
-    limit = 20,
-    includedFields = [],
-} = {}) {
-    const fieldsString = getFieldsForContentType();
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const searchFilter = searchTerm ? `&& title match "${searchTerm}*"` : '';
-    const includedFieldsFilter = includedFields.length > 0
-        ? includedFields.join(' && ')
-        : "";
+export async function fetchByReference(
+  brand,
+  { sortOrder = '-published_on', searchTerm = '', page = 1, limit = 20, includedFields = [] } = {}
+) {
+  const fieldsString = getFieldsForContentType()
+  const start = (page - 1) * limit
+  const end = start + limit
+  const searchFilter = searchTerm ? `&& title match "${searchTerm}*"` : ''
+  const includedFieldsFilter = includedFields.length > 0 ? includedFields.join(' && ') : ''
 
-    const filter = `brand == '${brand}' ${searchFilter} && references(*[${includedFieldsFilter}]._id)`;
-    const filterWithRestrictions = await new FilterBuilder(filter).buildFilter();
-    const query = buildEntityAndTotalQuery(
-        filterWithRestrictions,
-        fieldsString,
-        {
-            sortOrder: getSortOrder(sortOrder, brand),
-            start: start,
-            end: end,
-        },
-    );
-    return fetchSanity(query, true);
+  const filter = `brand == '${brand}' ${searchFilter} && references(*[${includedFieldsFilter}]._id)`
+  const filterWithRestrictions = await new FilterBuilder(filter).buildFilter()
+  const query = buildEntityAndTotalQuery(filterWithRestrictions, fieldsString, {
+    sortOrder: getSortOrder(sortOrder, brand),
+    start: start,
+    end: end,
+  })
+  return fetchSanity(query, true)
 }
 
 /**
@@ -1429,29 +1473,37 @@ export async function fetchByReference(brand, {
  *   .then(lessons => console.log(lessons))
  *   .catch(error => console.error(error));
  */
-export async function fetchArtistLessons(brand, name, contentType, {
+export async function fetchArtistLessons(
+  brand,
+  name,
+  contentType,
+  {
     sort = '-published_on',
     searchTerm = '',
     page = 1,
     limit = 10,
     includedFields = [],
     progressIds = undefined,
-} = {}) {
+  } = {}
+) {
+  const fieldsString = DEFAULT_FIELDS.join(',')
+  const start = (page - 1) * limit
+  const end = start + limit
+  const searchFilter = searchTerm ? `&& title match "${searchTerm}*"` : ''
+  const sortOrder = getSortOrder(sort, brand)
+  const addType =
+    contentType && Array.isArray(contentType)
+      ? `_type in ['${contentType.join("', '")}'] &&`
+      : contentType
+        ? `_type == '${contentType}' && `
+        : ''
+  const includedFieldsFilter = includedFields.length > 0 ? filtersToGroq(includedFields) : ''
 
-    const fieldsString = DEFAULT_FIELDS.join(',');
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const searchFilter = searchTerm ? `&& title match "${searchTerm}*"` : ''
-    const sortOrder = getSortOrder(sort, brand);
-    const addType = contentType && Array.isArray(contentType) ? `_type in ['${contentType.join("', '")}'] &&` : contentType ? `_type == '${contentType}' && ` : ''
-    const includedFieldsFilter = includedFields.length > 0
-        ? filtersToGroq(includedFields)
-        : "";
-
-    // limits the results to supplied progressIds for started & completed filters
-    const progressFilter = progressIds !== undefined ? `&& railcontent_id in [${progressIds.join(',')}]` : "";
-    const now = getSanityDate(new Date());
-    const query = `{
+  // limits the results to supplied progressIds for started & completed filters
+  const progressFilter =
+    progressIds !== undefined ? `&& railcontent_id in [${progressIds.join(',')}]` : ''
+  const now = getSanityDate(new Date())
+  const query = `{
     "entity": 
       *[_type == 'artist' && name == '${name}']
         {'type': _type, name, 'thumbnail_url':thumbnail_url.asset->url, 
@@ -1459,8 +1511,8 @@ export async function fetchArtistLessons(brand, name, contentType, {
         'lessons': *[${addType} brand == '${brand}' && references(^._id) && (status in ['published'] || (status == 'scheduled' && defined(published_on) && published_on >= '${now}')) ${searchFilter} ${includedFieldsFilter} ${progressFilter}]{${fieldsString}}
       [${start}...${end}]}
       |order(${sortOrder})
-  }`;
-    return fetchSanity(query, true);
+  }`
+  return fetchSanity(query, true)
 }
 
 /**
@@ -1481,27 +1533,31 @@ export async function fetchArtistLessons(brand, name, contentType, {
  *   .then(lessons => console.log(lessons))
  *   .catch(error => console.error(error));
  */
-export async function fetchGenreLessons(brand, name, contentType, {
+export async function fetchGenreLessons(
+  brand,
+  name,
+  contentType,
+  {
     sort = '-published_on',
     searchTerm = '',
     page = 1,
     limit = 10,
     includedFields = [],
     progressIds = undefined,
-} = {}) {
-    const fieldsString = DEFAULT_FIELDS.join(',');
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const searchFilter = searchTerm ? `&& title match "${searchTerm}*"` : ''
-    const sortOrder = getSortOrder(sort, brand);
-    const addType = contentType ? `_type == '${contentType}' && ` : ''
-    const includedFieldsFilter = includedFields.length > 0
-        ? filtersToGroq(includedFields)
-        : "";
-    // limits the results to supplied progressIds for started & completed filters
-    const progressFilter = progressIds !== undefined ? `&& railcontent_id in [${progressIds.join(',')}]` : "";
-    const now = getSanityDate(new Date());
-    const query = `{
+  } = {}
+) {
+  const fieldsString = DEFAULT_FIELDS.join(',')
+  const start = (page - 1) * limit
+  const end = start + limit
+  const searchFilter = searchTerm ? `&& title match "${searchTerm}*"` : ''
+  const sortOrder = getSortOrder(sort, brand)
+  const addType = contentType ? `_type == '${contentType}' && ` : ''
+  const includedFieldsFilter = includedFields.length > 0 ? filtersToGroq(includedFields) : ''
+  // limits the results to supplied progressIds for started & completed filters
+  const progressFilter =
+    progressIds !== undefined ? `&& railcontent_id in [${progressIds.join(',')}]` : ''
+  const now = getSanityDate(new Date())
+  const query = `{
     "entity": 
       *[_type == 'genre' && name == '${name}']
         {'type': _type, name, 'thumbnail_url':thumbnail_url.asset->url, 
@@ -1509,14 +1565,14 @@ export async function fetchGenreLessons(brand, name, contentType, {
         'lessons': *[${addType} brand == '${brand}' && references(^._id) && (status in ['published'] || (status == 'scheduled' && defined(published_on) && published_on >= '${now}')) ${searchFilter} ${includedFieldsFilter} ${progressFilter}]{${fieldsString}}
       [${start}...${end}]}
       |order(${sortOrder})
-  }`;
-    return fetchSanity(query, true);
+  }`
+  return fetchSanity(query, true)
 }
 
 export async function fetchTopLevelParentId(railcontentId) {
-    const statusFilter = "&& status in ['scheduled', 'published', 'archived', 'unlisted']";
+  const statusFilter = "&& status in ['scheduled', 'published', 'archived', 'unlisted']"
 
-    const query = `*[railcontent_id == ${railcontentId}]{
+  const query = `*[railcontent_id == ${railcontentId}]{
       railcontent_id,
       'parents': *[^._id in child[]._ref ${statusFilter}]{
         railcontent_id,
@@ -1530,24 +1586,24 @@ export async function fetchTopLevelParentId(railcontentId) {
           }
         }
       }
-    }`;
-    let response = await fetchSanity(query, false, {processNeedAccess: false});
-    if (!response) return null;
-    let currentLevel = response;
-    for (let i = 0; i < 4; i++) {
-        if (currentLevel['parents'].length > 0) {
-            currentLevel = currentLevel['parents'][0];
-        } else {
-            return currentLevel['railcontent_id'];
-        }
+    }`
+  let response = await fetchSanity(query, false, { processNeedAccess: false })
+  if (!response) return null
+  let currentLevel = response
+  for (let i = 0; i < 4; i++) {
+    if (currentLevel['parents'].length > 0) {
+      currentLevel = currentLevel['parents'][0]
+    } else {
+      return currentLevel['railcontent_id']
     }
-    return null;
+  }
+  return null
 }
 
 export async function fetchHierarchy(railcontentId) {
-    let topLevelId = await fetchTopLevelParentId(railcontentId);
-    const childrenFilter = await new FilterBuilder(``, {isChildrenFilter: true} ).buildFilter();
-    const query = `*[railcontent_id == ${topLevelId}]{
+  let topLevelId = await fetchTopLevelParentId(railcontentId)
+  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
+  const query = `*[railcontent_id == ${topLevelId}]{
       railcontent_id,
       'assignments': assignment[]{railcontent_id},
       'children': child[${childrenFilter}]->{
@@ -1565,42 +1621,40 @@ export async function fetchHierarchy(railcontentId) {
           }
         }
       },
-    }`;
-    let response = await fetchSanity(query, false, {processNeedAccess: false});
-    if (!response) return null;
-    let data = {
-        topLevelId: topLevelId,
-        parents: {},
-        children: {}
-    };
-    populateHierarchyLookups(response, data, null);
-    return data;
+    }`
+  let response = await fetchSanity(query, false, { processNeedAccess: false })
+  if (!response) return null
+  let data = {
+    topLevelId: topLevelId,
+    parents: {},
+    children: {},
+  }
+  populateHierarchyLookups(response, data, null)
+  return data
 }
 
-
 function populateHierarchyLookups(currentLevel, data, parentId) {
-    let contentId = currentLevel['railcontent_id'];
-    let children = currentLevel['children'];
+  let contentId = currentLevel['railcontent_id']
+  let children = currentLevel['children']
 
-    data.parents[contentId] = parentId;
-    if (children) {
-        data.children[contentId] = children.map(child => child['railcontent_id']);
-        for (let i = 0; i < children.length; i++) {
-            populateHierarchyLookups(children[i], data, contentId);
-        }
-    } else {
-        data.children[contentId] = [];
+  data.parents[contentId] = parentId
+  if (children) {
+    data.children[contentId] = children.map((child) => child['railcontent_id'])
+    for (let i = 0; i < children.length; i++) {
+      populateHierarchyLookups(children[i], data, contentId)
     }
+  } else {
+    data.children[contentId] = []
+  }
 
-    let assignments = currentLevel['assignments'];
-    if (assignments) {
-        let assignmentIds = assignments.map(assignment => assignment['railcontent_id']);
-        data.children[contentId] = (data.children[contentId] ?? []).concat(assignmentIds);
-        assignmentIds.forEach(assignmentId => {
-            data.parents[assignmentId] = contentId;
-        });
-    }
-
+  let assignments = currentLevel['assignments']
+  if (assignments) {
+    let assignmentIds = assignments.map((assignment) => assignment['railcontent_id'])
+    data.children[contentId] = (data.children[contentId] ?? []).concat(assignmentIds)
+    assignmentIds.forEach((assignmentId) => {
+      data.parents[assignmentId] = contentId
+    })
+  }
 }
 
 /**
@@ -1610,26 +1664,27 @@ function populateHierarchyLookups(currentLevel, data, parentId) {
  * @returns {Promise<Object|null>} - A promise that resolves to an object containing the data
  */
 export async function fetchCommentModContentData(ids) {
-    const idsString = ids.join(',');
-    const fields = `"id": railcontent_id, "type": _type, title, "url": web_url_path, "parent": *[^._id in child[]._ref]{"id": railcontent_id, title}`;
-    const query = await buildQuery(`railcontent_id in [${idsString}]`,
-        {bypassPermissions: true},
-        fields,
-        {end: 50});
-    let data = await fetchSanity(query, true);
-    let mapped = {};
-    data.forEach(function (content) {
-        mapped[content.id] = {
-            "id": content.id,
-            "type": content.type,
-            "title": content.title,
-            "url": content.url,
-            "parentTitle": content.parent[0]?.title ?? null
-        };
-    });
-    return mapped;
+  const idsString = ids.join(',')
+  const fields = `"id": railcontent_id, "type": _type, title, "url": web_url_path, "parent": *[^._id in child[]._ref]{"id": railcontent_id, title}`
+  const query = await buildQuery(
+    `railcontent_id in [${idsString}]`,
+    { bypassPermissions: true },
+    fields,
+    { end: 50 }
+  )
+  let data = await fetchSanity(query, true)
+  let mapped = {}
+  data.forEach(function (content) {
+    mapped[content.id] = {
+      id: content.id,
+      type: content.type,
+      title: content.title,
+      url: content.url,
+      parentTitle: content.parent[0]?.title ?? null,
+    }
+  })
+  return mapped
 }
-
 
 /**
  *
@@ -1646,110 +1701,110 @@ export async function fetchCommentModContentData(ids) {
  *   .catch(error => console.error(error));
  */
 
-export async function fetchSanity(query,
-                                  isList,
-                                  {
-                                      customPostProcess = null,
-                                      processNeedAccess = true,
-                                  } = {}
+export async function fetchSanity(
+  query,
+  isList,
+  { customPostProcess = null, processNeedAccess = true } = {}
 ) {
-    // Check the config object before proceeding
-    if (!checkSanityConfig(globalConfig)) {
-        return null;
+  // Check the config object before proceeding
+  if (!checkSanityConfig(globalConfig)) {
+    return null
+  }
+
+  if (globalConfig.sanityConfig.debug) {
+    console.log('fetchSanity Query:', query)
+  }
+  const perspective = globalConfig.sanityConfig.perspective ?? 'published'
+  const api = globalConfig.sanityConfig.useCachedAPI ? 'apicdn' : 'api'
+  const url = `https://${globalConfig.sanityConfig.projectId}.${api}.sanity.io/v${globalConfig.sanityConfig.version}/data/query/${globalConfig.sanityConfig.dataset}?perspective=${perspective}`
+  const headers = {
+    Authorization: `Bearer ${globalConfig.sanityConfig.token}`,
+    'Content-Type': 'application/json',
+  }
+
+  try {
+    const method = 'post'
+    const options = {
+      method,
+      headers,
+      body: JSON.stringify({ query: query }),
     }
 
-    if (globalConfig.sanityConfig.debug) {
-        console.log("fetchSanity Query:", query);
+    let promisesResult = await Promise.all([
+      fetch(url, options),
+      processNeedAccess ? fetchUserPermissions() : null,
+    ])
+    const response = promisesResult[0]
+    const userPermissions = promisesResult[1]?.permissions
+    const isAdmin = promisesResult[1]?.isAdmin
+
+    if (!response.ok) {
+      throw new Error(`Sanity API error: ${response.status} - ${response.statusText}`)
     }
-    const perspective = globalConfig.sanityConfig.perspective ?? 'published';
-    const api = globalConfig.sanityConfig.useCachedAPI ? 'apicdn' : 'api';
-    const url = `https://${globalConfig.sanityConfig.projectId}.${api}.sanity.io/v${globalConfig.sanityConfig.version}/data/query/${globalConfig.sanityConfig.dataset}?perspective=${perspective}`;
-    const headers = {
-        'Authorization': `Bearer ${globalConfig.sanityConfig.token}`,
-        'Content-Type': 'application/json'
-    };
-
-    try {
-        const method = 'post';
-        const options = {
-            method,
-            headers,
-            body: JSON.stringify({'query': query})
-        };
-
-        let promisesResult = await Promise.all([
-            fetch(url, options),
-            processNeedAccess ? fetchUserPermissions() : null
-        ]);
-        const response = promisesResult[0];
-        const userPermissions = promisesResult[1]?.permissions;
-        const isAdmin = promisesResult[1]?.isAdmin;
-
-        if (!response.ok) {
-            throw new Error(`Sanity API error: ${response.status} - ${response.statusText}`);
-        }
-        const result = await response.json();
-        if (result.result) {
-            if (globalConfig.sanityConfig.debug) {
-                console.log("fetchSanity Results:", result);
-            }
-            let results = isList ? result.result : result.result[0];
-            results = processNeedAccess ? await needsAccessDecorator(results, userPermissions, isAdmin) : results;
-            return customPostProcess ? customPostProcess(results) : results;
-        } else {
-            throw new Error('No results found');
-        }
-    } catch (error) {
-        console.error('fetchSanity: Fetch error:', error);
-        return null;
+    const result = await response.json()
+    if (result.result) {
+      if (globalConfig.sanityConfig.debug) {
+        console.log('fetchSanity Results:', result)
+      }
+      let results = isList ? result.result : result.result[0]
+      results = processNeedAccess
+        ? await needsAccessDecorator(results, userPermissions, isAdmin)
+        : results
+      return customPostProcess ? customPostProcess(results) : results
+    } else {
+      throw new Error('No results found')
     }
+  } catch (error) {
+    console.error('fetchSanity: Fetch error:', error)
+    return null
+  }
 }
 
 function needsAccessDecorator(results, userPermissions, isAdmin) {
-    if (globalConfig.sanityConfig.useDummyRailContentMethods) return results;
+  if (globalConfig.sanityConfig.useDummyRailContentMethods) return results
 
-    userPermissions = new Set(userPermissions);
+  userPermissions = new Set(userPermissions)
 
-    if (Array.isArray(results)) {
-        results.forEach((result) => {
-            result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin);
-        });
-    } else if (results.entity && Array.isArray(results.entity)) {
-        // Group By
-        results.entity.forEach((result) => {
-            if (result.lessons) {
-                result.lessons.forEach((lesson) => {
-                    lesson['need_access'] = doesUserNeedAccessToContent(lesson, userPermissions, isAdmin); // Updated to check lesson access
-                });
-            } else {
-                result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin);
-            }
-        });
-    } else if (results.related_lessons && Array.isArray(results.related_lessons)) {
-        results.related_lessons.forEach((result) => {
-            result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin);
+  if (Array.isArray(results)) {
+    results.forEach((result) => {
+      result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin)
+    })
+  } else if (results.entity && Array.isArray(results.entity)) {
+    // Group By
+    results.entity.forEach((result) => {
+      if (result.lessons) {
+        result.lessons.forEach((lesson) => {
+          lesson['need_access'] = doesUserNeedAccessToContent(lesson, userPermissions, isAdmin) // Updated to check lesson access
         })
-    } else {
-        results['need_access'] = doesUserNeedAccessToContent(results, userPermissions, isAdmin);
-    }
+      } else {
+        result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin)
+      }
+    })
+  } else if (results.related_lessons && Array.isArray(results.related_lessons)) {
+    results.related_lessons.forEach((result) => {
+      result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin)
+    })
+  } else {
+    results['need_access'] = doesUserNeedAccessToContent(results, userPermissions, isAdmin)
+  }
 
-    return results;
+  return results
 }
 
 function doesUserNeedAccessToContent(result, userPermissions, isAdmin) {
-    if (isAdmin ?? false) {
-        return false;
+  if (isAdmin ?? false) {
+    return false
+  }
+  const permissions = new Set(result?.permission_id ?? [])
+  if (permissions.size === 0) {
+    return false
+  }
+  for (let permission of permissions) {
+    if (userPermissions.has(permission)) {
+      return false
     }
-    const permissions = new Set(result?.permission_id ?? []);
-    if (permissions.size === 0) {
-        return false;
-    }
-    for (let permission of permissions) {
-        if (userPermissions.has(permission)) {
-            return false;
-        }
-    }
-    return true;
+  }
+  return true
 }
 
 /**
@@ -1765,15 +1820,15 @@ function doesUserNeedAccessToContent(result, userPermissions, isAdmin) {
  *   .catch(error => console.error(error));
  */
 export async function fetchShowsData(brand) {
-    let shows = showsTypes[brand] ?? [];
-    const showsInfo = [];
+  let shows = showsTypes[brand] ?? []
+  const showsInfo = []
 
-    shows.forEach(type => {
-        const processedData = processMetadata(brand, type);
-        if (processedData) showsInfo.push(processedData)
-    });
+  shows.forEach((type) => {
+    const processedData = processMetadata(brand, type)
+    if (processedData) showsInfo.push(processedData)
+  })
 
-    return showsInfo;
+  return showsInfo
 }
 
 /**
@@ -1790,220 +1845,205 @@ export async function fetchShowsData(brand) {
  *   .catch(error => console.error(error));
  */
 export async function fetchMetadata(brand, type) {
-    const processedData = processMetadata(brand, type, true);
-    return processedData ? processedData : {};
+  const processedData = processMetadata(brand, type, true)
+  return processedData ? processedData : {}
 }
 
 export async function fetchChatAndLiveEnvent(brand, forcedId = null) {
-    const liveEvent = (forcedId !== null) ? await fetchByRailContentIds([forcedId]): [await fetchLiveEvent(brand)];
-    if (liveEvent.length === 0 || (liveEvent.length === 1 && liveEvent[0] === undefined)) {
-        return null;
-    }
-    let url = `/content/live-chat?brand=${brand}`;
-    const chatData = await fetchHandler(url);
-    const mergedData = { ...chatData, ...liveEvent[0] };
-    return mergedData;
+  const liveEvent =
+    forcedId !== null ? await fetchByRailContentIds([forcedId]) : [await fetchLiveEvent(brand)]
+  if (liveEvent.length === 0 || (liveEvent.length === 1 && liveEvent[0] === undefined)) {
+    return null
+  }
+  let url = `/content/live-chat?brand=${brand}`
+  const chatData = await fetchHandler(url)
+  const mergedData = { ...chatData, ...liveEvent[0] }
+  return mergedData
 }
-
 
 //Helper Functions
 function arrayJoinWithQuotes(array, delimiter = ',') {
-    const wrapped = array.map(value => `'${value}'`);
-    return wrapped.join(delimiter)
+  const wrapped = array.map((value) => `'${value}'`)
+  return wrapped.join(delimiter)
 }
 
 function getSanityDate(date, roundToHourForCaching = true) {
-    if (roundToHourForCaching) {
-        // We need to set the published on filter date to be a round time so that it doesn't bypass the query cache
-        // with every request by changing the filter date every second. I've set it to one minute past the current hour
-        // because publishing usually publishes content on the hour exactly which means it should still skip the cache
-        // when the new content is available.
-        // Round to the start of the current hour
-        const roundedDate = new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours());
+  if (roundToHourForCaching) {
+    // We need to set the published on filter date to be a round time so that it doesn't bypass the query cache
+    // with every request by changing the filter date every second. I've set it to one minute past the current hour
+    // because publishing usually publishes content on the hour exactly which means it should still skip the cache
+    // when the new content is available.
+    // Round to the start of the current hour
+    const roundedDate = new Date(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours()
+    )
 
-        return roundedDate.toISOString();
-    }
+    return roundedDate.toISOString()
+  }
 
-    return date.toISOString();
+  return date.toISOString()
 }
 
 const merge = (a, b, predicate = (a, b) => a === b) => {
-    const c = [...a]; // copy to avoid side effects
-    // add all items from B to copy C if they're not already present
-    b.forEach((bItem) => (c.some((cItem) => predicate(bItem, cItem)) ? null : c.push(bItem)))
-    return c;
+  const c = [...a] // copy to avoid side effects
+  // add all items from B to copy C if they're not already present
+  b.forEach((bItem) => (c.some((cItem) => predicate(bItem, cItem)) ? null : c.push(bItem)))
+  return c
 }
 
 function checkSanityConfig(config) {
-    if (!config.sanityConfig.token) {
-        console.warn('fetchSanity: The "token" property is missing in the config object.');
-        return false;
-    }
-    if (!config.sanityConfig.projectId) {
-        console.warn('fetchSanity: The "projectId" property is missing in the config object.');
-        return false;
-    }
-    if (!config.sanityConfig.dataset) {
-        console.warn('fetchSanity: The "dataset" property is missing in the config object.');
-        return false;
-    }
-    if (!config.sanityConfig.version) {
-        console.warn('fetchSanity: The "version" property is missing in the config object.');
-        return false;
-    }
-    return true;
+  if (!config.sanityConfig.token) {
+    console.warn('fetchSanity: The "token" property is missing in the config object.')
+    return false
+  }
+  if (!config.sanityConfig.projectId) {
+    console.warn('fetchSanity: The "projectId" property is missing in the config object.')
+    return false
+  }
+  if (!config.sanityConfig.dataset) {
+    console.warn('fetchSanity: The "dataset" property is missing in the config object.')
+    return false
+  }
+  if (!config.sanityConfig.version) {
+    console.warn('fetchSanity: The "version" property is missing in the config object.')
+    return false
+  }
+  return true
 }
-
 
 function buildRawQuery(
-    filter = '',
-    fields = '...',
-    {
-        sortOrder = 'published_on desc',
-        start = 0,
-        end = 10,
-        isSingle = false,
-    }
+  filter = '',
+  fields = '...',
+  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false }
 ) {
-    const sortString = sortOrder ? `order(${sortOrder})` : '';
-    const countString = isSingle ? '[0...1]' : `[${start}...${end}]`;
-    const query = `*[${filter}]{
+  const sortString = sortOrder ? `order(${sortOrder})` : ''
+  const countString = isSingle ? '[0...1]' : `[${start}...${end}]`
+  const query = `*[${filter}]{
         ${fields}
     } | ${sortString}${countString}`
-    return query;
+  return query
 }
 
-
 async function buildQuery(
-    baseFilter = '',
-    filterParams = {pullFutureContent: false},
-    fields = '...',
-    {
-        sortOrder = 'published_on desc',
-        start = 0,
-        end = 10,
-        isSingle = false,
-    },
+  baseFilter = '',
+  filterParams = { pullFutureContent: false },
+  fields = '...',
+  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false }
 ) {
-    const filter = await new FilterBuilder(baseFilter, filterParams).buildFilter();
-    return buildRawQuery(filter, fields, {sortOrder, start, end, isSingle});
+  const filter = await new FilterBuilder(baseFilter, filterParams).buildFilter()
+  return buildRawQuery(filter, fields, { sortOrder, start, end, isSingle })
 }
 
 function buildEntityAndTotalQuery(
-    filter = '',
-    fields = '...',
-    {
-        sortOrder = 'published_on desc',
-        start = 0,
-        end = 10,
-        isSingle = false,
-    },
+  filter = '',
+  fields = '...',
+  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false }
 ) {
-    const sortString = sortOrder ? `order(${sortOrder})` : '';
-    const countString = isSingle ? '[0...1]' : `[${start}...${end}]`;
-    const query = `{
+  const sortString = sortOrder ? `order(${sortOrder})` : ''
+  const countString = isSingle ? '[0...1]' : `[${start}...${end}]`
+  const query = `{
       "entity": *[${filter}] | ${sortString}${countString} 
       {
         ${fields}
       },
       "total": 0
-    }`;
-    return query;
+    }`
+  return query
 }
 
-
 function getFilterOptions(option, commonFilter, contentType, brand) {
-    let filterGroq = '';
-    const types = Array.from(new Set([...coachLessonsTypes, ...showsTypes[brand]]));
+  let filterGroq = ''
+  const types = Array.from(new Set([...coachLessonsTypes, ...showsTypes[brand]]))
 
-    switch (option) {
-        case "difficulty":
-            filterGroq = ` 
+  switch (option) {
+    case 'difficulty':
+      filterGroq = ` 
                 "difficulty": [
         {"type": "All", "count": count(*[${commonFilter} && difficulty_string == "All"])},
-        {"type": "Introductory", "count": count(*[${commonFilter} && difficulty_string == "Introductory"])},
+        {"type": "Introductory", "count": count(*[${commonFilter} && (difficulty_string == "Novice" || difficulty_string == "Introductory")])},
         {"type": "Beginner", "count": count(*[${commonFilter} && difficulty_string == "Beginner"])},
         {"type": "Intermediate", "count": count(*[${commonFilter} && difficulty_string == "Intermediate" ])},
         {"type": "Advanced", "count": count(*[${commonFilter} && difficulty_string == "Advanced" ])},
         {"type": "Expert", "count": count(*[${commonFilter} && difficulty_string == "Expert" ])}
-        ][count > 0],`;
-            break;
-        case "type":
-            const typesString = types.map(t => {
-                return `{"type": "${t}"}`
-            }).join(', ');
-            filterGroq = `"type": [${typesString}]{type, 'count': count(*[_type == ^.type && ${commonFilter}])}[count > 0],`;
-            break;
-        case "genre":
-        case "essential":
-        case "focus":
-        case "theory":
-        case "topic":
-        case "lifestyle":
-        case "creativity":
-            filterGroq = `
+        ][count > 0],`
+      break
+    case 'type':
+      const typesString = types
+        .map((t) => {
+          return `{"type": "${t}"}`
+        })
+        .join(', ')
+      filterGroq = `"type": [${typesString}]{type, 'count': count(*[_type == ^.type && ${commonFilter}])}[count > 0],`
+      break
+    case 'genre':
+    case 'essential':
+    case 'focus':
+    case 'theory':
+    case 'topic':
+    case 'lifestyle':
+    case 'creativity':
+      filterGroq = `
             "${option}": *[_type == '${option}' ${contentType ? ` && '${contentType}' in filter_types` : ''} ] {
             "type": name,
                 "count": count(*[${commonFilter} && references(^._id)])
-        }[count > 0],`;
-            break;
-        case "instrumentless":
-            filterGroq = `
+        }[count > 0],`
+      break
+    case 'instrumentless':
+      filterGroq = `
             "${option}":  [
                   {"type": "Full Song Only", "count": count(*[${commonFilter} && instrumentless == false ])},
                   {"type": "Instrument Removed", "count": count(*[${commonFilter} && instrumentless == true ])}
-              ][count > 0],`;
-            break;
-        case "gear":
-            filterGroq = `
+              ][count > 0],`
+      break
+    case 'gear':
+      filterGroq = `
             "${option}":  [
                   {"type": "Practice Pad", "count": count(*[${commonFilter} && gear match 'Practice Pad' ])},
                   {"type": "Drum-Set", "count": count(*[${commonFilter} && gear match 'Drum-Set'])}
-              ][count > 0],`;
-            break;
-        case "bpm":
-            filterGroq = `
+              ][count > 0],`
+      break
+    case 'bpm':
+      filterGroq = `
             "${option}":  [
                   {"type": "50-90", "count": count(*[${commonFilter} && bpm > 50 && bpm < 91])},
                   {"type": "91-120", "count": count(*[${commonFilter} && bpm > 90 && bpm < 121])},
                   {"type": "121-150", "count": count(*[${commonFilter} && bpm > 120 && bpm < 151])},
                   {"type": "151-180", "count": count(*[${commonFilter} && bpm > 150 && bpm < 181])},
                   {"type": "180+", "count": count(*[${commonFilter} && bpm > 180])},
-              ][count > 0],`;
-            break;
-        default:
-            filterGroq = "";
-            break;
-    }
+              ][count > 0],`
+      break
+    default:
+      filterGroq = ''
+      break
+  }
 
-    return filterGroq;
+  return filterGroq
 }
 
 function cleanUpGroq(query) {
-    // Split the query into clauses based on the logical operators
-    const clauses = query.split(/(\s*&&|\s*\|\|)/).map(clause => clause.trim());
+  // Split the query into clauses based on the logical operators
+  const clauses = query.split(/(\s*&&|\s*\|\|)/).map((clause) => clause.trim())
 
-    // Filter out empty clauses
-    const filteredClauses = clauses.filter(clause => clause.length > 0);
+  // Filter out empty clauses
+  const filteredClauses = clauses.filter((clause) => clause.length > 0)
 
-    // Check if there are valid conditions in the clauses
-    const hasConditions = filteredClauses.some(clause => !clause.match(/^\s*&&\s*|\s*\|\|\s*$/));
+  // Check if there are valid conditions in the clauses
+  const hasConditions = filteredClauses.some((clause) => !clause.match(/^\s*&&\s*|\s*\|\|\s*$/))
 
-    if (!hasConditions) {
-        // If no valid conditions, return an empty string or the original query
-        return '';
-    }
+  if (!hasConditions) {
+    // If no valid conditions, return an empty string or the original query
+    return ''
+  }
 
-    // Remove occurrences of '&& ()'
-    const cleanedQuery = filteredClauses.join(' ')
-        .replace(/&&\s*\(\)/g, '')
-        .replace(/(\s*&&|\s*\|\|)(?=\s*[\s()]*$|(?=\s*&&|\s*\|\|))/g, '')
-        .trim();
+  // Remove occurrences of '&& ()'
+  const cleanedQuery = filteredClauses
+    .join(' ')
+    .replace(/&&\s*\(\)/g, '')
+    .replace(/(\s*&&|\s*\|\|)(?=\s*[\s()]*$|(?=\s*&&|\s*\|\|))/g, '')
+    .trim()
 
-    return cleanedQuery;
+  return cleanedQuery
 }
-
-
-
-
-

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -67,6 +67,69 @@ export async function fetchSongById(documentId) {
 }
 
 /**
+ * fetches from Sanity all content marked for removal next quarter
+ *
+ * @string brand
+ * @returns {Promise<Object|null>}
+ */
+export async function fetchQuarterRemoved(brand) {
+    const now = getSanityDate(new Date());
+    const nextQuarter = getNextAndPreviousQuarterDates()['next'];
+    const filterString = `status == 'published' && published_on <= '${now}' && brand == '${brand}' && quarter_removed == '${nextQuarter}'`
+    const query = await buildQuery(filterString, {pullFutureContent: true}, undefined, {SortOrder: "published_on desc, id desc", end: 20});
+    return fetchSanity(query, false);
+}
+
+/**
+ * fetches from Sanity all content marked for publish next quarter
+ *
+ * @string brand
+ * @returns {Promise<Object|null>}
+ */
+export async function fetchQuarterPublished(brand) {
+    const nextQuarter = getNextAndPreviousQuarterDates()['next'];
+    const filterString = `status == 'draft' && brand == '${brand}' && quarter_published == '${nextQuarter}'`;
+    const query = await buildQuery(filterString, {pullFutureContent: false}, undefined, {SortOrder: "published_on desc, id desc", end: 20})
+
+    return fetchSanity(query, false);
+}
+
+/**
+ * returns array of next and previous quarter dates as strings
+ *
+ * @returns {*[]}
+ */
+export function getNextAndPreviousQuarterDates() {
+    const january = 1;
+    const april = 4;
+    const july = 7;
+    const october = 10;
+    const month = new Date().getMonth();
+    let year = new Date().getFullYear();
+    let nextQuarter = '';
+    let prevQuarter = '';
+    if (month < april) {
+        nextQuarter = `${year}-0${april}-01`;
+        prevQuarter = `${year}-0${january}-01`;
+    } else if (month < july) {
+        nextQuarter = `${year}-0${july}-01`;
+        prevQuarter = `${year}-0${april}-01`;
+    } else if (month < october) {
+        nextQuarter = `${year}-${october}-01`;
+        prevQuarter = `${year}-0${july}-01`;
+    } else {
+        prevQuarter = `${year}-${october}-01`;
+        year++;
+        nextQuarter = `${year}-0${january}-01`;
+    }
+
+    let result = [];
+    result['next'] = nextQuarter;
+    result['previous'] = prevQuarter;
+    return result;
+}
+
+/**
  * Fetch all artists with lessons available for a specific brand.
  *
  * @param {string} brand - The brand for which to fetch artists.

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -73,10 +73,9 @@ export async function fetchSongById(documentId) {
  * @returns {Promise<Object|null>}
  */
 export async function fetchQuarterRemoved(brand) {
-    const now = getSanityDate(new Date());
     const nextQuarter = getNextAndPreviousQuarterDates()['next'];
-    const filterString = `status == 'published' && published_on <= '${now}' && brand == '${brand}' && quarter_removed == '${nextQuarter}'`
-    const query = await buildQuery(filterString, {pullFutureContent: true}, undefined, {SortOrder: "published_on desc, id desc", end: 20});
+    const filterString = `brand == '${brand}' && quarter_removed == '${nextQuarter}'`
+    const query = await buildQuery(filterString, {pullFutureContent: false, bypassPermissions: true, availableContentStatuses: ["published"]}, getFieldsForContentType(), {SortOrder: "published_on desc, id desc", end: 20});
     return fetchSanity(query, false);
 }
 
@@ -88,8 +87,8 @@ export async function fetchQuarterRemoved(brand) {
  */
 export async function fetchQuarterPublished(brand) {
     const nextQuarter = getNextAndPreviousQuarterDates()['next'];
-    const filterString = `status == 'draft' && brand == '${brand}' && quarter_published == '${nextQuarter}'`;
-    const query = await buildQuery(filterString, {pullFutureContent: false}, undefined, {SortOrder: "published_on desc, id desc", end: 20})
+    const filterString = `brand == '${brand}' && quarter_published == '${nextQuarter}'`;
+    const query = await buildQuery(filterString, {pullFutureContent: true, bypassPermissions: true, checkNullPublished: true}, getFieldsForContentType(), {SortOrder: "published_on desc, id desc", end: 20});
 
     return fetchSanity(query, false);
 }

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -14,6 +14,8 @@ import {fetchOwnedChallenges} from "../src";
 const {
     fetchSongById,
     fetchArtists,
+    fetchQuarterPublished,
+    fetchQuarterRemoved,
     fetchSongArtistCount,
     fetchRelatedSongs,
     fetchNewReleases,
@@ -61,13 +63,22 @@ describe('Sanity Queries', function () {
 
     });
 
-
     test('fetchArtists', async () => {
         const response = await fetchArtists('drumeo');
         const artistNames = response.map((x) => x.name);
         expect(artistNames).toContain("Audioslave");
 
     }, 10000);
+
+    test('fetchQuarterPublished', async () => {
+        const brand = 'guitareo';
+        const response = await fetchQuarterPublished(brand);
+    });
+
+    test('fetchQuarterRemoved', async () => {
+        const brand = 'guitareo';
+        const response = await fetchQuarterRemoved(brand);
+    });
 
     test('fetchSongArtistCount', async () => {
         const response = await fetchSongArtistCount('drumeo');

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -1,15 +1,15 @@
-import {getFieldsForContentType} from "../src/contentTypeConfig";
+import { getFieldsForContentType } from '../src/contentTypeConfig'
 const railContentModule = require('../src/services/railcontent.js')
 
 import {
-    fetchCommentModContentData,
-    fetchMethodPreviousNextLesson,
-    fetchSanity
-} from "../src/services/sanity";
-import {log} from './log.js';
-import {initializeTestService} from "./initializeTests";
-import {dataContext} from "../src/services/contentProgress";
-import {fetchOwnedChallenges} from "../src";
+  fetchCommentModContentData,
+  fetchMethodPreviousNextLesson,
+  fetchSanity,
+} from '../src/services/sanity'
+import { log } from './log.js'
+import { initializeTestService } from './initializeTests'
+import { dataContext } from '../src/services/contentProgress'
+import { fetchOwnedChallenges } from '../src'
 
 const {
     fetchSongById,
@@ -40,8 +40,8 @@ const {
     fetchMetadata,
     fetchNextPreviousLesson,
     fetchHierarchy,
-    fetchTopLevelParentId
-} = require('../src/services/sanity.js');
+    fetchTopLevelParentId,
+} = require('../src/services/sanity.js')
 
 const {
     FilterBuilder,
@@ -56,35 +56,33 @@ describe('Sanity Queries', function () {
         initializeTestService();
     });
 
-    test('fetchSongById', async () => {
-        const id = 380094;
-        const response = await fetchSongById(id);
-        expect(response.id).toBe(id);
+  test('fetchSongById', async () => {
+    const id = 380094
+    const response = await fetchSongById(id)
+    expect(response.id).toBe(id)
+  })
 
-    });
-
-    test('fetchArtists', async () => {
-        const response = await fetchArtists('drumeo');
-        const artistNames = response.map((x) => x.name);
-        expect(artistNames).toContain("Audioslave");
-
-    }, 10000);
+  test('fetchArtists', async () => {
+    const response = await fetchArtists('drumeo')
+    const artistNames = response.map((x) => x.name)
+    expect(artistNames).toContain('Audioslave')
+  }, 10000)
 
     test('fetchQuarterPublished', async () => {
-        const brand = 'guitareo';
-        const response = await fetchQuarterPublished(brand);
+        const brand = 'guitareo'
+        const response = await fetchQuarterPublished(brand)
     });
 
     test('fetchQuarterRemoved', async () => {
-        const brand = 'guitareo';
-        const response = await fetchQuarterRemoved(brand);
+        const brand = 'guitareo'
+        const response = await fetchQuarterRemoved(brand)
     });
 
     test('fetchSongArtistCount', async () => {
-        const response = await fetchSongArtistCount('drumeo');
-        log(response);
-        expect(response).toBeGreaterThan(1000);
-    }, 10000);
+        const response = await fetchSongArtistCount('drumeo')
+        log(response)
+        expect(response).toBeGreaterThan(1000)
+    }, 10000)
 
     test('fetchSanity-WithPostProcess', async () => {
         const id = 380094;


### PR DESCRIPTION
[TP-558](https://musora.atlassian.net/browse/TP-558)

Features:
* added functions for querying sanity to get content with quarter_removed / quarter_published

Testing:
* go to `sanityQueryService.test.js`
* insert these functions:
for quarter_removed: `    test('fetchQuarterRemoved', async () => {
        const brand = 'guitareo';
        const response = await fetchQuarterRemoved(brand);
    });`
for quarter_published: `    test('fetchQuarterPublished', async () => {
        const brand = 'guitareo';
        const response = await fetchQuarterPublished(brand);
    });`
* add `fetchQuarterRemoved` and `fetchQuarterPublished` to the const list at the beginning of the doc
* go to Sanity content, and change the `quarter_removed` attribute of a guitareo song to `2025-04-01` (the next quarter date). publish.
* grab a new piece of guitareo content (not a song) and change the `quarter_removed` attribute to `2025-04-01` (the next quarter date). publish.
* go to Sanity content, and change the `quarter_published` attribute of a guitareo song to `2025-04-01` (the next quarter date). publish.
* grab a new piece of guitareo content (not a song) and change the `quarter_published` attribute to `2025-04-01` (the next quarter date). publish.
* run the test functions we just put in.
* see the content you just published

[TP-558]: https://musora.atlassian.net/browse/TP-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ