### PR TITLE
Delete local context for entire day when user call deletePracticeSession

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -348,9 +348,7 @@ export async function deletePracticeSession(day) {
   await userActivityContext.update(
     async function (localContext) {
       if (localContext.data?.[DATA_KEY_PRACTICES]?.[day]) {
-        localContext.data[DATA_KEY_PRACTICES][day] = localContext.data[DATA_KEY_PRACTICES][day].filter(
-          practice => !userPracticesIds.includes(practice.id)
-        );
+        delete localContext.data[DATA_KEY_PRACTICES][day];
       }
     },
     async function () {


### PR DESCRIPTION
Delete local context for entire day when user call deletePracticeSession

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated practice session deletion so that removing a session now clears all sessions for the selected day, streamlining session management for a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->