### PR TITLE
Add a flag continueStreak to the first element of the weeklyActiveSta…

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -118,6 +118,22 @@ export async function getUserMonthlyStats(year = new Date().getFullYear(), month
   today.setHours(0, 0, 0, 0);
 
   let startOfGrid = getMonday(firstDayOfMonth)
+
+  let previousWeekStart = new Date(startOfGrid)
+  previousWeekStart.setDate(previousWeekStart.getDate() - 7)
+
+  let previousWeekEnd = new Date(startOfGrid)
+  previousWeekEnd.setDate(previousWeekEnd.getDate() - 1)
+
+  let hadStreakBeforeMonth = false
+  for (let d = new Date(previousWeekStart); d <= previousWeekEnd; d.setDate(d.getDate() + 1)) {
+    let dayKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    if (practices[dayKey]) {
+      hadStreakBeforeMonth = true
+      break
+    }
+  }
+
   let endOfMonth = new Date(year, month + 1, 0)
   while (endOfMonth.getDay() !== 0) {
     endOfMonth.setDate(endOfMonth.getDate() + 1)
@@ -162,6 +178,13 @@ export async function getUserMonthlyStats(year = new Date().getFullYear(), month
       inStreak: dayActivity !== null,
       type,
     })
+  }
+
+  if (hadStreakBeforeMonth) {
+    const firstWeekKey = getWeekNumber(startOfGrid)
+    if (weeklyStats[firstWeekKey]) {
+      weeklyStats[firstWeekKey].continueStreak = true
+    }
   }
 
   let filteredPractices = Object.keys(practices)


### PR DESCRIPTION
Add a flag continueStreak to the first element of the weeklyActiveStats to identify if its a carryover streak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new indicator in monthly statistics to show if a practice streak continued from the previous week into the current month. The first week of the month will now display a streak continuity flag when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->