### PR TITLE
Add report endpoints 

### DIFF
--- a/src/lib/httpHelper.js
+++ b/src/lib/httpHelper.js
@@ -1,0 +1,46 @@
+import { globalConfig } from '../services/config.js'
+
+export async function fetchJSONHandler(url, token, baseUrl, method = 'get', dataVersion = null, body = null) {
+  let headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-CSRF-TOKEN': token,
+  }
+
+  if (!globalConfig.isMA) {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('testNow')) {
+      headers['testNow'] = params.get('testNow')
+    }
+    if (params.get('timezone')) {
+      headers['M-Client-Timezone'] = params.get('timezone')
+    }
+  }
+
+  if (globalConfig.localTimezoneString) headers['M-Client-Timezone'] = globalConfig.localTimezoneString
+  if (dataVersion) headers['Data-Version'] = dataVersion
+  const options = {
+    method,
+    headers,
+  }
+  if (body) options.body = JSON.stringify(body)
+  if (token) options.headers['Authorization'] = `Bearer ${token}`
+  if (baseUrl && url.startsWith('/')) url = baseUrl + url
+  try {
+    const response = await fetch(url, options)
+    if (response.ok) {
+      const contentType = response.headers.get("content-type");
+      if (contentType && contentType.indexOf("application/json") !== -1) {
+        return await response.json()
+      } else {
+        return await response.text()
+      }
+    } else {
+      console.error(`Fetch error: ${method} ${url} ${response.status} ${response.statusText}`)
+      console.log(response)
+    }
+  } catch (error) {
+    console.error('Fetch error:', error)
+  }
+  return null
+}

--- a/src/services/recommendations.js
+++ b/src/services/recommendations.js
@@ -3,6 +3,7 @@
  */
 
 import { globalConfig } from './config.js'
+import { fetchJSONHandler} from '../lib/httpHelper.js'
 
 /**
  * Exported functions that are excluded from index generation.
@@ -129,44 +130,12 @@ export async function recommendations(brand, {
 }
 
 async function fetchHandler(url, method = 'get', body = null) {
-
-  let headers = {
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
-    'X-CSRF-TOKEN': globalConfig.recommendationsConfig.token,
-  }
-
-  const options = {
+  return fetchJSONHandler(
+    url,
+    globalConfig.recommendationsConfig.token,
+    globalConfig.recommendationsConfig.baseUrl,
     method,
-    headers,
-  }
-
-  if (body) {
-    options.body = JSON.stringify(body)
-  }
-  try {
-    const response = await fetchAbsolute(url, options)
-    if (response.ok) {
-      return await response.json()
-    } else {
-      console.error(`Fetch error: ${method} ${url} ${response.status} ${response.statusText}`)
-      console.log(response)
-    }
-  } catch (error) {
-    console.error('Fetch error:', error)
-  }
-  return null
-}
-
-
-function fetchAbsolute(url, params) {
-  if (globalConfig.recommendationsConfig.token) {
-    params.headers['Authorization'] = `Bearer ${globalConfig.recommendationsConfig.token}`
-  }
-  if (globalConfig.recommendationsConfig.baseUrl) {
-    if (url.startsWith('/')) {
-      return fetch(globalConfig.recommendationsConfig.baseUrl + url, params)
-    }
-  }
-  return fetch(url, params)
+    null,
+    body
+    )
 }

--- a/src/services/user/management.js
+++ b/src/services/user/management.js
@@ -12,7 +12,7 @@ import { fetchHandler } from '../railcontent.js'
  */
 const excludeFromGeneratedIndex = []
 
-const baseUrl = `/api/user-management-system/v1`
+const baseUrl = `/api/user-management-system`
 
 /**
  * Block the provided user
@@ -20,7 +20,7 @@ const baseUrl = `/api/user-management-system/v1`
  * @returns {Promise<any|string|null>}
  */
 export async function blockUser(userId) {
-  const url = `${baseUrl}/block/${userId}`
+  const url = `${baseUrl}/v1/block/${userId}`
   return fetchHandler(url, 'post')
 }
 
@@ -30,6 +30,6 @@ export async function blockUser(userId) {
  * @returns {Promise<any|string|null>}
  */
 export async function unblockUser(userId) {
-  const url = `${baseUrl}/unblock/${userId}`
+  const url = `${baseUrl}/v1/unblock/${userId}`
   return fetchHandler(url, 'post')
 }

--- a/src/services/user/management.js
+++ b/src/services/user/management.js
@@ -14,16 +14,22 @@ const excludeFromGeneratedIndex = []
 
 const baseUrl = `/api/user-management-system/v1`
 
+/**
+ * Block the provided user
+ * @param userId
+ * @returns {Promise<any|string|null>}
+ */
 export async function blockUser(userId) {
   const url = `${baseUrl}/block/${userId}`
-  return postHandler(url)
+  return fetchHandler(url, 'post')
 }
 
+/**
+ * Unblock the provided user. Returns a 422 if the user wasn't blocked
+ * @param userId
+ * @returns {Promise<any|string|null>}
+ */
 export async function unblockUser(userId) {
   const url = `${baseUrl}/unblock/${userId}`
-  return postHandler(url)
-}
-
-async function postHandler(url, body = null) {
-  return fetchHandler(url,'post',null, body)
+  return fetchHandler(url, 'post')
 }

--- a/src/services/user/management.js
+++ b/src/services/user/management.js
@@ -20,7 +20,7 @@ globalConfig = {
  */
 const excludeFromGeneratedIndex = []
 
-const baseUrl = `${globalConfig.railcontentConfig.baseUrl}/api/user-management-system/v1`
+const baseUrl = `/api/user-management-system/v1`
 
 export async function blockUser(userId) {
   const url = `${baseUrl}/block/${userId}`

--- a/src/services/user/management.js
+++ b/src/services/user/management.js
@@ -1,0 +1,67 @@
+/**
+ * @module User-Management
+ */
+import { globalConfig } from '../config.js'
+import './types.js'
+
+globalConfig = {
+  railcontentConfig: {
+    token: 'pDxpLMl0xtG6hJTQC092Yw5MUKg9UKkSkl2X1ZXx',
+    userId: 631736,
+    authToken: 'pDxpLMl0xtG6hJTQC092Yw5MUKg9UKkSkl2X1ZXx',
+    //baseUrl = 'https://dev.musora.com:8443'
+  }
+}
+
+/**
+ * Exported functions that are excluded from index generation.
+ *
+ * @type {string[]}
+ */
+const excludeFromGeneratedIndex = []
+
+const baseUrl = `${globalConfig.railcontentConfig.baseUrl}/api/user-management-system/v1`
+
+export async function blockUser(userId) {
+  const url = `${baseUrl}/block/${userId}`
+  postHandler(url)
+}
+
+export async function unblockUser(userId) {
+  const url = `${baseUrl}/unblock/${userId}`
+  postHandler(url)
+}
+
+async function postHandler(url, body = null) {
+  let headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-CSRF-TOKEN': globalConfig.railcontentConfig.token,
+  }
+
+  if (globalConfig.railcontentConfig.authToken) {
+    headers['Authorization'] = `Bearer ${globalConfig.railcontentConfig.authToken}`
+  }
+
+  const options = {
+    method: 'post',
+    headers,
+  }
+  if (body) {
+    options.body = JSON.stringify(body)
+  }
+  try {
+    if (globalConfig.railcontentConfig.baseUrl) {
+      if (url.startsWith('/')) {
+        return fetch(globalConfig.railcontentConfig.baseUrl + url, options)
+      }
+    }
+    const response = await fetch(url, options)
+    if (!response.ok) {
+      console.error(`Fetch error: post ${url} ${response.status} ${response.statusText}`)
+      console.log(response)
+    }
+  } catch (error) {
+    console.error('Fetch error:', error)
+  }
+}

--- a/src/services/user/management.js
+++ b/src/services/user/management.js
@@ -1,17 +1,9 @@
 /**
  * @module User-Management
  */
-import { globalConfig } from '../config.js'
-import './types.js'
+import { fetchHandler } from '../railcontent.js'
 
-globalConfig = {
-  railcontentConfig: {
-    token: 'pDxpLMl0xtG6hJTQC092Yw5MUKg9UKkSkl2X1ZXx',
-    userId: 631736,
-    authToken: 'pDxpLMl0xtG6hJTQC092Yw5MUKg9UKkSkl2X1ZXx',
-    //baseUrl = 'https://dev.musora.com:8443'
-  }
-}
+
 
 /**
  * Exported functions that are excluded from index generation.
@@ -24,44 +16,14 @@ const baseUrl = `/api/user-management-system/v1`
 
 export async function blockUser(userId) {
   const url = `${baseUrl}/block/${userId}`
-  postHandler(url)
+  return postHandler(url)
 }
 
 export async function unblockUser(userId) {
   const url = `${baseUrl}/unblock/${userId}`
-  postHandler(url)
+  return postHandler(url)
 }
 
 async function postHandler(url, body = null) {
-  let headers = {
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
-    'X-CSRF-TOKEN': globalConfig.railcontentConfig.token,
-  }
-
-  if (globalConfig.railcontentConfig.authToken) {
-    headers['Authorization'] = `Bearer ${globalConfig.railcontentConfig.authToken}`
-  }
-
-  const options = {
-    method: 'post',
-    headers,
-  }
-  if (body) {
-    options.body = JSON.stringify(body)
-  }
-  try {
-    if (globalConfig.railcontentConfig.baseUrl) {
-      if (url.startsWith('/')) {
-        return fetch(globalConfig.railcontentConfig.baseUrl + url, options)
-      }
-    }
-    const response = await fetch(url, options)
-    if (!response.ok) {
-      console.error(`Fetch error: post ${url} ${response.status} ${response.statusText}`)
-      console.log(response)
-    }
-  } catch (error) {
-    console.error('Fetch error:', error)
-  }
+  return fetchHandler(url,'post',null, body)
 }


### PR DESCRIPTION
I needed to add the new set of endpoints for user management block/unblock.

Refactored the fetch handler into it's own utility file. It takes a token and baseURl now, so it can be supported by both railcontent.js and recommended.js (or any external JSON API)

I tested this in console, because I don't have a quick way to test through the FEW yet.
To do so, wrote the global config file into console like so. 
token was generated by running `api/user-management-system/v1/sessions` in postmand and pulling the tokens out.
```
globalConfig = {  
railcontentConfig: {  
token: 'pDxpLMl0xtG6hJTQC092Yw5MUKg9UKkSkl2X1ZXx',  
userId: 631736,  
//baseUrl = 'https://dev.musora.com:8443'  
},  
recommendationsConfig: {  
token: '<go grab it from the .env file',  
baseUrl: 'https://MusoraProductDepartment-PWGenerator.hf.space',

}  
}
```

Then dumped the  `fetchHandler` for `recommended.js`, then ran
```await rankItems('drumeo', [410430, 388642, 388199, 411095])```
Then dumped the `fetchHandler` for `railcontent.js` (and the `postHandler`), then ran:
```await createComment(402199, 'im a new comment')```
and then ran the block and unblock commands
