### PR TITLE
New method getStartedOrCompletedProgressOnly for FE

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,6 +59,7 @@ import {
 	getProgressStateByIds,
 	getResumeTimeSeconds,
 	getResumeTimeSecondsByIds,
+	getStartedOrCompletedProgressOnly,
 	recordWatchSession
 } from './services/contentProgress.js';
 
@@ -417,6 +418,7 @@ declare module 'musora-content-services' {
 		getResumeTimeSecondsByIds,
 		getScheduleContentRows,
 		getSortOrder,
+		getStartedOrCompletedProgressOnly,
 		getTabResults,
 		getTimeRemainingUntilLocal,
 		getUserMonthlyStats,

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ import {
 	getProgressStateByIds,
 	getResumeTimeSeconds,
 	getResumeTimeSecondsByIds,
+	getStartedOrCompletedProgressOnly,
 	recordWatchSession
 } from './services/contentProgress.js';
 
@@ -416,6 +417,7 @@ export {
 	getResumeTimeSecondsByIds,
 	getScheduleContentRows,
 	getSortOrder,
+	getStartedOrCompletedProgressOnly,
 	getTabResults,
 	getTimeRemainingUntilLocal,
 	getUserMonthlyStats,

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -151,6 +151,40 @@ export async function getAllStartedOrCompleted({ limit = null, onlyIds = true, b
   }
 }
 
+/**
+ * Simplified version of `getAllStartedOrCompleted`.
+ *
+ * Fetches content IDs and progress percentages for items that were
+ * started or completed.
+ *
+ * @param {Object} [options={}] - Optional filtering options.
+ * @param {string|null} [options.brand=null] - Brand to filter by (e.g., 'drumeo').
+ * @returns {Promise<Object>} - A map of content ID to progress value:
+ *   {
+ *     [id]: progressPercentage
+ *   }
+ *
+ * @example
+ * const progressMap = await getStartedOrCompletedProgressOnly({ brand: 'drumeo' });
+ * console.log(progressMap[123]); // => 52
+ */
+export async function getStartedOrCompletedProgressOnly({ brand = null} = {}) {
+  const data = await dataContext.getData()
+  const result = {}
+
+  Object.entries(data).forEach(([key, item]) => {
+    const id = parseInt(key)
+    const isRelevantStatus = item[DATA_KEY_STATUS] === STATE_STARTED || item[DATA_KEY_STATUS] === STATE_COMPLETED
+    const isCorrectBrand = !brand || item.b === brand
+
+    if (isRelevantStatus && isCorrectBrand) {
+      result[id] = item?.[DATA_KEY_PROGRESS] ?? 0
+    }
+  })
+
+  return result
+}
+
 export async function assignmentStatusCompleted(assignmentId, parentContentId) {
   await dataContext.update(
     async function (localContext) {


### PR DESCRIPTION
[MU2-478](https://musora.atlassian.net/browse/MU2-478?atlOrigin=eyJpIjoiYWYyMmE5ODRmN2JhNDEyZGFhZjMwZTMzMDgwZGNiZGQiLCJwIjoiaiJ9)

simplified version of getAllStartedOrCompleted method
will be used by FE for content progress

[MU2-478]: https://musora.atlassian.net/browse/MU2-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new function to retrieve progress percentages for content items that are either started or completed, with optional filtering by brand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->