### PR TITLE
TP-558: Adding Query Functions for Quarter Removed/Quarter Published Content

### DIFF
--- a/src/filterBuilder.js
+++ b/src/filterBuilder.js
@@ -21,6 +21,7 @@ export class FilterBuilder {
       isSingle = false,
       allowsPullSongsContent = true,
       isChildrenFilter = false,
+      checkNullPublished = false,
     } = {}
   ) {
     this.availableContentStatuses = availableContentStatuses
@@ -36,6 +37,7 @@ export class FilterBuilder {
     // this.debug = process.env.DEBUG === 'true' || false;
     this.debug = false
     this.prefix = isChildrenFilter ? '@->' : ''
+    this.checkNullPublished = checkNullPublished
   }
 
   static withOnlyFilterAvailableStatuses(filter, availableContentStatuses, bypassPermissions) {
@@ -132,7 +134,10 @@ export class FilterBuilder {
 
     now = roundedDate.toISOString()
 
-    if (this.getFutureContentOnly) {
+    if (this.checkNullPublished) {
+      this._andWhere(`(published_on >='${now}'`)
+      this._orWhere(`published_on == null)`)
+    } else if (this.getFutureContentOnly) {
       this._andWhere(`${this.prefix}published_on >= '${now}'`)
     } else if (!this.pullFutureContent) {
       this._andWhere(`${this.prefix}published_on <= '${now}'`)

--- a/src/filterBuilder.js
+++ b/src/filterBuilder.js
@@ -21,7 +21,6 @@ export class FilterBuilder {
       isSingle = false,
       allowsPullSongsContent = true,
       isChildrenFilter = false,
-      checkNullPublished = false,
     } = {}
   ) {
     this.availableContentStatuses = availableContentStatuses
@@ -37,7 +36,6 @@ export class FilterBuilder {
     // this.debug = process.env.DEBUG === 'true' || false;
     this.debug = false
     this.prefix = isChildrenFilter ? '@->' : ''
-    this.checkNullPublished = checkNullPublished
   }
 
   static withOnlyFilterAvailableStatuses(filter, availableContentStatuses, bypassPermissions) {
@@ -134,10 +132,7 @@ export class FilterBuilder {
 
     now = roundedDate.toISOString()
 
-    if (this.checkNullPublished) {
-      this._andWhere(`(published_on >='${now}'`)
-      this._orWhere(`published_on == null)`)
-    } else if (this.getFutureContentOnly) {
+    if (this.getFutureContentOnly) {
       this._andWhere(`${this.prefix}published_on >= '${now}'`)
     } else if (!this.pullFutureContent) {
       this._andWhere(`${this.prefix}published_on <= '${now}'`)

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -65,6 +65,33 @@ export async function fetchSongById(documentId) {
 }
 
 /**
+* fetches from Sanity all content marked for removal next quarter
+*
+* @string brand
+* @returns {Promise<Object|null>}
+*/
+export async function fetchQuarterRemoved(brand) {
+  const nextQuarter = getNextAndPreviousQuarterDates()['next'];
+  const filterString = `brand == '${brand}' && quarter_removed == '${nextQuarter}'`
+  const query = await buildQuery(filterString, {pullFutureContent: false, bypassPermissions: true, availableContentStatuses: ["published"]}, getFieldsForContentType(), {SortOrder: "published_on desc, id desc", end: 20});
+  return fetchSanity(query, false);
+}
+
+/**
+ * fetches from Sanity all content marked for publish next quarter
+ *
+ * @string brand
+ * @returns {Promise<Object|null>}
+ */
+export async function fetchQuarterPublished(brand) {
+  const nextQuarter = getNextAndPreviousQuarterDates()['next'];
+  const filterString = `brand == '${brand}' && quarter_published == '${nextQuarter}'`;
+  const query = await buildQuery(filterString, {pullFutureContent: true, bypassPermissions: true, checkNullPublished: true}, getFieldsForContentType(), {SortOrder: "published_on desc, id desc", end: 20});
+
+  return fetchSanity(query, false);
+}
+
+/**
  * Fetch all artists with lessons available for a specific brand.
  *
  * @param {string} brand - The brand for which to fetch artists.

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -73,7 +73,7 @@ export async function fetchSongById(documentId) {
 export async function fetchQuarterRemoved(brand) {
   const nextQuarter = getNextAndPreviousQuarterDates()['next'];
   const filterString = `brand == '${brand}' && quarter_removed == '${nextQuarter}'`
-  const query = await buildQuery(filterString, {pullFutureContent: false, bypassPermissions: true, availableContentStatuses: ["published"]}, getFieldsForContentType(), {SortOrder: "published_on desc, id desc", end: 20});
+  const query = await buildQuery(filterString, {pullFutureContent: false, availableContentStatuses: ["published"]}, getFieldsForContentType(), {SortOrder: "published_on desc, id desc", end: 20});
   return fetchSanity(query, false);
 }
 
@@ -86,7 +86,7 @@ export async function fetchQuarterRemoved(brand) {
 export async function fetchQuarterPublished(brand) {
   const nextQuarter = getNextAndPreviousQuarterDates()['next'];
   const filterString = `brand == '${brand}' && quarter_published == '${nextQuarter}'`;
-  const query = await buildQuery(filterString, {pullFutureContent: true, bypassPermissions: true, checkNullPublished: true}, getFieldsForContentType(), {SortOrder: "published_on desc, id desc", end: 20});
+  const query = await buildQuery(filterString, {pullFutureContent: true, availableContentStatuses: ["draft"]}, getFieldsForContentType(), {SortOrder: "published_on desc, id desc", end: 20});
 
   return fetchSanity(query, false);
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -92,6 +92,41 @@ export async function fetchQuarterPublished(brand) {
 }
 
 /**
+ * returns array of next and previous quarter dates as strings
+ *
+ * @returns {*[]}
+ */
+export function getNextAndPreviousQuarterDates() {
+  const january = 1;
+  const april = 4;
+  const july = 7;
+  const october = 10;
+  const month = new Date().getMonth();
+  let year = new Date().getFullYear();
+  let nextQuarter = '';
+  let prevQuarter = '';
+  if (month < april) {
+    nextQuarter = `${year}-0${april}-01`;
+    prevQuarter = `${year}-0${january}-01`;
+  } else if (month < july) {
+    nextQuarter = `${year}-0${july}-01`;
+    prevQuarter = `${year}-0${april}-01`;
+  } else if (month < october) {
+    nextQuarter = `${year}-${october}-01`;
+    prevQuarter = `${year}-0${july}-01`;
+  } else {
+    prevQuarter = `${year}-${october}-01`;
+    year++;
+    nextQuarter = `${year}-0${january}-01`;
+  }
+
+  let result = [];
+  result['next'] = nextQuarter;
+  result['previous'] = prevQuarter;
+  return result;
+}
+
+/**
  * Fetch all artists with lessons available for a specific brand.
  *
  * @param {string} brand - The brand for which to fetch artists.

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -14,6 +14,8 @@ import { fetchOwnedChallenges } from '../src'
 const {
   fetchSongById,
   fetchArtists,
+  fetchQuarterPublished,
+  fetchQuarterRemoved,
   fetchSongArtistCount,
   fetchRelatedSongs,
   fetchNewReleases,
@@ -55,6 +57,17 @@ describe('Sanity Queries', function () {
     const response = await fetchSongById(id)
     expect(response.id).toBe(id)
   })
+
+  test('fetchQuarterPublished', async () => {
+    const brand = 'guitareo'
+    const response = await fetchQuarterPublished(brand)
+  });
+
+  test('fetchQuarterRemoved', async () => {
+    const brand = 'guitareo'
+    const response = await fetchQuarterRemoved(brand)
+  });
+
 
   test('fetchArtists', async () => {
     const response = await fetchArtists('drumeo')


### PR DESCRIPTION
previous

[TP-558](https://musora.atlassian.net/browse/TP-558)

Features:
- added functions for querying sanity to get content with quarter_removed / quarter_published

Testing

- go to sanityQueryService.test.js
- insert these functions:
- for quarter_removed:     test('fetchQuarterRemoved', async () => { const brand = 'guitareo'; const response = await fetchQuarterRemoved(brand); });
- for quarter_published:     test('fetchQuarterPublished', async () => { const brand = 'guitareo'; const response = await fetchQuarterPublished(brand); });
- add fetchQuarterRemoved and fetchQuarterPublished to the const list at the beginning of the doc
- go to Sanity content, and change the quarter_removed attribute of a guitareo song to 2025-04-01 (the next quarter date). publish.
- grab a new piece of guitareo content (not a song) and change the quarter_removed attribute to 2025-04-01 (the next quarter date). publish.
- go to Sanity content, and change the quarter_published attribute of a guitareo song to 2025-04-01 (the next quarter date). publish.
- grab a new piece of guitareo content (not a song) and change the quarter_published attribute to 2025-04-01 (the next quarter date). publish.
- run the test functions we just put in.
- see the content you just published

[TP-558]: https://musora.atlassian.net/browse/TP-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ