### PR TITLE
fix (BEH-122) need_access_on_challenge

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1968,9 +1968,8 @@ function needsAccessDecorator(results, userPermissions, isAdmin) {
         result.lessons.forEach((lesson) => {
           lesson['need_access'] = doesUserNeedAccessToContent(lesson, userPermissions, isAdmin) // Updated to check lesson access
         })
-      } else {
-        result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin)
       }
+      result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin)
     })
   } else if (results.related_lessons && Array.isArray(results.related_lessons)) {
     results.related_lessons.forEach((result) => {


### PR DESCRIPTION
[MWP PR](https://github.com/railroadmedia/musora-web-platform/pull/2155)

Changes:
- `needs_access` flag is now also set to the parent lesson when pulling data from sanity, previously only children lessons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access handling so that both parent items and their associated lessons now consistently display access requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->