### PR TITLE
MU2 241 content rows

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -27,6 +27,7 @@ export const DEFAULT_FIELDS = [
   "'permission_id': permission[]->railcontent_id",
   'xp',
   'child_count',
+  '"lesson_count": coalesce(count(child[]->.child[]->), child_count)',
 ]
 
 export const descriptionField = 'description[0].children[0].text'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ import {
 } from './services/config.js';
 
 import {
+	getContentRows,
 	getLessonContentRows,
 	getRecent,
 	getTabResults
@@ -225,6 +226,7 @@ declare module 'musora-content-services' {
 		getAllCompleted,
 		getAllStarted,
 		getAllStartedOrCompleted,
+		getContentRows,
 		getLessonContentRows,
 		getProgressPercentage,
 		getProgressPercentageByIds,

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {
 } from './services/config.js';
 
 import {
+	getContentRows,
 	getLessonContentRows,
 	getRecent,
 	getTabResults
@@ -224,6 +225,7 @@ export {
 	getAllCompleted,
 	getAllStarted,
 	getAllStartedOrCompleted,
+	getContentRows,
 	getLessonContentRows,
 	getProgressPercentage,
 	getProgressPercentageByIds,

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -12,7 +12,7 @@ export async function getLessonContentRows (brand='drumeo', pageName = 'lessons'
   let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent' });
   recentContentIds = recentContentIds.map(item => item.id);
 
-  const url = `/v1/content/contentRows?brand=${brand}&pageName=${pageName}`;
+  const url = `/api/v1/content/contentRows?brand=${brand}&pageName=${pageName}`;
   const rowss =  await fetchHandler(url, 'get', null);
   console.log('rox :::: ',rowss);
 

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -5,15 +5,15 @@
 import {fetchAll, fetchByRailContentIds, fetchMetadata, fetchRecent, fetchTabData} from './sanity.js'
 import {TabResponseType, Tabs, capitalizeFirstLetter} from '../contentMetaData.js'
 import {getAllStartedOrCompleted} from "./contentProgress";
-import {fetchAbsolute} from "./railcontent";
+import {fetchHandler} from "./railcontent";
 
 export async function getLessonContentRows (brand='drumeo', pageName = 'lessons') {
   //TODO: this should come from backend
   let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent' });
   recentContentIds = recentContentIds.map(item => item.id);
 
-  const url = `/v1/content/contentRows?brand=${brand}&pageName=${pageName}`;
-  const rowss =  await fetchAbsolute(url);
+  const url = `/v1/content/contentRows`;
+  const rowss =  await fetchHandler(url, 'get', null, { brand: brand, pageName: pageName });
   console.log('rox :::: ',rowss);
 
   let contentIds = [389313, 389314, 389315, 389316, 389317, 389318, 389319, 389320, 389321, 389322];

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -12,8 +12,8 @@ export async function getLessonContentRows (brand='drumeo', pageName = 'lessons'
   let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent' });
   recentContentIds = recentContentIds.map(item => item.id);
 
-  const url = `/v1/content/contentRows`;
-  const rowss =  await fetchHandler(url, 'get', null, { brand: brand, pageName: pageName });
+  const url = `/v1/content/contentRows?brand=${brand}&pageName=${pageName}`;
+  const rowss =  await fetchHandler(url, 'get', null);
   console.log('rox :::: ',rowss);
 
   let contentIds = [389313, 389314, 389315, 389316, 389317, 389318, 389319, 389320, 389321, 389322];

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -5,11 +5,16 @@
 import {fetchAll, fetchByRailContentIds, fetchMetadata, fetchRecent, fetchTabData} from './sanity.js'
 import {TabResponseType, Tabs, capitalizeFirstLetter} from '../contentMetaData.js'
 import {getAllStartedOrCompleted} from "./contentProgress";
+import {fetchAbsolute} from "./railcontent";
 
 export async function getLessonContentRows (brand='drumeo', pageName = 'lessons') {
   //TODO: this should come from backend
   let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent' });
   recentContentIds = recentContentIds.map(item => item.id);
+
+  const url = `/v1/content/contentRows?brand=${brand}&pageName=${pageName}`;
+  const rowss =  await fetchAbsolute(url);
+  console.log('rox :::: ',rowss);
 
   let contentIds = [389313, 389314, 389315, 389316, 389317, 389318, 389319, 389320, 389321, 389322];
   if(pageName == 'songs'){
@@ -69,7 +74,7 @@ export async function getLessonContentRows (brand='drumeo', pageName = 'lessons'
   ]
 
   const results = await Promise.all(
-    rows.map(async (row) => {
+    rowss.map(async (row) => {
       if (row.content.length == 0){
         return { id: row.id, title: row.title, items: [] }
       }

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -166,6 +166,6 @@ export async function getContentRows(brand, pageName, contentRowId , {
   limit = 10,
 } = {}) {
   const contentRow = contentRowId ? `&content_row_id=${contentRowId}` : ''
-  const url = `/api/content/v1/contentRows?brand=${brand}&page_name=${pageName}${contentRow}&page=${page}&limit=${limit}`;
+  const url = `/api/content/v1/rows?brand=${brand}&page_name=${pageName}${contentRow}&page=${page}&limit=${limit}`;
   return  await fetchHandler(url, 'get', null);
 }

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -8,79 +8,25 @@ import {getAllStartedOrCompleted} from "./contentProgress";
 import {fetchHandler} from "./railcontent";
 
 export async function getLessonContentRows (brand='drumeo', pageName = 'lessons') {
-  //TODO: this should come from backend
   let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent' });
   recentContentIds = recentContentIds.map(item => item.id);
 
-  const url = `/api/v1/content/contentRows?brand=${brand}&pageName=${pageName}`;
-  const rowss =  await fetchHandler(url, 'get', null);
-  console.log('rox :::: ',rowss);
-
-  let contentIds = [389313, 389314, 389315, 389316, 389317, 389318, 389319, 389320, 389321, 389322];
-  if(pageName == 'songs'){
-    contentIds = [415581, 415603, 416206, 416373, 416133, 415723];
-  }
-  const rows = [
-    {
-      id: 'recent',
-      title: 'Recent ' + capitalizeFirstLetter(pageName),
-      content: recentContentIds || []
-    },
-    {
-      id: 'recommended',
-      title: 'Recommended For You',
-      content: contentIds
-    },
-    {
-      id: 'method-progress',
-      title: 'Inspired By Your Method Progress',
-      content: contentIds
-    },
-    {
-      id: 'creativity',
-      title: 'Unlock Your Creativity',
-      content: contentIds
-    },
-    {
-      id: 'essential-skills',
-      title: 'Essential Skills',
-      content: contentIds
-    },
-    {
-      id: 'technique',
-      title: 'Improve Your Technique',
-      content: contentIds
-    },
-    {
-      id: 'five-levels',
-      title: '5 Levels of...',
-      content: contentIds
-    },
-    {
-      id: 'arpeggios',
-      title: 'Get Started With Arpeggios',
-      content: contentIds
-    },
-    {
-      id: 'hears-first-time',
-      title: 'Hears For The First Time',
-      content: contentIds
-    },
-    {
-      id: 'ten-minute',
-      title: '10-Minute Workouts',
-      content: contentIds
-    }
-  ]
+  let contentRows = await getContentRows(brand, pageName);
+  contentRows = Array.isArray(contentRows) ? contentRows : [];
+  contentRows.unshift({
+    id: 'recent',
+    title: 'Recent ' + capitalizeFirstLetter(pageName),
+    content: recentContentIds || []
+  });
 
   const results = await Promise.all(
-    rowss.map(async (row) => {
-      if (row.content.length == 0){
-        return { id: row.id, title: row.title, items: [] }
-      }
-      const data = await fetchByRailContentIds(row.content)
-      return { id: row.id, title: row.title, items: data }
-    })
+      contentRows.map(async (row) => {
+        if (row.content.length == 0){
+          return { id: row.id, title: row.title, items: [] }
+        }
+        const data = await fetchByRailContentIds(row.content)
+        return { id: row.id, title: row.title, items: data }
+      })
   )
   return results
 }
@@ -160,6 +106,27 @@ export async function getTabResults(brand, pageName, tabName, {
   };
 }
 
+/**
+ * Fetches recent content for a given brand and page with pagination.
+ *
+ * @param {string} brand - The brand for which to fetch data.
+ * @param {string} pageName - The page name (e.g., 'all', 'incomplete', 'completed').
+ * @param {string} [tabName='all'] - The tab name (defaults to 'all' for recent content).
+ * @param {Object} params - Parameters for pagination and sorting.
+ * @param {number} [params.page=1] - The page number for pagination.
+ * @param {number} [params.limit=10] - The number of items per page.
+ * @param {string} [params.sort="-published_on"] - The field to sort the data by.
+ * @returns {Promise<Object>} - The fetched content data.
+ *
+ * @example
+ * getRecent('drumeo', 'lessons', 'all', {
+ *   page: 2,
+ *   limit: 15,
+ *   sort: '-popularity'
+ * })
+ *   .then(content => console.log(content))
+ *   .catch(error => console.error(error));
+ */
 export async function getRecent(brand, pageName, tabName = 'all', {
   page = 1,
   limit = 10,
@@ -173,4 +140,32 @@ export async function getRecent(brand, pageName, tabName = 'all', {
     data: recentContentIds,
     meta:  { tabs: metaData.tabs }
   };
+}
+
+/**
+ * Fetches content rows for a given brand and page with optional filtering by content row id.
+ *
+ * @param {string} brand - The brand for which to fetch content rows.
+ * @param {string} pageName - The page name (e.g., 'lessons', 'songs', 'challenges').
+ * @param {string} [contentRowId] - The specific content row ID to fetch.
+ * @param {Object} params - Parameters for pagination.
+ * @param {number} [params.page=1] - The page number for pagination.
+ * @param {number} [params.limit=10] - The maximum number of content items per row.
+ * @returns {Promise<Object>} - The fetched content rows.
+ *
+ * @example
+ * getContentRows('drumeo', 'lessons', 'Your-Daily-Warmup', {
+ *   page: 1,
+ *   limit: 5
+ * })
+ *   .then(content => console.log(content))
+ *   .catch(error => console.error(error));
+ */
+export async function getContentRows(brand, pageName, contentRowId , {
+  page = 1,
+  limit = 10,
+} = {}) {
+  const contentRow = contentRowId ? `&content_row_id=${contentRowId}` : ''
+  const url = `/api/content/v1/contentRows?brand=${brand}&page_name=${pageName}${contentRow}&page=${page}&limit=${limit}`;
+  return  await fetchHandler(url, 'get', null);
 }

--- a/test/contentProgress.test.js
+++ b/test/contentProgress.test.js
@@ -20,6 +20,7 @@ import {getRecent, getTabResults} from "../src/services/content";
 import {individualLessonsTypes, playAlongLessonTypes, transcriptionsLessonTypes, tutorialsLessonTypes} from "../src/contentTypeConfig";
 
 const railContentModule = require('../src/services/railcontent.js')
+const contentModule = require('../src/services/content.js')
 
 describe('contentProgressDataContext', function () {
   let mock = null
@@ -44,6 +45,26 @@ describe('contentProgressDataContext', function () {
 
     let mock4 = jest.spyOn(railContentModule, 'postContentReset')
     mock4.mockImplementation(() => JSON.parse(`{"version": ${serverVersion}}`))
+
+    let mock5 = jest.spyOn(contentModule, 'getContentRows')
+    let testData = [
+      {
+        id: 'recent',
+        title: 'Recent Lessons',
+        content: ['lesson1', 'lesson2', 'lesson3'],
+      },
+      {
+        id: 'popular',
+        title: 'Popular Lessons',
+        content: ['lesson4', 'lesson5', 'lesson6'],
+      },
+      {
+        id: 'new-arrivals',
+        title: 'New Arrivals',
+        content: ['lesson7', 'lesson8', 'lesson9'],
+      }
+    ];
+    mock5.mockImplementation(() => Promise.resolve(testData));
   })
 
   test('getProgressPercentage', async () => {

--- a/test/initializeTests.js
+++ b/test/initializeTests.js
@@ -30,6 +30,7 @@ export async function initializeTestService(useLive = false) {
       authToken: token,
     },
     localStorage: new LocalStorageMock(),
+    isMA: true
   }
   initializeService(config)
 


### PR DESCRIPTION
[MU2-241](https://musora.atlassian.net/browse/MU2-241?atlOrigin=eyJpIjoiN2IwNWUyYWQ3NWUwNGNlNmI3YjE5ZTAyOTJjMTgxYzAiLCJwIjoiaiJ9)
- new method that call BE endpoint to obtain content rows per brand and page name. Optional can filter by a content row id, for See All buttons
- FOR YOU tab - call the new method


[MU2-241]: https://musora.atlassian.net/browse/MU2-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ