### PR TITLE
MU2-513 pinned progress row

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -978,12 +978,9 @@ export async function getProgressRows({ brand = null, limit = 8 } = {}) {
   if (pinnedItem) {
     pinnedItem.pinned = true
   }
-
   const pinnedId = pinnedItem?.id
-  const pinnedType = pinnedItem?.type || (pinnedItem?.raw?.type === 'playlist' ? 'playlist' : 'content')
-
-  const filteredProgressList = progressList.filter(item => item.id !== pinnedId || pinnedType !== 'content')
-  const filteredPlaylists = eligiblePlaylistItems.filter(item => item.id !== pinnedId || pinnedType !== 'playlist')
+  const filteredProgressList = progressList.filter(item => item.id !== pinnedId)
+  const filteredPlaylists = eligiblePlaylistItems.filter(item => item.id !== pinnedId)
 
   const combinedBase = [...filteredProgressList, ...filteredPlaylists]
   const combined = pinnedItem ? [pinnedItem, ...combinedBase] : combinedBase


### PR DESCRIPTION
[MU2-513](https://musora.atlassian.net/browse/MU2-513?atlOrigin=eyJpIjoiZDIzODVkNDFmODgxNGM3ZGJmZGFjYTRkNDYxZjI3MjEiLCJwIjoiaiJ9) - Update getProgressRows to Support Pinned Progress Items

Refactored getProgressRows logic to:
- Check if the user has a pinned progress row item.
- Ensure the pinned item is displayed first in the list.
- Avoid duplicate entries in the progress rows (pinned + regular).
- Handle cases where a default pinned item exists for the user.

Local Storage Integration:
- Pinned items are stored per brand in localStorage under the user key brand_pinned_progress.
- localStorage is updated whenever a progress row is pinned or unpinned by the user.