### PR TITLE
fix (MU2-403) - Add MCS call for auto practice when user watch a video

### DIFF
--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -253,6 +253,11 @@ export async function recordWatchSession(
   }
 
   await recordUserPractice({ content_id: contentId, duration_seconds: secondsPlayed })
+    try {
+      await recordUserPractice({ content_id: contentId, duration_seconds: secondsPlayed })
+    } catch (error) {
+      console.error('Failed to record user practice:', error)
+    }
 
   await dataContext.update(
     async function (localContext) {

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -6,6 +6,7 @@ import {
 } from './railcontent.js'
 import { DataContext, ContentProgressVersionKey } from './dataContext.js'
 import { fetchHierarchy } from './sanity.js'
+import {recordUserPractice} from "./userActivity";
 
 const STATE_STARTED = 'started'
 const STATE_COMPLETED = 'completed'
@@ -250,6 +251,9 @@ export async function recordWatchSession(
   if (!sessionId) {
     sessionId = uuidv4()
   }
+
+  await recordUserPractice({ content_id: contentId, duration_seconds: secondsPlayed })
+
   await dataContext.update(
     async function (localContext) {
       if (contentId && updateLocalProgress) {


### PR DESCRIPTION
Add MCS call for auto practice when user watch a video

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - User practice activity is now recorded automatically during watch sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->