### PR TITLE
BEH-341 - Verify fetchLessonData works for new playalong structure

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1273,6 +1273,7 @@ export async function fetchLessonContent(railContentId) {
             chapter_timecode,
             "chapter_thumbnail_url": chapter_thumbnail_url.asset->url
           },
+          artist->,
           "instructors":instructor[]->name,
           "instructor": instructor[]->{
             "id":railcontent_id,

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -148,9 +148,22 @@ describe('Sanity Queries', function() {
   })
 
   test('fetchLessonContent', async () => {
-    const id = 380094
+    const id = 392820
     const response = await fetchLessonContent(id)
     expect(response.id).toBe(id)
+    expect(response.video.type).toBeDefined()
+  })
+
+  test('fetchLessonContent-PlayAlong-containts-array-of-videos', async () => {
+    const id = 9184
+    const response = await fetchLessonContent(id)
+    expect(response.id).toBe(id)
+    log(response.video)
+    log(response.permissions_id)
+    log(response.instructors)
+    expect(response.video.length).toBeGreaterThanOrEqual(1)
+    const firstElement = response.video.find(() => true)
+    expect(firstElement.version_name).toBeDefined()
   })
 
   test('fetchAllSongsInProgress', async () => {


### PR DESCRIPTION
Design:
- Jam tracks and Play-alongs will be added to `main` with this [PR](https://github.com/railroadmedia/musora-web-platform/pull/2082). This is currently live on `app-staging-two`, and I've run the migration for drumeo play-alongs
- existing guitareo play-alongs don't need to be tested as those will be archived, and dealt with separately. 
- I've also added a few jam-tracks, though these may get wiped at any moment when the sanity `staging` dataset gets refreshed from `production`
- add artist fields to lesson contents for song types



Testing:
- I tested with the jest tests
- testing front end will require updates to FEW/MA that have not yet happened (:D, message sent to Peter/Meenu)
- Jam tracks are not yet testable in jest, as non-exist (and we need to make them on production first). they can be tested by FE/MA by adding to the staging