### PR TITLE
fix(TP-833): mod comments missing content

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1858,7 +1858,7 @@ export async function fetchCommentModContentData(ids) {
     `railcontent_id in [${idsString}]`,
     { bypassPermissions: true },
     fields,
-    { end: 50 }
+    { end: 100 }
   )
   let data = await fetchSanity(query, true)
   let mapped = {}

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1852,13 +1852,16 @@ function populateHierarchyLookups(currentLevel, data, parentId) {
  * @returns {Promise<Object|null>} - A promise that resolves to an object containing the data
  */
 export async function fetchCommentModContentData(ids) {
+  if (!ids) {
+    return []
+  }
   const idsString = ids.join(',')
   const fields = `"id": railcontent_id, "type": _type, title, "url": web_url_path, "parent": *[^._id in child[]._ref]{"id": railcontent_id, title}`
   const query = await buildQuery(
     `railcontent_id in [${idsString}]`,
     { bypassPermissions: true },
     fields,
-    { end: 100 }
+    { end: ids.length }
   )
   let data = await fetchSanity(query, true)
   let mapped = {}


### PR DESCRIPTION
[TP-833](https://musora.atlassian.net/browse/TP-833)

Changes:
* increases sanity query return length to account for more content

Testing:
* go to https://dev.musora.com:8443/drumeo/comments
* adjust filters to show closed comments (we are trying to show the most comments possible
* verify there are no comments with broken content links (missing title and type)

[TP-833]: https://musora.atlassian.net/browse/TP-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved content retrieval by gracefully handling cases with missing or empty inputs, preventing unnecessary processing.
  - Enhanced performance by dynamically adjusting the number of records fetched to match the input size, ensuring more efficient and accurate data delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->