### PR TITLE
BEh-312: Add reccommended endpoints

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,6 +50,8 @@ import {
 	fetchChallengeLessonData,
 	fetchChallengeMetadata,
 	fetchChallengeUserActiveChallenges,
+	fetchCommentRelies,
+	fetchComments,
 	fetchCompletedChallenges,
 	fetchCompletedContent,
 	fetchCompletedState,
@@ -64,6 +66,7 @@ import {
 	fetchPlaylistItem,
 	fetchPlaylistItems,
 	fetchSongsInProgress,
+	fetchTopComment,
 	fetchUserAward,
 	fetchUserBadges,
 	fetchUserChallengeProgress,
@@ -93,6 +96,10 @@ import {
 	updatePlaylist,
 	updatePlaylistItem
 } from './services/railcontent.js';
+
+import {
+	rankItems
+} from './services/recommendations.js';
 
 import {
 	fetchAll,
@@ -174,6 +181,8 @@ declare module 'musora-content-services' {
 		fetchCoachLessons,
 		fetchComingSoon,
 		fetchCommentModContentData,
+		fetchCommentRelies,
+		fetchComments,
 		fetchCompletedChallenges,
 		fetchCompletedContent,
 		fetchCompletedState,
@@ -213,6 +222,7 @@ declare module 'musora-content-services' {
 		fetchSongArtistCount,
 		fetchSongById,
 		fetchSongsInProgress,
+		fetchTopComment,
 		fetchTopLevelParentId,
 		fetchUpcomingEvents,
 		fetchUserAward,
@@ -253,6 +263,7 @@ declare module 'musora-content-services' {
 		postContentReset,
 		postContentUnliked,
 		postRecordWatchSession,
+		rankItems,
 		recordWatchSession,
 		reportPlaylist,
 		reset,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -98,7 +98,9 @@ import {
 } from './services/railcontent.js';
 
 import {
-	rankItems
+	rankCategories,
+	rankItems,
+	similarItems
 } from './services/recommendations.js';
 
 import {
@@ -263,12 +265,14 @@ declare module 'musora-content-services' {
 		postContentReset,
 		postContentUnliked,
 		postRecordWatchSession,
+		rankCategories,
 		rankItems,
 		recordWatchSession,
 		reportPlaylist,
 		reset,
 		setLastUpdatedTime,
 		setStudentViewForUser,
+		similarItems,
 		unlikeContent,
 		unpinPlaylist,
 		updatePlaylist,

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,8 @@ import {
 	fetchChallengeLessonData,
 	fetchChallengeMetadata,
 	fetchChallengeUserActiveChallenges,
+	fetchCommentRelies,
+	fetchComments,
 	fetchCompletedChallenges,
 	fetchCompletedContent,
 	fetchCompletedState,
@@ -64,6 +66,7 @@ import {
 	fetchPlaylistItem,
 	fetchPlaylistItems,
 	fetchSongsInProgress,
+	fetchTopComment,
 	fetchUserAward,
 	fetchUserBadges,
 	fetchUserChallengeProgress,
@@ -93,6 +96,10 @@ import {
 	updatePlaylist,
 	updatePlaylistItem
 } from './services/railcontent.js';
+
+import {
+	rankItems
+} from './services/recommendations.js';
 
 import {
 	fetchAll,
@@ -173,6 +180,8 @@ export {
 	fetchCoachLessons,
 	fetchComingSoon,
 	fetchCommentModContentData,
+	fetchCommentRelies,
+	fetchComments,
 	fetchCompletedChallenges,
 	fetchCompletedContent,
 	fetchCompletedState,
@@ -212,6 +221,7 @@ export {
 	fetchSongArtistCount,
 	fetchSongById,
 	fetchSongsInProgress,
+	fetchTopComment,
 	fetchTopLevelParentId,
 	fetchUpcomingEvents,
 	fetchUserAward,
@@ -252,6 +262,7 @@ export {
 	postContentReset,
 	postContentUnliked,
 	postRecordWatchSession,
+	rankItems,
 	recordWatchSession,
 	reportPlaylist,
 	reset,

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,9 @@ import {
 } from './services/railcontent.js';
 
 import {
-	rankItems
+	rankCategories,
+	rankItems,
+	similarItems
 } from './services/recommendations.js';
 
 import {
@@ -262,12 +264,14 @@ export {
 	postContentReset,
 	postContentUnliked,
 	postRecordWatchSession,
+	rankCategories,
 	rankItems,
 	recordWatchSession,
 	reportPlaylist,
 	reset,
 	setLastUpdatedTime,
 	setStudentViewForUser,
+	similarItems,
 	unlikeContent,
 	unpinPlaylist,
 	updatePlaylist,

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -5,7 +5,7 @@
 export let globalConfig = {
   sanityConfig: {},
   railcontentConfig: {},
-  huggingFaceConfig: {},
+  recommendationsConfig: {},
   localStorage: null,
   isMA: false,
   localTimezoneString: null, // In format: America/Vancouver

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -5,6 +5,7 @@
 export let globalConfig = {
   sanityConfig: {},
   railcontentConfig: {},
+  huggingFaceConfig: {},
   localStorage: null,
   isMA: false,
   localTimezoneString: null, // In format: America/Vancouver
@@ -35,6 +36,8 @@ const excludeFromGeneratedIndex = []
  * @param {string} config.railcontentConfig.userId - The user ID for fetching user-specific data.
  * @param {string} config.railcontentConfig.baseUrl - The url for the environment.
  * @param {string} config.railcontentConfig.authToken - The bearer authorization token.
+ * @param {string} config.recommendationsConfig.token - The token for authenticating recommendation requests.
+ * @param {string} config.recommendationsConfig.baseUrl - The url for the recommendation server.
  * @param {Object} config.localStorage - Cache to use for localStorage
  * @param {boolean} config.isMA - Variable that tells if the library is used by MA or FEW
  * @param {string} config.localTimezoneString - The local timezone string in format: America/Vancouver
@@ -49,15 +52,20 @@ const excludeFromGeneratedIndex = []
  *     dataset: 'your-dataset-name',
  *     version: '2021-06-07',
  *     debug: true,
- *     useCachedAPI: false
+ *     useCachedAPI: false,
  *   },
  *   railcontentConfig: {
  *     token: 'your-user-api-token',
  *     userId: 'current-user-id',
- *     baseUrl: 'https://web-staging-one.musora.com'
+ *     baseUrl: 'https://web-staging-one.musora.com',
+ *     authToken 'your-auth-token',
+ *   },
+ *   recommendationsConfig: {
+ *     token: 'your-user-api-token',
+ *     baseUrl: 'https://MusoraProductDepartment-PWGenerator.hf.space',
  *   },
  *   localStorage: localStorage,
- *   isMA: false
+ *   isMA: false,
  * });
  */
 export function initializeService(config) {
@@ -66,4 +74,5 @@ export function initializeService(config) {
   globalConfig.localStorage = config.localStorage
   globalConfig.isMA = config.isMA || false
   globalConfig.localTimezoneString = config.localTimezoneString || null
+  globalConfig.recommendationsConfig = config.recommendationsConfig
 }

--- a/src/services/recommendations.js
+++ b/src/services/recommendations.js
@@ -11,8 +11,78 @@ import { globalConfig } from './config.js'
  * @type {string[]}
  */
 const excludeFromGeneratedIndex = [
-  'fetchHandler'
+  'fetchHandler',
 ]
+
+/**
+ * Fetches similar content to the provided content id
+ *
+ * @param {brand} brand - brand of the content to filter
+ * @param {integer} content_id - The ID of the content to find similar items for
+ * @param {integer} count - number of items to return
+ * @returns {Promise<Object|null>} - Returns the content_ids sorted by rank (most significant first)
+ * @example
+ * rankItems('drumeo', 1113)
+ *   .then(status => console.log(status))
+ *   .catch(error => console.error(error));
+ */
+export async function similarItems(brand, content_id, count = 10) {
+  if (!content_id) {
+    return []
+  }
+
+  let data = {
+    'brand': brand,
+    'content_ids': content_id,
+    'num_similar': count,
+  }
+  const url = `/similar_items/`
+  try {
+    const response = await fetchHandler(url, 'POST', data)
+    return response['similar_items']
+  } catch (error) {
+    console.error('Fetch error:', error)
+    return null
+  }
+}
+
+/**
+ * Sorts the provided categories based on the user's match
+ *
+ * @param {brand} brand - brand of the content to filter
+ * @param {Object} categories - Keyed arrays of content ids
+ * @param {boolean} rankEachCategory - flag to sort each category by user's match
+ * @returns {Promise<Object|null>} - Returns the content_ids sorted by rank (most significant first)
+ * @example
+ * rankCategories('drumeo', {
+ *                            1: [111222, 23120, 402199],
+ *                            2: [2222, 33333, 44444]
+ *                          }
+*                )
+ *   .then(status => console.log(status))
+ *   .catch(error => console.error(error));
+ */
+export async function rankCategories(brand, categories, rankEachCategory = true) {
+  if (categories.length === 0) {
+    return []
+  }
+  let data = {
+    'brand': brand,
+    'user_id': globalConfig.railcontentConfig.userId,
+    'playlists': categories,
+    'rank_each_list': Boolean(rankEachCategory),
+  }
+  const url = `/rank_playlists/`
+  try {
+    const response = await fetchHandler(url, 'POST', data)
+    let rankedCategories = {}
+    response['ranked_playlists'].forEach((category) => rankedCategories[category['playlist_id']] = categories[category['playlist_id']])
+    return rankedCategories
+  } catch (error) {
+    console.error('Fetch error:', error)
+    return null
+  }
+}
 
 /**
  * Fetches the completion status of a specific lesson for the current user.
@@ -27,17 +97,16 @@ const excludeFromGeneratedIndex = [
  */
 export async function rankItems(brand, content_ids) {
   if (content_ids.length === 0) {
-    return [];
+    return []
   }
   let data = {
-    "brand": brand,
-    "user_id": globalConfig.railcontentConfig.userId,
-    "content_ids": content_ids
+    'brand': brand,
+    'user_id': globalConfig.railcontentConfig.userId,
+    'content_ids': content_ids,
   }
   const url = `/rank_items/`
   try {
     const response = await fetchHandler(url, 'POST', data)
-    console.log('result rankItems', response)
     return response['ranked_content_ids']
   } catch (error) {
     console.error('Fetch error:', error)
@@ -63,7 +132,6 @@ async function fetchHandler(url, method = 'get', body = null) {
   }
   try {
     const response = await fetchAbsolute(url, options)
-    console.log('r', response);
     if (response.ok) {
       return await response.json()
     } else {
@@ -76,13 +144,14 @@ async function fetchHandler(url, method = 'get', body = null) {
   return null
 }
 
+
 function fetchAbsolute(url, params) {
   if (globalConfig.recommendationsConfig.token) {
     params.headers['Authorization'] = `Bearer ${globalConfig.recommendationsConfig.token}`
   }
   if (globalConfig.recommendationsConfig.baseUrl) {
     if (url.startsWith('/')) {
-      return fetch(globalConfig.recommendationsConfig.token + url, params)
+      return fetch(globalConfig.recommendationsConfig.baseUrl + url, params)
     }
   }
   return fetch(url, params)

--- a/src/services/recommendations.js
+++ b/src/services/recommendations.js
@@ -1,0 +1,89 @@
+/**
+ * @module Railcontent-Services
+ */
+import { contentStatusCompleted } from './contentProgress.js'
+
+import { globalConfig } from './config.js'
+
+/**
+ * Exported functions that are excluded from index generation.
+ *
+ * @type {string[]}
+ */
+const excludeFromGeneratedIndex = [
+  'fetchHandler'
+]
+
+/**
+ * Fetches the completion status of a specific lesson for the current user.
+ *
+ * @param {brand} brand - brand of the content to filter
+ * @param {Array<string>} content_ids - The IDs of the content to rank
+ * @returns {Promise<Object|null>} - Returns the content_ids sorted by rank (most significant first)
+ * @example
+ * rankItems('drumeo', ([111222, 23120, 402199])
+ *   .then(status => console.log(status))
+ *   .catch(error => console.error(error));
+ */
+export async function rankItems(brand, content_ids) {
+  if (content_ids.length === 0) {
+    return [];
+  }
+  let data = {
+    "brand": brand,
+    "user_id": globalConfig.railcontentConfig.userId,
+    "content_ids": content_ids
+  }
+  const url = `/rank_items/`
+  try {
+    const response = await fetchHandler(url, 'POST', data)
+    console.log('result rankItems', response)
+    return response['ranked_content_ids']
+  } catch (error) {
+    console.error('Fetch error:', error)
+    return null
+  }
+}
+
+async function fetchHandler(url, method = 'get', body = null) {
+
+  let headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-CSRF-TOKEN': globalConfig.recommendationsConfig.token,
+  }
+
+  const options = {
+    method,
+    headers,
+  }
+
+  if (body) {
+    options.body = JSON.stringify(body)
+  }
+  try {
+    const response = await fetchAbsolute(url, options)
+    console.log('r', response);
+    if (response.ok) {
+      return await response.json()
+    } else {
+      console.error(`Fetch error: ${method} ${url} ${response.status} ${response.statusText}`)
+      console.log(response)
+    }
+  } catch (error) {
+    console.error('Fetch error:', error)
+  }
+  return null
+}
+
+function fetchAbsolute(url, params) {
+  if (globalConfig.recommendationsConfig.token) {
+    params.headers['Authorization'] = `Bearer ${globalConfig.recommendationsConfig.token}`
+  }
+  if (globalConfig.recommendationsConfig.baseUrl) {
+    if (url.startsWith('/')) {
+      return fetch(globalConfig.recommendationsConfig.token + url, params)
+    }
+  }
+  return fetch(url, params)
+}

--- a/src/services/recommendations.js
+++ b/src/services/recommendations.js
@@ -1,7 +1,6 @@
 /**
  * @module Railcontent-Services
  */
-import { contentStatusCompleted } from './contentProgress.js'
 
 import { globalConfig } from './config.js'
 
@@ -10,9 +9,7 @@ import { globalConfig } from './config.js'
  *
  * @type {string[]}
  */
-const excludeFromGeneratedIndex = [
-  'fetchHandler',
-]
+const excludeFromGeneratedIndex = []
 
 /**
  * Fetches similar content to the provided content id
@@ -58,7 +55,7 @@ export async function similarItems(brand, content_id, count = 10) {
  *                            1: [111222, 23120, 402199],
  *                            2: [2222, 33333, 44444]
  *                          }
-*                )
+ *                )
  *   .then(status => console.log(status))
  *   .catch(error => console.error(error));
  */


### PR DESCRIPTION
[JIRA](https://musora.atlassian.net/browse/BEH-312)

[MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/14)
[MWP PR](https://github.com/railroadmedia/musora-web-platform/pull/2051)

Notes:
- I used [this](https://docs.google.com/document/d/1Acyo38JIEcTAD3HX2K1uF9ckW-bpgtBn2-FmrgtuKEg/edit?tab=t.0) as the spec sheet
- Then tested in [Postman](https://red-shadow-611407.postman.co/workspace/Team-Workspace~38bb093f-0978-4a83-8423-944a3c78fd51/folder/31092567-ebf37dbe-30b7-4f37-96d0-e2daf1c71f7e?ctx=documentation)
- then implemented a new service file in MCS
- Then tested things :dagger: 
I haven't done anything other than the most basic error handling because I don't know what kind of garbage in/garbage out we're gunna be dealing with. Hopefully everyone plays nice. 
- `rankEachCategory` is not yet implemented, but Gabriel is going to handle it and I've specified the parameter name. It runs fine with the extra parameter


Testing:
- I did all my testing in console, because MWP frontend wont build for me and I'm too lazy and grumpy to figure it out today.
- I posted the recommendations.js methods (removing the `export` keyword) directly into console. Then also pasted a globalConfig mock
```
const globalConfig = {
  railcontentConfig: {
    userId: 347747
  },
  recommendationsConfig: {
    token: <get this from me>
    baseUrl: 'https://MusoraProductDepartment-PWGenerator.hf.space'
  }
}
```
I then ran: 
```
await rankItems('drumeo', [410430, 388642, 388199, 411095])
await rankCategories('drumeo', {3: [111222, 23120, 402199], 2: [2222, 33333, 44444]})
await similarItems("drumeo", 410430)
```
to verify they returned what I expected; either a list of content, or an object of lists for `rankCategories`.
