### PR TITLE
fix(BR-178): fix url routing to genres on song-tutorial page

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -154,6 +154,7 @@ export let contentTypeConfig = {
         isOneToOne: true,
       },
     },
+    slug: 'song-tutorials',
   },
   'song-tutorial-children': {
     fields: [`"resources": ${resourcesField}`],

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -579,6 +579,7 @@ export async function fetchAll(
   let additionalFields = config?.fields ?? []
   let isGroupByOneToOne = (groupBy ? config?.relationships?.[groupBy]?.isOneToOne : false) ?? false
   let webUrlPathType = config?.slug ?? type
+  webUrlPathType = webUrlPathType == "song-tutorial" ? "song-tutorials" : "song-tutorial";
   const start = (page - 1) * limit
   const end = start + limit
   let bypassStatusAndPublishedValidation =

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -579,7 +579,6 @@ export async function fetchAll(
   let additionalFields = config?.fields ?? []
   let isGroupByOneToOne = (groupBy ? config?.relationships?.[groupBy]?.isOneToOne : false) ?? false
   let webUrlPathType = config?.slug ?? type
-  webUrlPathType = webUrlPathType == "song-tutorial" ? "song-tutorials" : "song-tutorial";
   const start = (page - 1) * limit
   const end = start + limit
   let bypassStatusAndPublishedValidation =


### PR DESCRIPTION
[BR-178](https://musora.atlassian.net/browse/BR-178)

Changes:
* adds pluralization handling for song-tutorials

Testing:
* go to song-tutorial page, genre tab: https://dev.musora.com:8443/pianote/song-tutorials?sort=-popularity&tabs%5B%5D=genre
* click on any of the genre titles
* you will be directed to the correct url (/pianote/genres/{genre}/song-tutorials?sort=-published_on

[BR-178]: https://musora.atlassian.net/browse/BR-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a distinct identifier for the song tutorial section that improves content organization and navigation through enhanced categorization and routing, all while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->