### PR TITLE
Fix/mu2 473 play alongs filter type

### DIFF
--- a/src/contentMetaData.js
+++ b/src/contentMetaData.js
@@ -310,7 +310,7 @@ const contentMetadata = {
       sortBy: 'sort',
     },
     'play-along': {
-      name: 'Play Alongs',
+      name: 'Play-Alongs',
       icon: 'icon-play-alongs',
       description:
             'Add your drumming to high-quality drumless play-along tracks - with handy playback tools to help you create the perfect performance.',
@@ -354,7 +354,7 @@ const contentMetadata = {
           'Blues', 'Christian', 'Classical', 'Country', 'Disco', 'Electronic', 'Folk', 'Funk', 'Hip-Hop/Rap', 'Holiday', 'Jazz', 'Soundtrack',
           'World', 'Metal', 'Pop', 'R&B/Soul', 'Rock'
         ],
-        type:       ['Tutorials', 'Transcriptions', 'Play Alongs', 'Jam Tracks'],
+        type:       ['Tutorials', 'Transcriptions', 'Play-Alongs', 'Jam Tracks'],
         progress:   PROGRESS_NAMES,
       },
       sortingOptions: {
@@ -395,7 +395,7 @@ const contentMetadata = {
           'Blues', 'Christian', 'Classical', 'Country', 'Disco', 'Electronic', 'Folk', 'Funk', 'Hip-Hop/Rap', 'Holiday', 'Jazz', 'Soundtrack',
           'World', 'Metal', 'Pop', 'R&B/Soul', 'Rock'
         ],
-        type:       ['Tutorials', 'Sheet Music', 'Play Alongs', 'Jam Tracks'],
+        type:       ['Tutorials', 'Sheet Music', 'Play-Alongs', 'Jam Tracks'],
         progress:   PROGRESS_NAMES,
       },
       sortingOptions: {
@@ -446,7 +446,7 @@ const contentMetadata = {
           'Blues', 'Christian', 'Classical', 'Country', 'Disco', 'Electronic', 'Folk', 'Funk', 'Hip-Hop/Rap', 'Holiday', 'Jazz', 'Soundtrack',
           'World', 'Metal', 'Pop', 'R&B/Soul', 'Rock'
         ],
-        type:       ['Tutorials', 'Tabs', 'Play Alongs', 'Jam Tracks'],
+        type:       ['Tutorials', 'Tabs', 'Play-Alongs', 'Jam Tracks'],
         progress:   PROGRESS_NAMES,
       },
       sortingOptions: {
@@ -486,7 +486,7 @@ const contentMetadata = {
           'Blues', 'Christian', 'Classical', 'Country', 'Disco', 'Electronic', 'Folk', 'Funk', 'Hip-Hop/Rap', 'Holiday', 'Jazz', 'Soundtrack',
           'World', 'Metal', 'Pop', 'R&B/Soul', 'Rock'
         ],
-        type:       ['Tutorials', 'Sheet Music', 'Play Alongs', 'Jam Tracks'],
+        type:       ['Tutorials', 'Sheet Music', 'Play-Alongs', 'Jam Tracks'],
         progress:   PROGRESS_NAMES,
       },
       sortingOptions: {

--- a/src/contentMetaData.js
+++ b/src/contentMetaData.js
@@ -411,6 +411,14 @@ const contentMetadata = {
         Tabs.ExploreAll
       ],
     },
+    'recent': {
+      name: 'Recent Lessons',
+      tabs: [
+        Tabs.RecentAll,
+        Tabs.RecentIncomplete,
+        Tabs.RecentCompleted
+      ],
+    },
   },
   guitareo: {
     instructor: {
@@ -454,6 +462,14 @@ const contentMetadata = {
         Tabs.ExploreAll
       ],
     },
+    'recent': {
+      name: 'Recent Lessons',
+      tabs: [
+        Tabs.RecentAll,
+        Tabs.RecentIncomplete,
+        Tabs.RecentCompleted
+      ],
+    },
   },
   singeo: {
     'student-review': {
@@ -484,6 +500,14 @@ const contentMetadata = {
         Tabs.Transcriptions,
         Tabs.PlayAlongs,
         Tabs.ExploreAll
+      ],
+    },
+    'recent': {
+      name: 'Recent Lessons',
+      tabs: [
+        Tabs.RecentAll,
+        Tabs.RecentIncomplete,
+        Tabs.RecentCompleted
       ],
     },
   }

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -176,13 +176,14 @@ export const lessonTypesMapping = {
   'transcriptions': transcriptionsLessonTypes,
   'tabs': transcriptionsLessonTypes,
   'sheet music': transcriptionsLessonTypes,
-  'play alongs': playAlongLessonTypes,
+  'play-alongs': playAlongLessonTypes,
+  'jam tracks': ['jam-track'],
 };
 
 
 export const filterTypes = {
   lessons: [...individualLessonsTypes, ...collectionLessonTypes],
-  songs: [...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes]
+  songs: [...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes, 'jam-track'],
 }
 
 export const recentTypes = {


### PR DESCRIPTION
**Jira Ticket**
[MU2-473](https://musora.atlassian.net/browse/MU2-473?atlOrigin=eyJpIjoiZmIxOWIxZTE1YWJmNDQ5MGExYzI1ZjI0ZjM5NmY5MWEiLCJwIjoiaiJ9)

**Description**
Add hyphen between Play-Alongs in Filter Type

[MU2-473]: https://musora.atlassian.net/browse/MU2-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Recent Lessons" tab group with options for viewing all, incomplete, or completed recent lessons across Drumeo, Pianote, Guitareo, and Singeo brands.
	- Added support for filtering and categorizing "Jam Tracks" alongside existing song types.

- **Style**
	- Standardized the naming of the "Play-Alongs" content type for consistency across all supported brands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->