### PR TITLE
BEH-313: Add related lesson endpoints

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -3,6 +3,12 @@ import {Tabs} from "./contentMetaData.js";
 
 export const AWSUrl = 'https://s3.us-east-1.amazonaws.com/musora-web-platform'
 export const CloudFrontURl = 'https://d3fzm1tzeyr5n3.cloudfront.net'
+
+export const SONG_TYPES = ['song', 'play-along', 'jam-track', 'song-tutorial-children']
+// Challenges are excluded for the moment as they're still in design flex
+// Single hierarchy refers to only one element in the hierarchy has video lessons, not that they have a single parent
+export const SINGLE_PARENT_TYPES = ['course-part', 'pack-bundle-lesson', 'song-tutorial-children']
+
 export const DEFAULT_FIELDS = [
   "'sanity_id' : _id",
   "'id': railcontent_id",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -120,10 +120,10 @@ import {
 } from './services/railcontent.js';
 
 import {
+	fetchSimilarItems,
 	rankCategories,
 	rankItems,
-	recommendations,
-	similarItems
+	recommendations
 } from './services/recommendations.js';
 
 import {
@@ -144,6 +144,7 @@ import {
 	fetchHierarchy,
 	fetchLeaving,
 	fetchLessonContent,
+	fetchLessonsFeaturingThisContent,
 	fetchLiveEvent,
 	fetchMetadata,
 	fetchMethod,
@@ -152,12 +153,14 @@ import {
 	fetchMethodPreviousNextLesson,
 	fetchNewReleases,
 	fetchNextPreviousLesson,
+	fetchOtherSongVersions,
 	fetchPackAll,
 	fetchPackData,
 	fetchParentForDownload,
 	fetchPlayAlongsCount,
 	fetchRecent,
 	fetchRelatedLessons,
+	fetchRelatedRecommendedContent,
 	fetchRelatedSongs,
 	fetchReturning,
 	fetchSanity,
@@ -237,6 +240,7 @@ declare module 'musora-content-services' {
 		fetchHierarchy,
 		fetchLeaving,
 		fetchLessonContent,
+		fetchLessonsFeaturingThisContent,
 		fetchLiveEvent,
 		fetchMetadata,
 		fetchMethod,
@@ -246,6 +250,7 @@ declare module 'musora-content-services' {
 		fetchNewReleases,
 		fetchNextContentDataForParent,
 		fetchNextPreviousLesson,
+		fetchOtherSongVersions,
 		fetchOwnedChallenges,
 		fetchPackAll,
 		fetchPackData,
@@ -257,12 +262,14 @@ declare module 'musora-content-services' {
 		fetchPlaylistItems,
 		fetchRecent,
 		fetchRelatedLessons,
+		fetchRelatedRecommendedContent,
 		fetchRelatedSongs,
 		fetchReturning,
 		fetchSanity,
 		fetchScheduledAndNewReleases,
 		fetchScheduledReleases,
 		fetchShowsData,
+		fetchSimilarItems,
 		fetchSongArtistCount,
 		fetchSongById,
 		fetchSongsInProgress,
@@ -329,7 +336,6 @@ declare module 'musora-content-services' {
 		reportPlaylist,
 		reset,
 		setStudentViewForUser,
-		similarItems,
 		unassignModeratorToComment,
 		unlikeComment,
 		unlikeContent,

--- a/src/index.js
+++ b/src/index.js
@@ -120,10 +120,10 @@ import {
 } from './services/railcontent.js';
 
 import {
+	fetchSimilarItems,
 	rankCategories,
 	rankItems,
-	recommendations,
-	similarItems
+	recommendations
 } from './services/recommendations.js';
 
 import {
@@ -144,6 +144,7 @@ import {
 	fetchHierarchy,
 	fetchLeaving,
 	fetchLessonContent,
+	fetchLessonsFeaturingThisContent,
 	fetchLiveEvent,
 	fetchMetadata,
 	fetchMethod,
@@ -152,12 +153,14 @@ import {
 	fetchMethodPreviousNextLesson,
 	fetchNewReleases,
 	fetchNextPreviousLesson,
+	fetchOtherSongVersions,
 	fetchPackAll,
 	fetchPackData,
 	fetchParentForDownload,
 	fetchPlayAlongsCount,
 	fetchRecent,
 	fetchRelatedLessons,
+	fetchRelatedRecommendedContent,
 	fetchRelatedSongs,
 	fetchReturning,
 	fetchSanity,
@@ -236,6 +239,7 @@ export {
 	fetchHierarchy,
 	fetchLeaving,
 	fetchLessonContent,
+	fetchLessonsFeaturingThisContent,
 	fetchLiveEvent,
 	fetchMetadata,
 	fetchMethod,
@@ -245,6 +249,7 @@ export {
 	fetchNewReleases,
 	fetchNextContentDataForParent,
 	fetchNextPreviousLesson,
+	fetchOtherSongVersions,
 	fetchOwnedChallenges,
 	fetchPackAll,
 	fetchPackData,
@@ -256,12 +261,14 @@ export {
 	fetchPlaylistItems,
 	fetchRecent,
 	fetchRelatedLessons,
+	fetchRelatedRecommendedContent,
 	fetchRelatedSongs,
 	fetchReturning,
 	fetchSanity,
 	fetchScheduledAndNewReleases,
 	fetchScheduledReleases,
 	fetchShowsData,
+	fetchSimilarItems,
 	fetchSongArtistCount,
 	fetchSongById,
 	fetchSongsInProgress,
@@ -328,7 +335,6 @@ export {
 	reportPlaylist,
 	reset,
 	setStudentViewForUser,
-	similarItems,
 	unassignModeratorToComment,
 	unlikeComment,
 	unlikeContent,

--- a/src/services/recommendations.js
+++ b/src/services/recommendations.js
@@ -14,8 +14,8 @@ const excludeFromGeneratedIndex = []
 /**
  * Fetches similar content to the provided content id
  *
- * @param {brand} brand - brand of the content to filter
  * @param {integer} content_id - The ID of the content to find similar items for
+ * @param {brand} brand - brand of the content to filter
  * @param {integer} count - number of items to return
  * @returns {Promise<Object|null>} - Returns the content_ids sorted by rank (most significant first)
  * @example
@@ -23,7 +23,7 @@ const excludeFromGeneratedIndex = []
  *   .then(status => console.log(status))
  *   .catch(error => console.error(error));
  */
-export async function similarItems(brand, content_id, count = 10) {
+export async function fetchSimilarItems(content_id, brand, count = 10) {
   if (!content_id) {
     return []
   }

--- a/test/initializeTests.js
+++ b/test/initializeTests.js
@@ -5,7 +5,7 @@ const railContentModule = require('../src/services/railcontent.js')
 let token = null
 let userId = process.env.RAILCONTENT_USER_ID ?? null
 
-export async function initializeTestService(useLive = false) {
+export async function initializeTestService(useLive = false, isAdmin = false) {
   if (useLive && !token && process.env.RAILCONTENT_BASE_URL) {
     let data = await fetchLoginToken(
       process.env.RAILCONTENT_EMAIL,
@@ -39,7 +39,7 @@ export async function initializeTestService(useLive = false) {
   initializeService(config)
 
   let mock = jest.spyOn(railContentModule, 'fetchUserPermissionsData')
-  let testData = { permissions: [78, 91, 92], isAdmin: false }
+  let testData = { permissions: [78, 91, 92], isAdmin: isAdmin }
   mock.mockImplementation(() => testData)
 }
 

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -915,29 +915,6 @@ describe('api.v1', function() {
     log(liveEvent)
     //expect(metaData).toBeNull()
   })
-})
-
-describe('api.v1.admin', function() {
-  beforeEach(() => {
-    initializeTestService(false, true)
-  })
-
-  test('fetchOtherSongVersions', async () => {
-    // much of the licensed content is currently drafted, so this must be run in the admin test-suite
-    const railContentId = 386901
-    const licenseQuery = `*[railcontent_id == ${railContentId}]{
-      'content_ids': *[_type == 'license' && references(^._id)].content[]->railcontent_id
-    }[0]`
-    const otherReferencedContent = (await fetchSanity(licenseQuery, true))['content_ids']
-    log(otherReferencedContent)
-    const relatedSongsTypes = await fetchOtherSongVersions(railContentId, 'drumeo', 100)
-    log(relatedSongsTypes)
-    relatedSongsTypes.forEach(document => {
-      expect(SONG_TYPES).toContain(document.type)
-      expect(document.id).not.toStrictEqual(railContentId)
-      expect(otherReferencedContent).toContain(document.id)
-    })
-  })
 
   test('fetchLessonsFeaturingThisContent', async () => {
     // much of the licensed content is currently drafted, so this must be run in the admin test-suite
@@ -1023,6 +1000,29 @@ describe('api.v1.admin', function() {
       web_url_path.pop()
       web_url_path.pop()
       expect(web_url_path).toEqual(expectedPath)
+    })
+  })
+})
+
+describe('api.v1.admin', function() {
+  beforeEach(() => {
+    initializeTestService(false, true)
+  })
+
+  test('fetchOtherSongVersions', async () => {
+    // much of the licensed content is currently drafted, so this must be run in the admin test-suite
+    const railContentId = 386901
+    const licenseQuery = `*[railcontent_id == ${railContentId}]{
+      'content_ids': *[_type == 'license' && references(^._id)].content[]->railcontent_id
+    }[0]`
+    const otherReferencedContent = (await fetchSanity(licenseQuery, true))['content_ids']
+    log(otherReferencedContent)
+    const relatedSongsTypes = await fetchOtherSongVersions(railContentId, 'drumeo', 100)
+    log(relatedSongsTypes)
+    relatedSongsTypes.forEach(document => {
+      expect(SONG_TYPES).toContain(document.type)
+      expect(document.id).not.toStrictEqual(railContentId)
+      expect(otherReferencedContent).toContain(document.id)
     })
   })
 })

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -857,38 +857,7 @@ describe('api.v1', function() {
     //expect(metaData).toBeNull()
   })
 
-  test('fetchLessonsFeaturingThisContent', async () => {
-    // much of the licensed content is currently drafted, so this must be run in the admin test-suite
-    const railContentId = 386901
-    const licenseQuery = `*[railcontent_id == ${railContentId}]{
-      'content_ids': *[_type == 'license' && references(^._id)].content[]->railcontent_id
-    }[0]`
-    const otherReferencedContent = (await fetchSanity(licenseQuery, true))['content_ids']
-    const relatedNotSongs = await fetchLessonsFeaturingThisContent(railContentId, 'drumeo', 100)
-    log(relatedNotSongs)
-    relatedNotSongs.forEach(document => {
-      expect(SONG_TYPES).not.toContain(document.type)
-      expect(document.id).not.toStrictEqual(railContentId)
-      expect(otherReferencedContent).toContain(document.id)
-    })
-  })
 
-  test('fetchRelatedLessons-song-tutorial-children', async () => {
-    const railContentId = 222631
-    const relatedLessons = await fetchRelatedLessons(railContentId, 'pianote')
-    log(relatedLessons)
-    const expectedPath = ['', 'pianote', 'song-tutorials', 'hallelujah', '221831']
-    relatedLessons['related_lessons'].forEach(document => {
-      expect('song-tutorial-children').toStrictEqual(document.type)
-      let web_url_path = document.web_url_path.split('/')
-      // remove id, slug
-      web_url_path.pop()
-      web_url_path.pop()
-      expect(web_url_path).toEqual(expectedPath)
-    })
-  })
-
-  297927
 
   test('fetchRelatedLessons-pack-bundle-lessons', async () => {
     //https://www.musora.com/singeo/packs/sing-harmony-in-30-days/410537/sing-harmony-in-30-days/410538/day-2/410541
@@ -896,6 +865,7 @@ describe('api.v1', function() {
     const relatedLessons = await fetchRelatedLessons(railContentId, 'singeo')
     log(relatedLessons)
     const expectedPath = ['', 'singeo', 'packs', 'sing-harmony-in-30-days', '410537', 'sing-harmony-in-30-days', '410538']
+    expect(relatedLessons['related_lessons'].length).toBeGreaterThanOrEqual(1)
     relatedLessons['related_lessons'].forEach(document => {
       expect('pack-bundle-lesson').toStrictEqual(document.type)
       // there are other ways to check that these all have the same parent, but I don't want to write it
@@ -913,6 +883,7 @@ describe('api.v1', function() {
     const relatedLessons = await fetchRelatedLessons(railContentId, 'drumeo')
     log(relatedLessons)
     const expectedPath = ['', 'drumeo', 'courses', 'ultra-compact-drum-set-gear-guide', '295177']
+    expect(relatedLessons['related_lessons'].length).toBeGreaterThanOrEqual(1)
     relatedLessons['related_lessons'].forEach(document => {
       expect('course-part').toStrictEqual(document.type)
       // there are other ways to check that these all have the same parent, but I don't want to write it
@@ -940,10 +911,45 @@ describe('api.v1.admin', function() {
     log(otherReferencedContent)
     const relatedSongsTypes = await fetchOtherSongVersions(railContentId, 'drumeo', 100)
     log(relatedSongsTypes)
+    expect(relatedSongsTypes.length).toBeGreaterThanOrEqual(1)
     relatedSongsTypes.forEach(document => {
       expect(SONG_TYPES).toContain(document.type)
       expect(document.id).not.toStrictEqual(railContentId)
       expect(otherReferencedContent).toContain(document.id)
+    })
+  })
+
+  test('fetchLessonsFeaturingThisContent', async () => {
+    // much of the licensed content is currently drafted, so this must be run in the admin test-suite
+    const railContentId = 386901
+    const licenseQuery = `*[railcontent_id == ${railContentId}]{
+      'content_ids': *[_type == 'license' && references(^._id)].content[]->railcontent_id
+    }[0]`
+    const otherReferencedContent = (await fetchSanity(licenseQuery, true))['content_ids']
+    const relatedNotSongs = await fetchLessonsFeaturingThisContent(railContentId, 'drumeo', 100)
+    log(relatedNotSongs)
+    expect(relatedNotSongs.length).toBeGreaterThanOrEqual(1)
+    relatedNotSongs.forEach(document => {
+      expect(SONG_TYPES).not.toContain(document.type)
+      expect(document.id).not.toStrictEqual(railContentId)
+      expect(otherReferencedContent).toContain(document.id)
+    })
+  })
+
+  test('fetchRelatedLessons-song-tutorial-children', async () => {
+    // When I wrote this it didn't need admin, but something changed. Shrug
+    const railContentId = 222633
+    const relatedLessons = await fetchRelatedLessons(railContentId, 'pianote')
+    log(relatedLessons)
+    const expectedPath = ['', 'pianote', 'song-tutorials', 'hallelujah', '221831']
+    expect(relatedLessons['related_lessons'].length).toBeGreaterThanOrEqual(1)
+    relatedLessons['related_lessons'].forEach(document => {
+      expect('song-tutorial-children').toStrictEqual(document.type)
+      let web_url_path = document.web_url_path.split('/')
+      // remove id, slug
+      web_url_path.pop()
+      web_url_path.pop()
+      expect(web_url_path).toEqual(expectedPath)
     })
   })
 })

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -155,9 +155,7 @@ describe('Sanity Queries', function() {
 
   test('fetchAllSongsInProgress', async () => {
     var mock = jest.spyOn(dataContext, 'fetchData')
-    var json = JSON.parse(
-      `{"version":1,"config":{"key":1,"enabled":1,"checkInterval":1,"refreshInterval":2},"data":{"412941":{"s":"started","p":6,"t":20,"u":1731108082}}}`,
-    )
+    var json = JSON.parse(`{"version":1,"config":{"key":1,"enabled":1,"checkInterval":1,"refreshInterval":2},"data":{"412941":{"s":"started","p":6,"t":20,"u":1731108082}}}`)
     mock.mockImplementation(() => json)
     const response = await fetchAll('drumeo', 'song', { progress: 'in progress' })
     expect(response.entity[0].id).toBe(412941)
@@ -263,8 +261,7 @@ describe('Sanity Queries', function() {
     expect(response.entity[0].id).toBeDefined()
 
     response = await fetchAll('drumeo', 'challenge', {
-      useDefaultFields: false,
-      customFields: ['garbage'],
+      useDefaultFields: false, customFields: ['garbage'],
     })
     log(response)
     expect(response.entity[0].garbage).toBeDefined()
@@ -279,13 +276,11 @@ describe('Sanity Queries', function() {
     let relatedDoc = await fetchByRailContentId(response.related_lessons[0].id, 'song')
     // match on artist or any genre
     let isMatch = artist === relatedDoc.artist.name
-    isMatch =
-      isMatch ||
-      document.genre.some((genre) => {
-        return relatedDoc.genre.some((relatedGenre) => {
-          return genre._ref === relatedGenre._ref
-        })
+    isMatch = isMatch || document.genre.some((genre) => {
+      return relatedDoc.genre.some((relatedGenre) => {
+        return genre._ref === relatedGenre._ref
       })
+    })
     expect(isMatch).toBeTruthy()
   })
 
@@ -348,16 +343,14 @@ describe('Sanity Queries', function() {
   test('fetchAll-WithProgress', async () => {
     const ids = [410213, 410215]
     let response = await fetchAll('drumeo', 'song', {
-      sort: 'slug',
-      progressIds: ids,
+      sort: 'slug', progressIds: ids,
     })
     expect(response.entity.length).toBe(2)
     expect((response.entity[0].id = 410215))
     expect((response.entity[1].id = 410213))
     // change the type and we expect no results
     response = await fetchAll('drumeo', 'quick-tip', {
-      sort: 'slug',
-      progressIds: ids,
+      sort: 'slug', progressIds: ids,
     })
     expect(response.entity.length).toBe(0)
   })
@@ -401,16 +394,7 @@ describe('Sanity Queries', function() {
     expect(response.entity.length).toBeGreaterThan(0)
   })
   test('fetchCoachLessons-WithTypeFilters', async () => {
-    const response = await fetchAllFilterOptions(
-      'drumeo',
-      ['type,course', 'type,live'],
-      '',
-      '',
-      'coach-lessons',
-      '',
-      [],
-      31880,
-    )
+    const response = await fetchAllFilterOptions('drumeo', ['type,course', 'type,live'], '', '', 'coach-lessons', '', [], 31880)
     log(response)
     expect(response.meta.filterOptions.difficulty).toBeDefined()
     expect(response.meta.filterOptions.type).toBeDefined()
@@ -423,18 +407,7 @@ describe('Sanity Queries', function() {
     const coachId = 31880
     const invalidContentType = 'course' // Not 'coach-lessons'
 
-    await expect(
-      fetchAllFilterOptions(
-        brand,
-        ['type,course', 'type,live'],
-        '',
-        '',
-        invalidContentType,
-        '',
-        [],
-        coachId,
-      ),
-    ).rejects.toThrow('Invalid contentType: \'course\' for coachId. It must be \'coach-lessons\'.')
+    await expect(fetchAllFilterOptions(brand, ['type,course', 'type,live'], '', '', invalidContentType, '', [], coachId)).rejects.toThrow(`Invalid contentType: 'course' for coachId. It must be 'coach-lessons'.`)
   })
 
   test('fetchCoachLessons-IncludedFields', async () => {
@@ -638,9 +611,7 @@ describe('Sanity Queries', function() {
     let data = await fetchCommentModContentData([241251, 241252, 211153])
     expect(data[241251].title).toBe('Setting Up Your Space')
     expect(data[241251].type).toBe('learning-path-lesson')
-    expect(data[241251].url).toBe(
-      '/drumeo/method/drumeo-method/241247/getting-started-on-the-drums/241248/gear/241249/setting-up-your-space/241251',
-    )
+    expect(data[241251].url).toBe('/drumeo/method/drumeo-method/241247/getting-started-on-the-drums/241248/gear/241249/setting-up-your-space/241251')
     expect(data[241251].parentTitle).toBe('Gear')
     expect(data[241252].title).toBe('Setting Up Your Pedals & Throne')
   })
@@ -671,26 +642,21 @@ describe('Filter Builder', function() {
 
   test('withOnlyFilterAvailableStatuses', async () => {
     const filter = 'railcontent_id = 111'
-    const builder = FilterBuilder.withOnlyFilterAvailableStatuses(
-      filter,
-      ['published', 'unlisted'],
-      true,
-    )
+    const builder = FilterBuilder.withOnlyFilterAvailableStatuses(filter, ['published', 'unlisted'], true)
     const finalFilter = await builder.buildFilter()
     const clauses = spliceFilterForAnds(finalFilter)
     expect(clauses[0].phrase).toBe(filter)
     expect(clauses[1].field).toBe('status')
     expect(clauses[1].operator).toBe('in')
     // not sure I like this
-    expect(clauses[1].condition).toBe('[\'published\',\'unlisted\']')
+    expect(clauses[1].condition).toBe(`['published','unlisted']`)
     expect(clauses[2].field).toBe('published_on')
   })
 
   test('withContentStatusAndFutureScheduledContent', async () => {
     const filter = 'railcontent_id = 111'
     const builder = new FilterBuilder(filter, {
-      availableContentStatuses: ['published', 'unlisted', 'scheduled'],
-      getFutureScheduledContentsOnly: true,
+      availableContentStatuses: ['published', 'unlisted', 'scheduled'], getFutureScheduledContentsOnly: true,
     })
     const finalFilter = await builder.buildFilter()
     const clauses = spliceFilterForAnds(finalFilter)
@@ -698,8 +664,7 @@ describe('Filter Builder', function() {
     expect(clauses[1].field).toBe('(status') // extra ( because it's a multi part filter
     expect(clauses[1].operator).toBe('in')
     // getFutureScheduledContentsOnly doesn't make a filter that's splicable, so we match on the more static string
-    const expected =
-      '[\'published\',\'unlisted\'] || (status == \'scheduled\' && defined(published_on) && published_on >='
+    const expected = `['published','unlisted'] || (status == 'scheduled' && defined(published_on) && published_on >=`
     const isMatch = finalFilter.includes(expected)
     expect(isMatch).toBeTruthy()
   })
@@ -708,7 +673,7 @@ describe('Filter Builder', function() {
     const filter = 'railcontent_id = 111'
     const builder = new FilterBuilder(filter)
     const finalFilter = await builder.buildFilter()
-    const expected = 'references(*[_type == \'permission\' && railcontent_id in [78,91,92]]._id)'
+    const expected = `references(*[_type == 'permission' && railcontent_id in [78,91,92]]._id)`
     const isMatch = finalFilter.includes(expected)
     expect(isMatch).toBeTruthy()
   })
@@ -717,7 +682,7 @@ describe('Filter Builder', function() {
     const filter = 'railcontent_id = 111'
     const builder = new FilterBuilder(filter)
     const finalFilter = await builder.buildFilter()
-    const expected = 'references(*[_type == \'permission\' && railcontent_id in [78,91,92]]._id)'
+    const expected = `references(*[_type == 'permission' && railcontent_id in [78,91,92]]._id)`
     const isMatch = finalFilter.includes(expected)
     expect(isMatch).toBeTruthy()
   })
@@ -725,11 +690,10 @@ describe('Filter Builder', function() {
   test('withPermissionBypass', async () => {
     const filter = 'railcontent_id = 111'
     const builder = new FilterBuilder(filter, {
-      bypassPermissions: true,
-      pullFutureContent: false,
+      bypassPermissions: true, pullFutureContent: false,
     })
     const finalFilter = await builder.buildFilter()
-    const expected = 'references(*[_type == \'permission\' && railcontent_id in [78,91,92]]._id)'
+    const expected = `references(*[_type == 'permission' && railcontent_id in [78,91,92]]._id)`
     const isMatch = finalFilter.includes(expected)
     expect(isMatch).toBeFalsy()
     const clauses = spliceFilterForAnds(finalFilter)
@@ -743,8 +707,7 @@ describe('Filter Builder', function() {
 
     const filter = 'railcontent_id = 111'
     let builder = new FilterBuilder(filter, {
-      pullFutureContent: true,
-      bypassPermissions: true,
+      pullFutureContent: true, bypassPermissions: true,
     })
 
     let finalFilter = await builder.buildFilter()
@@ -756,8 +719,7 @@ describe('Filter Builder', function() {
     expect(clauses[3].field).toBe('published_on')
 
     builder = new FilterBuilder(filter, {
-      getFutureContentOnly: true,
-      bypassPermissions: true,
+      getFutureContentOnly: true, bypassPermissions: true,
     })
     finalFilter = await builder.buildFilter()
     clauses = spliceFilterForAnds(finalFilter)
@@ -816,22 +778,7 @@ describe('Filter Builder', function() {
   })
 
   test('fetchAllFilterOptions-filter-selected', async () => {
-    let response = await fetchAllFilterOptions(
-      'drumeo',
-      [
-        'theory,notation',
-        'theory,time signatures',
-        'creativity,Grooves',
-        'creativity,Fills & Chops',
-        'difficulty,Beginner',
-        'difficulty,Intermediate',
-        'difficulty,Expert',
-      ],
-      '',
-      '',
-      'course',
-      '',
-    )
+    let response = await fetchAllFilterOptions('drumeo', ['theory,notation', 'theory,time signatures', 'creativity,Grooves', 'creativity,Fills & Chops', 'difficulty,Beginner', 'difficulty,Intermediate', 'difficulty,Expert'], '', '', 'course', '')
     log(response)
     expect(response.meta.filterOptions).toBeDefined()
   })
@@ -893,19 +840,13 @@ describe('api.v1', function() {
   })
 
   test('fetchAllFilterOptionsLessons', async () => {
-    const response = await fetchAllFilterOptions(
-      'pianote',
-      [], null, null, 'lessons',
-    )
+    const response = await fetchAllFilterOptions('pianote', [], null, null, 'lessons')
     log(response)
     expect(response.meta.filters).toBeDefined()
   })
 
   test('fetchAllFilterOptionsSongs', async () => {
-    const response = await fetchAllFilterOptions(
-      'pianote',
-      [], null, null, 'songs',
-    )
+    const response = await fetchAllFilterOptions('pianote', [], null, null, 'songs')
     log(response)
     expect(response.meta.filters).toBeDefined()
   })
@@ -936,13 +877,7 @@ describe('api.v1', function() {
     const railContentId = 222631
     const relatedLessons = await fetchRelatedLessons(railContentId, 'pianote')
     log(relatedLessons)
-    const expectedPath = [
-      '',
-      'pianote',
-      'song-tutorials',
-      'hallelujah',
-      '221831'
-    ]
+    const expectedPath = ['', 'pianote', 'song-tutorials', 'hallelujah', '221831']
     relatedLessons['related_lessons'].forEach(document => {
       expect('song-tutorial-children').toStrictEqual(document.type)
       let web_url_path = document.web_url_path.split('/')
@@ -960,15 +895,7 @@ describe('api.v1', function() {
     const railContentId = 410541
     const relatedLessons = await fetchRelatedLessons(railContentId, 'singeo')
     log(relatedLessons)
-    const expectedPath = [
-      '',
-      'singeo',
-      'packs',
-      'sing-harmony-in-30-days',
-      '410537',
-      'sing-harmony-in-30-days',
-      '410538'
-    ]
+    const expectedPath = ['', 'singeo', 'packs', 'sing-harmony-in-30-days', '410537', 'sing-harmony-in-30-days', '410538']
     relatedLessons['related_lessons'].forEach(document => {
       expect('pack-bundle-lesson').toStrictEqual(document.type)
       // there are other ways to check that these all have the same parent, but I don't want to write it
@@ -985,13 +912,7 @@ describe('api.v1', function() {
     const railContentId = 297929
     const relatedLessons = await fetchRelatedLessons(railContentId, 'drumeo')
     log(relatedLessons)
-    const expectedPath = [
-      '',
-      'drumeo',
-      'courses',
-      'ultra-compact-drum-set-gear-guide',
-      '295177',
-    ]
+    const expectedPath = ['', 'drumeo', 'courses', 'ultra-compact-drum-set-gear-guide', '295177']
     relatedLessons['related_lessons'].forEach(document => {
       expect('course-part').toStrictEqual(document.type)
       // there are other ways to check that these all have the same parent, but I don't want to write it


### PR DESCRIPTION
[JIRA](https://musora.atlassian.net/browse/BEH-313)


Design:
- i did one endponit for each module, as different content types will use different modules and I like the SPA style 
- I refactored the testsuites to have slightly better names, and added an admin version for testing content that's blocked behind admin issues for license reasons.
- Single parent types will potentially be used by FEW/MA to determine if the related lessons module should be called.
- Song types, may change names (jam-tracks don't exist yet) but that will be my problem later when I add the type


Testing:
- I did all my testing in the testsuite. 
- I added a test for each endpoint with the provided content type. I did not add a recommended test because we don't have it configured for testing and I can't be bothered right now.
- lessons in this X, were tested by passing an a child and verifying we find related content based on the web_url_path.
- license related information was tested by verifing the items are related by licenes and the content type matches the allow/reject filter for different song types.
- Neither of these tests are exaustive for ordering (which I assumed was fine as previously written)
