### PR TITLE
Hide certain Lessons filters

### DIFF
--- a/src/contentMetaData.js
+++ b/src/contentMetaData.js
@@ -210,7 +210,7 @@ const commonMetadata = {
     filterOptions: {
       difficulty: DIFFICULTY_STRINGS,
       style: ['Country/Folk', 'Funk/Disco', 'Hard Rock/Metal', 'Hip-Hop/Rap/EDM', 'Holiday/Soundtrack', 'Jazz/Blues', 'Latin/World', 'Pop/Rock', 'R&B/Soul', 'Worship/Gospel'],
-      type: ['Single Lessons', 'Practice Alongs', 'Performances', 'Courses', 'Shows', 'Documentaries', 'Live Archives', 'Student Archives'],
+      type: ['Single Lessons', 'Practice Alongs', 'Performances', 'Courses', 'Live Archives', 'Student Archives'],
       progress: PROGRESS_NAMES,
     },
     sortingOptions: {
@@ -392,7 +392,7 @@ const contentMetadata = {
       filterOptions: {
         difficulty: DIFFICULTY_STRINGS,
         style: ['Classical', 'Country/Folk', 'Funk/Disco', 'Hip-Hop/Rap/EDM', 'Holiday/Soundtrack', 'Jazz/Blues', 'Latin/World', 'Pop/Rock', 'R&B/Soul', 'Worship/Gospel'],
-        type: ['Single Lessons', 'Practice Alongs', 'Performances', 'Courses', 'Shows', 'Documentaries', 'Live Archives', 'Student Archives'],
+        type: ['Single Lessons', 'Practice Alongs', 'Performances', 'Courses', 'Live Archives', 'Student Archives'],
         progress: PROGRESS_NAMES,
       },
       tabs: [


### PR DESCRIPTION
**Jira Ticket**
[MU2-518](https://musora.atlassian.net/browse/MU2-518?atlOrigin=eyJpIjoiMzU4ODQ4MTQyZDRhNDM0YjhhNGNjNzE1MTA4M2M2M2UiLCJwIjoiaiJ9)

**Description**
Shows & Documentaries are only available for Drumeo

[MU2-518]: https://musora.atlassian.net/browse/MU2-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated lesson filters to remove "Shows" and "Documentaries" options for a more focused browsing experience. Only relevant lesson types are now available when filtering content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->