### PR TITLE
Add needs access for lessons for single results.

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1979,6 +1979,11 @@ function needsAccessDecorator(results, userPermissions, isAdmin) {
       result['need_access'] = doesUserNeedAccessToContent(result, userPermissions, isAdmin)
     })
   } else {
+    if (results.lessons) {
+      results.lessons.forEach((lesson) => {
+        lesson['need_access'] = doesUserNeedAccessToContent(lesson, userPermissions, isAdmin) // Updated to check lesson access
+      })
+    }
     results['need_access'] = doesUserNeedAccessToContent(results, userPermissions, isAdmin)
   }
 

--- a/src/services/userPermissions.js
+++ b/src/services/userPermissions.js
@@ -15,7 +15,7 @@ let userPermissionsPromise = null
 let lastUpdatedKey = `userPermissions_lastUpdated`
 
 export async function fetchUserPermissions() {
-  if (!userPermissionsPromise || wasLastUpdateOlderThanXSeconds(10, lastUpdatedKey)) {
+  if (!userPermissionsPromise || (await wasLastUpdateOlderThanXSeconds(10, lastUpdatedKey))) {
     userPermissionsPromise = fetchUserPermissionsData()
     setLastUpdatedTime(lastUpdatedKey)
   }

--- a/test/lastUpdated.test.js
+++ b/test/lastUpdated.test.js
@@ -11,11 +11,11 @@ describe('lastUpdated', function () {
 
   test('lastUpdated', async () => {
     setLastUpdatedTime('testKey')
-    let test1 = wasLastUpdateOlderThanXSeconds(1, 'testKey')
+    let test1 = await wasLastUpdateOlderThanXSeconds(1, 'testKey')
     await new Promise((r) => setTimeout(r, 800))
-    let test2 = wasLastUpdateOlderThanXSeconds(1, 'testKey')
+    let test2 = await wasLastUpdateOlderThanXSeconds(1, 'testKey')
     await new Promise((r) => setTimeout(r, 500))
-    let test3 = wasLastUpdateOlderThanXSeconds(1, 'testKey')
+    let test3 = await wasLastUpdateOlderThanXSeconds(1, 'testKey')
 
     expect(test1).toEqual(false)
     expect(test2).toEqual(false)


### PR DESCRIPTION
Add needs access for lessons for single results.
Fix issues with wasLastUpdateOlderThanXSeconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of access checks for individual lessons within search results.
  - Ensured user permission checks are performed correctly by properly handling asynchronous operations.

- **Tests**
  - Updated tests to correctly handle asynchronous functions, improving reliability of test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->