### PR TITLE
Add live_event_is_global for live events and remove live_event_end_ti…

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1307,11 +1307,12 @@ export async function fetchLessonContent(railContentId) {
           xp,
           stbs,ds2stbs, bdsStbs,
           ...select(
-                defined(live_event_start_time) && defined(live_event_end_time) => {
+                defined(live_event_start_time) => {
                   "live_event_start_time": live_event_start_time,
                   "live_event_end_time": live_event_end_time,
                   "live_event_youtube_id": live_event_youtube_id,
                   "videoId": coalesce(live_event_youtube_id, video.external_id),
+                  "live_event_is_global": live_global_event == true
                 }
               )`
   const query = await buildQuery(`railcontent_id == ${railContentId}`, filterParams, fields, {


### PR DESCRIPTION
[MU-678](https://musora.atlassian.net/browse/MU2-678?atlOrigin=eyJpIjoiN2E2NTJmMTc4MTBiNDM0NmE3NTVkODBmZmM4N2U5MGIiLCJwIjoiaiJ9): Add live_event_is_global for live events and remove live_event_end_time restriction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lesson content now includes an indicator showing whether a live event is global.
- **Enhancements**
  - Live event timing information is now available for lessons with a defined start time, even if the end time is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->