### PR TITLE
Add displayBrowseAll to get progress rows method

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1007,6 +1007,7 @@ export async function getProgressRows({ brand = null, limit = 8 } = {}) {
 
   return {
     type: TabResponseType.PROGRESS_ROWS,
+    displayBrowseAll: combined.length > limit,
     data: results
   };
 }


### PR DESCRIPTION
Add displayBrowseAll to get progress rows method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new indicator to show when the "Browse All" option should be displayed, based on the number of items in your progress and playlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->