### PR TITLE
Mu2 390 longest streaks

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,6 +23,7 @@ import {
 
 import {
 	isContentLiked,
+	isContentLikedByIds,
 	likeContent,
 	unlikeContent
 } from './services/contentLikes.js';
@@ -40,8 +41,13 @@ import {
 	getProgressState,
 	getProgressStateByIds,
 	getResumeTimeSeconds,
+	getResumeTimeSecondsByIds,
 	recordWatchSession
 } from './services/contentProgress.js';
+
+import {
+  addContextToContent
+} from './contentAggregator.js';
 
 import {
 	verifyLocalDataContext
@@ -101,6 +107,7 @@ import {
 	fetchContentPageUserData,
 	fetchContentProgress,
 	fetchHandler,
+	fetchLikeCount,
 	fetchNextContentDataForParent,
 	fetchOwnedChallenges,
 	fetchPinnedPlaylists,
@@ -220,6 +227,7 @@ import {
 } from './services/user/sessions.js';
 
 import {
+	calculateLongestStreaks,
 	createPracticeNotes,
 	deletePracticeSession,
 	getPracticeNotes,
@@ -236,12 +244,10 @@ import {
 	updateUserPractice
 } from './services/userActivity.js';
 
-import { addContextToContent } from './contentAggregator.js';
-
 declare module 'musora-content-services' {
 	export {
-		addContextToContent,
 		addItemToPlaylist,
+    addContextToContent,
 		applyCloudflareWrapper,
 		applySanityTransformations,
 		assignModeratorToComment,
@@ -249,6 +255,7 @@ declare module 'musora-content-services' {
 		assignmentStatusReset,
 		blockUser,
 		buildImageSRC,
+		calculateLongestStreaks,
 		closeComment,
 		contentStatusCompleted,
 		contentStatusReset,
@@ -299,6 +306,7 @@ declare module 'musora-content-services' {
 		fetchLeaving,
 		fetchLessonContent,
 		fetchLessonsFeaturingThisContent,
+		fetchLikeCount,
 		fetchLiveEvent,
 		fetchMetadata,
 		fetchMethod,
@@ -363,6 +371,7 @@ declare module 'musora-content-services' {
 		getRecentActivity,
 		getRecommendedForYou,
 		getResumeTimeSeconds,
+		getResumeTimeSecondsByIds,
 		getScheduleContentRows,
 		getSortOrder,
 		getTabResults,
@@ -374,6 +383,7 @@ declare module 'musora-content-services' {
 		initializeService,
 		isBucketUrl,
 		isContentLiked,
+		isContentLikedByIds,
 		isNextDay,
 		isSameDate,
 		jumpToContinueContent,

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import {
 
 import {
 	isContentLiked,
+	isContentLikedByIds,
 	likeContent,
 	unlikeContent
 } from './services/contentLikes.js';
@@ -40,6 +41,7 @@ import {
 	getProgressState,
 	getProgressStateByIds,
 	getResumeTimeSeconds,
+	getResumeTimeSecondsByIds,
 	recordWatchSession
 } from './services/contentProgress.js';
 
@@ -74,6 +76,9 @@ import {
 	isBucketUrl,
 	verifyImageSRC
 } from './services/imageSRCVerify.js';
+import {
+  addContextToContent
+} from './contentAggregator.js';
 
 import {
 	assignModeratorToComment,
@@ -101,6 +106,7 @@ import {
 	fetchContentPageUserData,
 	fetchContentProgress,
 	fetchHandler,
+	fetchLikeCount,
 	fetchNextContentDataForParent,
 	fetchOwnedChallenges,
 	fetchPinnedPlaylists,
@@ -220,6 +226,7 @@ import {
 } from './services/user/sessions.js';
 
 import {
+	calculateLongestStreaks,
 	createPracticeNotes,
 	deletePracticeSession,
 	getPracticeNotes,
@@ -236,10 +243,7 @@ import {
 	updateUserPractice
 } from './services/userActivity.js';
 
-import { addContextToContent } from './contentAggregator.js';
-
 export {
-	addContextToContent,
 	addItemToPlaylist,
 	applyCloudflareWrapper,
 	applySanityTransformations,
@@ -248,6 +252,7 @@ export {
 	assignmentStatusReset,
 	blockUser,
 	buildImageSRC,
+	calculateLongestStreaks,
 	closeComment,
 	contentStatusCompleted,
 	contentStatusReset,
@@ -298,6 +303,7 @@ export {
 	fetchLeaving,
 	fetchLessonContent,
 	fetchLessonsFeaturingThisContent,
+	fetchLikeCount,
 	fetchLiveEvent,
 	fetchMetadata,
 	fetchMethod,
@@ -362,6 +368,7 @@ export {
 	getRecentActivity,
 	getRecommendedForYou,
 	getResumeTimeSeconds,
+	getResumeTimeSecondsByIds,
 	getScheduleContentRows,
 	getSortOrder,
 	getTabResults,
@@ -373,6 +380,7 @@ export {
 	initializeService,
 	isBucketUrl,
 	isContentLiked,
+	isContentLikedByIds,
 	isNextDay,
 	isSameDate,
 	jumpToContinueContent,
@@ -422,4 +430,5 @@ export {
 	updateUserPractice,
 	verifyImageSRC,
 	verifyLocalDataContext,
+  addContextToContent
 };

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -665,9 +665,7 @@ function calculateStreaks(practices, includeStreakMessage = false) {
 export async function calculateLongestStreaks() {
   let data = await userActivityContext.getData()
   let practices = data?.[DATA_KEY_PRACTICES] ?? {}
-  console.log('rox:: practices', practices, Object.keys(practices) )
   let totalPracticeSeconds = 0;
-
   // Calculate total practice duration
   for (const date in practices) {
     for (const entry of practices[date]) {
@@ -700,7 +698,6 @@ export async function calculateLongestStreaks() {
   // ----- Daily Streak -----
   let longestDailyStreak = 1;
   let currentDailyStreak = 1;
-  console.log('rox:: calculateLongestStreaks practices dates', practiceDates, ' normalizedDates::::', normalizedDates);
   for (let i = 1; i < normalizedDates.length; i++) {
     const diffInDays = (normalizedDates[i] - normalizedDates[i - 1]) / (1000 * 60 * 60 * 24);
     if (diffInDays === 1) {

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -658,6 +658,90 @@ function calculateStreaks(practices, includeStreakMessage = false) {
   return { currentDailyStreak, currentWeeklyStreak, streakMessage };
 }
 
+/**
+ * Calculates the longest daily, weekly streaks and totalPracticeSeconds from user practice dates.
+ * @returns {{ longestDailyStreak: number, longestWeeklyStreak: number, totalPracticeSeconds:number }}
+ */
+export async function calculateLongestStreaks() {
+  let data = await userActivityContext.getData()
+  let practices = data?.[DATA_KEY_PRACTICES] ?? {}
+  console.log('rox:: practices', practices, Object.keys(practices) )
+  let totalPracticeSeconds = 0;
+
+  // Calculate total practice duration
+  for (const date in practices) {
+    for (const entry of practices[date]) {
+      totalPracticeSeconds += entry.duration_seconds;
+    }
+  }
+
+  let practiceDates = Object.keys(practices)
+    .map(dateStr => {
+      const [y, m, d] = dateStr.split('-').map(Number);
+      const newDate = new Date();
+      newDate.setFullYear(y, m - 1, d);
+      return newDate;
+    })
+    .sort((a, b) => a - b);
+
+  if (!practiceDates || practiceDates.length === 0) {
+    return {longestDailyStreak: 0, longestWeeklyStreak: 0, totalPracticeSeconds: 0};
+  }
+
+  // Normalize to Date objects
+  const normalizedDates = [
+    ...new Set(practiceDates.map(d => {
+      const date = new Date(d);
+      date.setHours(0, 0, 0, 0);
+      return date.getTime();
+    }))
+  ].sort((a, b) => a - b);
+
+  // ----- Daily Streak -----
+  let longestDailyStreak = 1;
+  let currentDailyStreak = 1;
+  console.log('rox:: calculateLongestStreaks practices dates', practiceDates, ' normalizedDates::::', normalizedDates);
+  for (let i = 1; i < normalizedDates.length; i++) {
+    const diffInDays = (normalizedDates[i] - normalizedDates[i - 1]) / (1000 * 60 * 60 * 24);
+    if (diffInDays === 1) {
+      currentDailyStreak++;
+      longestDailyStreak = Math.max(longestDailyStreak, currentDailyStreak);
+    } else {
+      currentDailyStreak = 1;
+    }
+  }
+
+  // ----- Weekly Streak -----
+  const weekStartDates = [
+    ...new Set(normalizedDates.map(ts => {
+      const d = new Date(ts);
+      const day = d.getDay();
+      const diff = d.getDate() - day + (day === 0 ? -6 : 1); // adjust to Monday
+      d.setDate(diff);
+      return d.getTime(); // timestamp for Monday
+    }))
+  ].sort((a, b) => a - b);
+
+  let longestWeeklyStreak = 1;
+  let currentWeeklyStreak = 1;
+
+  for (let i = 1; i < weekStartDates.length; i++) {
+    const diffInWeeks = (weekStartDates[i] - weekStartDates[i - 1]) / (1000 * 60 * 60 * 24 * 7);
+    if (diffInWeeks === 1) {
+      currentWeeklyStreak++;
+      longestWeeklyStreak = Math.max(longestWeeklyStreak, currentWeeklyStreak);
+    } else {
+      currentWeeklyStreak = 1;
+    }
+  }
+
+  return {
+    longestDailyStreak,
+    longestWeeklyStreak,
+    totalPracticeSeconds
+  };
+}
+
 
 
 


### PR DESCRIPTION
New JS method to calculate the longest daily, weekly streaks and totalPracticeSeconds from user practice dates

We already have user practices stored in local storage for the logged-in user, and with this method  we can calculate the longest week/days streaks easily and efficiently (without an extra call to the PHP server and DB), and most importantly, it can also be calculated offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new functions for public use: checking if content is liked by IDs, retrieving resume times by IDs, fetching like counts, adding context to content, and calculating longest daily and weekly streaks along with total practice duration. These enhancements expand the available API capabilities for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->