### PR TITLE
MU2-606: Add live related fields: live_event_start_time, live_event_end_time, …

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1252,6 +1252,7 @@ export async function jumpToContinueContent(railcontentId) {
  */
 export async function fetchLessonContent(railContentId) {
   const filterParams = { isSingle: true, pullFutureContent: true }
+  const now = getSanityDate(new Date())
   // Format changes made to the `fields` object may also need to be reflected in Musora-web-platform SanityGateway.php $fields object
   // Currently only for challenges and challenge lessons
   // If you're unsure, message Adrian, or just add them.
@@ -1305,7 +1306,16 @@ export async function fetchLessonContent(railContentId) {
           },
           sort,
           xp,
-          stbs,ds2stbs, bdsStbs`
+          stbs,ds2stbs, bdsStbs,
+          ...select(
+                defined(live_event_start_time) && defined(live_event_end_time) => {
+                  "isLive": live_event_start_time <= '${now}' && live_event_end_time >= '${now}',
+                  "live_event_start_time": live_event_start_time,
+                  "live_event_end_time": live_event_end_time,
+                  "live_event_youtube_id": live_event_youtube_id,
+                  "videoId": coalesce(live_event_youtube_id, video.external_id),
+                }
+              )`
   const query = await buildQuery(`railcontent_id == ${railContentId}`, filterParams, fields, {
     isSingle: true,
   })

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1252,7 +1252,6 @@ export async function jumpToContinueContent(railcontentId) {
  */
 export async function fetchLessonContent(railContentId) {
   const filterParams = { isSingle: true, pullFutureContent: true }
-  const now = getSanityDate(new Date())
   // Format changes made to the `fields` object may also need to be reflected in Musora-web-platform SanityGateway.php $fields object
   // Currently only for challenges and challenge lessons
   // If you're unsure, message Adrian, or just add them.
@@ -1309,7 +1308,6 @@ export async function fetchLessonContent(railContentId) {
           stbs,ds2stbs, bdsStbs,
           ...select(
                 defined(live_event_start_time) && defined(live_event_end_time) => {
-                  "isLive": live_event_start_time <= '${now}' && live_event_end_time >= '${now}',
                   "live_event_start_time": live_event_start_time,
                   "live_event_end_time": live_event_end_time,
                   "live_event_youtube_id": live_event_youtube_id,
@@ -1320,6 +1318,10 @@ export async function fetchLessonContent(railContentId) {
     isSingle: true,
   })
   const chapterProcess = (result) => {
+    const now = getSanityDate(new Date(), false)
+    if(result.live_event_start_time && result.live_event_start_time){
+      result.isLive = result.live_event_start_time <= now && result.live_event_end_time >= now
+    }
     const chapters = result.chapters ?? []
     if (chapters.length == 0) return result
     result.chapters = chapters.map((chapter, index) => ({


### PR DESCRIPTION
**JIra Ticket**
[MU2-606](https://musora.atlassian.net/browse/MU2-606?atlOrigin=eyJpIjoiNjJmOTZjOWFhNTgyNDUzOTlhN2Q1YWQ4Nzk4MWYwNGIiLCJwIjoiaiJ9)

**Description**
Update fetchLessonContent MCS method to check if lesson is live
If the lesson is live add live related fields: live_event_start_time, live_event_end_time, live_event_youtube_id, videoId and isLive

[MU2-606]: https://musora.atlassian.net/browse/MU2-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lesson content now displays live event information, including live status, event start and end times, and related video identifiers when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->