### PR TITLE
feat(BEH-459): allow dark/light logos for courses

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1226,7 +1226,7 @@ export async function fetchLessonContent(railContentId) {
           slug, artist->,
           "thumbnail_url":thumbnail.asset->url, 
           "url": web_url_path,
-          "logo_image_url": logo_image_url.asset->url
+          "logo_image_url": logo_image_url.asset->url,
           "dark_logo": dark_mode_logo_url.asset->url,
           "light_logo": light_mode_logo_url.asset->url,
           soundslice_slug,


### PR DESCRIPTION
[MWP PR](https://github.com/railroadmedia/musora-web-platform/pull/2149)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lesson content now includes additional logo image URLs, providing access to standard, dark mode, and light mode logos where available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->