### PR TITLE
Fix date in user timezone for React

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,6 +48,14 @@ import {
 } from './services/dataContext.js';
 
 import {
+	convertToTimeZone,
+	getMonday,
+	getWeekNumber,
+	isNextDay,
+	isSameDate
+} from './services/dateUtils.js';
+
+import {
 	getActiveDiscussions
 } from './services/forum.js';
 
@@ -236,6 +244,7 @@ declare module 'musora-content-services' {
 		closeComment,
 		contentStatusCompleted,
 		contentStatusReset,
+		convertToTimeZone,
 		countAssignmentsAndLessons,
 		createComment,
 		createPlaylist,
@@ -332,6 +341,7 @@ declare module 'musora-content-services' {
 		getAllStartedOrCompleted,
 		getContentRows,
 		getLessonContentRows,
+		getMonday,
 		getNewAndUpcoming,
 		getPracticeSessions,
 		getProgressPercentage,
@@ -348,10 +358,13 @@ declare module 'musora-content-services' {
 		getUserMonthlyStats,
 		getUserPractices,
 		getUserWeeklyStats,
+		getWeekNumber,
 		globalConfig,
 		initializeService,
 		isBucketUrl,
 		isContentLiked,
+		isNextDay,
+		isSameDate,
 		jumpToContinueContent,
 		likeComment,
 		likeContent,

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,14 @@ import {
 } from './services/dataContext.js';
 
 import {
+	convertToTimeZone,
+	getMonday,
+	getWeekNumber,
+	isNextDay,
+	isSameDate
+} from './services/dateUtils.js';
+
+import {
 	getActiveDiscussions
 } from './services/forum.js';
 
@@ -235,6 +243,7 @@ export {
 	closeComment,
 	contentStatusCompleted,
 	contentStatusReset,
+	convertToTimeZone,
 	countAssignmentsAndLessons,
 	createComment,
 	createPlaylist,
@@ -331,6 +340,7 @@ export {
 	getAllStartedOrCompleted,
 	getContentRows,
 	getLessonContentRows,
+	getMonday,
 	getNewAndUpcoming,
 	getPracticeSessions,
 	getProgressPercentage,
@@ -347,10 +357,13 @@ export {
 	getUserMonthlyStats,
 	getUserPractices,
 	getUserWeeklyStats,
+	getWeekNumber,
 	globalConfig,
 	initializeService,
 	isBucketUrl,
 	isContentLiked,
+	isNextDay,
+	isSameDate,
 	jumpToContinueContent,
 	likeComment,
 	likeContent,

--- a/src/services/dateUtils.js
+++ b/src/services/dateUtils.js
@@ -1,0 +1,55 @@
+// dateUtils.js
+
+export function convertToTimeZone(date, timeZone) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+
+  const parts = formatter.formatToParts(date).reduce((acc, part) => {
+    if (part.type !== 'literal') acc[part.type] = part.value;
+    return acc;
+  }, {});
+
+  return new Date(`${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}`);
+}
+// Get start of the week (Monday)
+export function getMonday(date) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(d.setDate(diff));
+}
+
+// Get the week number
+export function getWeekNumber(d) {
+  let newDate = new Date(d.getTime());
+  newDate.setUTCDate(newDate.getUTCDate() + 4 - (newDate.getUTCDay()||7));
+  var yearStart = new Date(Date.UTC(newDate.getUTCFullYear(),0,1));
+  var weekNo = Math.ceil(( ( (newDate - yearStart) / 86400000) + 1)/7);
+  return  weekNo;
+}
+//Check if two dates are the same
+export function isSameDate(date1, date2, method = '') {
+  return date1.toISOString().split('T')[0] === date2.toISOString().split('T')[0];
+}
+
+// Check if two dates are consecutive days
+export function isNextDay(prev, current) {
+  const prevDate = new Date(prev.getFullYear(), prev.getMonth(), prev.getDate());
+  const nextDate = new Date(prevDate);
+  nextDate.setDate(prevDate.getDate() + 1); // Add 1 day
+
+  return (
+    nextDate.getFullYear() === current.getFullYear() &&
+    nextDate.getMonth() === current.getMonth() &&
+    nextDate.getDate() === current.getDate()
+  );
+}
+

--- a/src/services/railcontent.js
+++ b/src/services/railcontent.js
@@ -3,6 +3,7 @@
  */
 import { globalConfig } from './config.js'
 import { fetchJSONHandler } from '../lib/httpHelper.js'
+import { convertToTimeZone } from './dateUtils.js';
 
 /**
  * Exported functions that are excluded from index generation.
@@ -1182,25 +1183,6 @@ export async function fetchUserPractices(currentVersion) {
 
   const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  function convertToTimeZone(date, timeZone) {
-    const formatter = new Intl.DateTimeFormat('en-US', {
-      timeZone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: false,
-    });
-
-    const parts = formatter.formatToParts(date).reduce((acc, part) => {
-      if (part.type !== 'literal') acc[part.type] = part.value;
-      return acc;
-    }, {});
-
-    return new Date(`${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}`);
-  }
 
   const formattedPractices = userPractices.reduce((acc, practice) => {
     // Convert UTC date to user's local date (still a Date object)


### PR DESCRIPTION
Fix convert user practice date to user timezone on React Native JS; add created_at in user timezone on user practice


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced date handling to accurately display local dates and times across the platform, ensuring consistency in scheduling and activity displays.

- **Refactor**
  - Centralized date manipulation logic to streamline how dates are processed, reducing redundancy and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->