### PR TITLE
fix (MU2-561) Update response structure for restoreUserPractice and getPracticeSessions

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -374,8 +374,8 @@ export async function restoreUserPractice(id) {
     });
   }
   const formattedMeta = await formatPracticeMeta(response.data);
-
-  return { data: formattedMeta, message: response.message, version: response.version };
+  const practiceDuration = formattedMeta.reduce((total, practice) => total + (practice.duration || 0), 0);
+  return { data: formattedMeta, message: response.message, version: response.version, practiceDuration };
 }
 
 /**
@@ -449,7 +449,7 @@ export async function restorePracticeSession(date) {
   const formattedMeta = await formatPracticeMeta(response?.data);
   const practiceDuration = formattedMeta.reduce((total, practice) => total + (practice.duration || 0), 0);
 
-  return { data: { practices: formattedMeta, practiceDuration} };
+  return { data: formattedMeta, practiceDuration};
 }
 
 /**


### PR DESCRIPTION
[MU2-561](https://musora.atlassian.net/browse/MU2-561?atlOrigin=eyJpIjoiNDUyZGJhMjJlN2RmNDE4OWFkZmQ4N2U5YjEyNDBkYmQiLCJwIjoiaiJ9)
 Update response structure for restoreUserPractice and getPracticeSessions to have same structure as getPracticeSessions(date)

[MU2-561]: https://musora.atlassian.net/browse/MU2-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved consistency in how user practice data is formatted and displayed across the application.
	- Practice session summaries now include standardized details such as duration, content type, and additional metadata.
	- Total practice duration is now calculated and shown in a more reliable and unified manner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->