### PR TITLE
Add external method for busting local cached data

### DIFF
--- a/src/services/dataContext.js
+++ b/src/services/dataContext.js
@@ -17,6 +17,23 @@ export class DataContext {
   context = null
   dataPromise = null
 
+  /**
+   * Verify current cached data is on the correct version
+   *
+   * @param {int} dataVersionKey - Data version key from the back end
+   * @param {int} currentVersion - Current version of the data on the back end
+   * */
+  static async verifyLocalData(dataVersionKey, currentVersion) {
+    const tempContext = new DataContext(dataVersionKey, null)
+    await tempContext.ensureLocalContextLoaded()
+
+    if (currentVersion !== tempContext.version()) {
+      tempContext.clearCache()
+    } else {
+      tempContext.setLastUpdatedTime()
+    }
+  }
+
   constructor(dataVersionKey, fetchDataFunction) {
     this.dataVersionKey = dataVersionKey
     this.fetchDataFunction = fetchDataFunction
@@ -33,7 +50,7 @@ export class DataContext {
 
   async getDataPromise() {
     await this.ensureLocalContextLoaded()
-    const shouldVerify = await this.shouldVerifyServerVerions()
+    const shouldVerify = await this.shouldVerifyServerVersions()
 
     if (!this.context || shouldVerify) {
       let version = this.version()
@@ -42,7 +59,7 @@ export class DataContext {
         this.context = data
         cache.setItem(this.localStorageKey, JSON.stringify(data))
       }
-      cache.setItem(this.localStorageLastUpdatedKey, new Date().getTime()?.toString())
+      this.setLastUpdatedTime()
     }
     this.dataPromise = null
     return this.context.data
@@ -73,11 +90,11 @@ export class DataContext {
     }
   }
 
-  async shouldVerifyServerVerions() {
+  async shouldVerifyServerVersions() {
     let lastUpdated = globalConfig.isMA
       ? await cache.getItem(this.localStorageLastUpdatedKey)
       : cache.getItem(this.localStorageLastUpdatedKey)
-    if (!lastUpdated) return false
+    if (!lastUpdated) return true
     const verifyServerTime = 10000 //10 s
     return new Date().getTime() - lastUpdated > verifyServerTime
   }
@@ -92,6 +109,10 @@ export class DataContext {
     this.context = null
   }
 
+  setLastUpdatedTime() {
+    cache.setItem(this.localStorageLastUpdatedKey, new Date().getTime().toString())
+  }
+
   async update(localUpdateFunction, serverUpdateFunction) {
     await this.ensureLocalContextLoaded()
     if (this.context) {
@@ -99,7 +120,7 @@ export class DataContext {
       if (this.context) this.context.version++
       let data = JSON.stringify(this.context)
       cache.setItem(this.localStorageKey, data)
-      cache.setItem(this.localStorageLastUpdatedKey, new Date().getTime().toString())
+      this.setLastUpdatedTime()
     }
     const updatePromise = serverUpdateFunction()
     updatePromise.then((response) => {

--- a/test/dataContext.test.js
+++ b/test/dataContext.test.js
@@ -1,0 +1,38 @@
+import { initializeTestService } from './initializeTests'
+import { DataContext } from '../src/services/dataContext.js'
+
+describe('dataContext', function () {
+  let mock = null
+  let testVersion = 1
+  const dataVersionKey = 1
+  const dataContext = new DataContext(dataVersionKey, null)
+
+  beforeEach(() => {
+    initializeTestService()
+    mock = jest.spyOn(dataContext, 'fetchData')
+    mock.mockImplementation(() =>
+      JSON.parse(`{"version":${testVersion},"data":[308516,308515,308514,308518]}`)
+    )
+  })
+
+  test('verifyLocalData', async () => {
+    //force load data into context and verify version 1 loaded
+    await dataContext.getData()
+    expect(dataContext.version()).toBe(1)
+
+    //increment source version and verify data context still uses old version
+    testVersion++
+    await dataContext.getData()
+    expect(dataContext.version()).toBe(1)
+
+    //verifyLocalData with old source version and verify context still uses old version
+    await DataContext.verifyLocalData(1, 1)
+    await dataContext.getData()
+    expect(dataContext.version()).toBe(1)
+
+    //verifyLocalData with new source version and verify context loads new version
+    await DataContext.verifyLocalData(1, 2)
+    await dataContext.getData()
+    expect(dataContext.version()).toBe(2)
+  })
+})


### PR DESCRIPTION
I need a method to bust the local data context caches or set last updated times from external sources.
This will be used to reduce the number of requests needed in certain situations.