### PR TITLE
fix(BEH-547): collection modules updates

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1442,7 +1442,7 @@ export async function fetchRelatedLessons(railContentId, brand) {
       ...(*[${filterSameType}]{${queryFields}}|order(published_on desc, title asc)[0...10])
       ,
       ])[0...10]}`
-  let result = fetchSanity(query, false)
+  let result = await fetchSanity(query, false)
 
   //there's no way in sanity to retrieve the index of an array, so we must calculate after fetch
   if (result['for-calculations']['parents-list']) {

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1447,9 +1447,9 @@ export async function fetchRelatedLessons(railContentId, brand) {
   //there's no way in sanity to retrieve the index of an array, so we must calculate after fetch
   if (result['for-calculations']['parents-list']) {
     const calc = result['for-calculations']
-    const parentCount = calc['parents-count'].length
+    const parentCount = calc['parents-list'].length
     const currentParent = calc['parents-list'].indexOf(result['parent_id']);
-    const siblingCount = calc['siblings-count'].length
+    const siblingCount = calc['siblings-list'].length
     const currentSibling = calc['siblings-list'].indexOf(result['railcontent_id']);
 
     delete result['for-calculations']

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1453,7 +1453,8 @@ export async function fetchRelatedLessons(railContentId, brand) {
     const currentSibling = calc['siblings-list'].indexOf(result['railcontent_id']);
 
     delete result['for-calculations']
-    return {...result, parentCount, currentParent, siblingCount, currentSibling}
+    result = {...result, parentCount, currentParent, siblingCount, currentSibling}
+    return result
   }
 }
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1455,6 +1455,9 @@ export async function fetchRelatedLessons(railContentId, brand) {
     delete result['for-calculations']
     result = {...result, parentCount, currentParent, siblingCount, currentSibling}
     return result
+  } else {
+    delete result['for-calculations']
+    return result
   }
 }
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1448,9 +1448,9 @@ export async function fetchRelatedLessons(railContentId, brand) {
   if (result['for-calculations']['parents-list']) {
     const calc = result['for-calculations']
     const parentCount = calc['parents-list'].length
-    const currentParent = calc['parents-list'].indexOf(result['parent_id']);
+    const currentParent = (calc['parents-list'].indexOf(result['parent_id']) + 1)
     const siblingCount = calc['siblings-list'].length
-    const currentSibling = calc['siblings-list'].indexOf(result['railcontent_id']);
+    const currentSibling = (calc['siblings-list'].indexOf(result['railcontent_id']) + 1)
 
     delete result['for-calculations']
     result = {...result, parentCount, currentParent, siblingCount, currentSibling}

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1431,7 +1431,7 @@ export async function fetchRelatedLessons(railContentId, brand) {
   const query = `*[railcontent_id == ${railContentId} && brand == "${brand}" && (!defined(permission) || references(*[_type=='permission']._id))]{
    _type, parent_type, 'parent_id': parent_content_data[0].id, railcontent_id,
    'for-calculations': *[references(^._id)][0]{
-    'children-list': child[],
+    'siblings-list': child[],
     'parents-list': *[references(^._id)][0].child[]
     },
     "related_lessons" : array::unique([
@@ -1449,11 +1449,11 @@ export async function fetchRelatedLessons(railContentId, brand) {
     const calc = result['for-calculations']
     const parentCount = calc['parents-count']
     const currentParent = calc['parents-list'].indexOf(result['parent_id']);
-    const childCount = calc['children-count']
-    const currentChild = calc['children-list'].indexOf(result['railcontent_id']);
+    const siblingCount = calc['siblings-count']
+    const currentSibling = calc['siblings-list'].indexOf(result['railcontent_id']);
 
     delete result['for-calculations']
-    return {...result, parentCount, currentParent, childCount, currentChild}
+    return {...result, parentCount, currentParent, siblingCount, currentSibling}
   }
 }
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1413,18 +1413,18 @@ async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, cou
  */
 export async function fetchRelatedLessons(railContentId, brand) {
   const filterSameTypeAndSortOrder = await new FilterBuilder(
-    `_type==^._type &&  _type in ${JSON.stringify(typeWithSortOrder)} && brand == "${brand}" && railcontent_id !=${railContentId}`
+    `_type==^._type &&  _type in ${JSON.stringify(typeWithSortOrder)} && brand == "${brand}" && railcontent_id !=${railContentId}`, {pullFutureContent: true}
   ).buildFilter()
   const filterSameType = await new FilterBuilder(
-    `_type==^._type && !(_type in ${JSON.stringify(typeWithSortOrder)}) && !(defined(parent_type)) && brand == "${brand}" && railcontent_id !=${railContentId}`
+    `_type==^._type && !(_type in ${JSON.stringify(typeWithSortOrder)}) && !(defined(parent_type)) && brand == "${brand}" && railcontent_id !=${railContentId}`, {pullFutureContent: true}
   ).buildFilter()
   const filterSongSameArtist = await new FilterBuilder(
-    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.artist->_id) && railcontent_id !=${railContentId}`
+    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.artist->_id) && railcontent_id !=${railContentId}`, {pullFutureContent: true}
   ).buildFilter()
   const filterSongSameGenre = await new FilterBuilder(
-    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.genre[]->_id) && railcontent_id !=${railContentId}`
+    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.genre[]->_id) && railcontent_id !=${railContentId}`, {pullFutureContent: true}
   ).buildFilter()
-  const filterNeighbouringSiblings = await new FilterBuilder(`references(^._id)`).buildFilter()
+  const filterNeighbouringSiblings = await new FilterBuilder(`references(^._id)`, {pullFutureContent: true}).buildFilter()
   const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
   const queryFields = `_id, "id":railcontent_id, published_on, "instructor": instructor[0]->name, title, "thumbnail":thumbnail.asset->url, length_in_seconds, web_url_path, "type": _type, difficulty, difficulty_string, railcontent_id, artist->,"permission_id": permission[]->railcontent_id,_type, "genre": genre[]->name`
   const queryFieldsWithSort = queryFields + ', sort'

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1430,7 +1430,7 @@ export async function fetchRelatedLessons(railContentId, brand) {
   const queryFieldsWithSort = queryFields + ', sort'
   const query = `*[railcontent_id == ${railContentId} && brand == "${brand}" && (!defined(permission) || references(*[_type=='permission']._id))]{
    _type, parent_type, 'parent_id': parent_content_data[0].id, railcontent_id,
-   'for-calculations': *[references(^._id)][0]{
+   'for-calculations': *[references(^._id) && !(_type in ['license'])][0]{
     'siblings-list': child[]->railcontent_id,
     'parents-list': *[references(^._id)][0].child[]->railcontent_id
     },

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1413,16 +1413,16 @@ async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, cou
  */
 export async function fetchRelatedLessons(railContentId, brand) {
   const filterSameTypeAndSortOrder = await new FilterBuilder(
-    `_type==^._type &&  _type in ${JSON.stringify(typeWithSortOrder)} && brand == "${brand}" && railcontent_id !=${railContentId}`, {pullFutureContent: true}
+    `_type==^._type &&  _type in ${JSON.stringify(typeWithSortOrder)} && brand == "${brand}" && railcontent_id !=${railContentId}`,
   ).buildFilter()
   const filterSameType = await new FilterBuilder(
-    `_type==^._type && !(_type in ${JSON.stringify(typeWithSortOrder)}) && !(defined(parent_type)) && brand == "${brand}" && railcontent_id !=${railContentId}`, {pullFutureContent: true}
+    `_type==^._type && !(_type in ${JSON.stringify(typeWithSortOrder)}) && !(defined(parent_type)) && brand == "${brand}" && railcontent_id !=${railContentId}`,
   ).buildFilter()
   const filterSongSameArtist = await new FilterBuilder(
-    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.artist->_id) && railcontent_id !=${railContentId}`, {pullFutureContent: true}
+    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.artist->_id) && railcontent_id !=${railContentId}`,
   ).buildFilter()
   const filterSongSameGenre = await new FilterBuilder(
-    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.genre[]->_id) && railcontent_id !=${railContentId}`, {pullFutureContent: true}
+    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.genre[]->_id) && railcontent_id !=${railContentId}`,
   ).buildFilter()
   const filterNeighbouringSiblings = await new FilterBuilder(`references(^._id)`, {pullFutureContent: true}).buildFilter()
   const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1431,8 +1431,8 @@ export async function fetchRelatedLessons(railContentId, brand) {
   const query = `*[railcontent_id == ${railContentId} && brand == "${brand}" && (!defined(permission) || references(*[_type=='permission']._id))]{
    _type, parent_type, 'parent_id': parent_content_data[0].id, railcontent_id,
    'for-calculations': *[references(^._id)][0]{
-    'siblings-list': child[],
-    'parents-list': *[references(^._id)][0].child[]
+    'siblings-list': child[]->railcontent_id,
+    'parents-list': *[references(^._id)][0].child[]->railcontent_id
     },
     "related_lessons" : array::unique([
       ...(*[${filterNeighbouringSiblings}][0].child[${childrenFilter}]->{${queryFields}}),
@@ -1447,9 +1447,9 @@ export async function fetchRelatedLessons(railContentId, brand) {
   //there's no way in sanity to retrieve the index of an array, so we must calculate after fetch
   if (result['for-calculations']['parents-list']) {
     const calc = result['for-calculations']
-    const parentCount = calc['parents-count']
+    const parentCount = calc['parents-count'].length
     const currentParent = calc['parents-list'].indexOf(result['parent_id']);
-    const siblingCount = calc['siblings-count']
+    const siblingCount = calc['siblings-count'].length
     const currentSibling = calc['siblings-list'].indexOf(result['railcontent_id']);
 
     delete result['for-calculations']

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1431,8 +1431,8 @@ export async function fetchRelatedLessons(railContentId, brand) {
   const query = `*[railcontent_id == ${railContentId} && brand == "${brand}" && (!defined(permission) || references(*[_type=='permission']._id))]{
    _type, parent_type, 'parent_id': parent_content_data[0].id, railcontent_id,
    'for-calculations': *[references(^._id)][0]{
-    'lessons-list': child[],
-    'courses-list': *[references(^._id)][0].child[]
+    'children-list': child[],
+    'parents-list': *[references(^._id)][0].child[]
     },
     "related_lessons" : array::unique([
       ...(*[${filterNeighbouringSiblings}][0].child[${childrenFilter}]->{${queryFields}}),
@@ -1445,14 +1445,15 @@ export async function fetchRelatedLessons(railContentId, brand) {
   let result = fetchSanity(query, false)
 
   //there's no way in sanity to retrieve the index of an array, so we must calculate after fetch
-  if (result['for-calculations']['courses-list']) {
+  if (result['for-calculations']['parents-list']) {
     const calc = result['for-calculations']
-    const courseCount = calc['courses-count']
-    const currentCourse = calc['courses-list'].indexOf(result['parent_id']);
-    const lessonCount = calc['lessons-count']
-    const currentLesson = calc['lessons-list'].indexOf(result['railcontent_id']);
-    //append
-    return result = {...result, courseCount, currentCourse, lessonCount, currentLesson}
+    const parentCount = calc['parents-count']
+    const currentParent = calc['parents-list'].indexOf(result['parent_id']);
+    const childCount = calc['children-count']
+    const currentChild = calc['children-list'].indexOf(result['railcontent_id']);
+
+    delete result['for-calculations']
+    return {...result, parentCount, currentParent, childCount, currentChild}
   }
 }
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1461,11 +1461,6 @@ export async function fetchRelatedLessons(railContentId, brand) {
   }
 }
 
-
-
-
-
-
 /**
  * Fetch all packs.
  * @param {string} brand - The brand for which to fetch packs.


### PR DESCRIPTION
## Jira
- [BEH-457](https://musora.atlassian.net/browse/BEH-547)

## Changes
- updates mcs function used for Collection Modules to return data about current lesson position, if applicable
- updates sibling content query to pull future content

## testing
course position info:
- run `fetchRelatedLessons(209405, 'drumeo')` in mpf devEndpoint
- use this qroq query to find all the course and lesson railcontent_ids, for use in the above function
```
*[railcontent_id == 206307]{
  'for-calculations': *[references(^._id) && !(_type in ['license'])][0]{
    'pack-data': *[references(^._id) && !(_type in ['license'])][0]{'pack_id': railcontent_id, 'courses': child[]->{'course_id': railcontent_id, 'child_ids':child[]->railcontent_id}}
  }
}
```
- try this function with several lesson ids and verify the `currentParent` and `currentSibling` are correct (off by one bcs lessons start at 1)
- verify we don't return any of these new parent/child fields when its not a pack/2-layer content: (try this course lesson: 

pulling future content:
- set a pack or course lesson to Scheduled and scheduled_on date to future.
- verify this lesson is returned in related_lessons from the function, when the parameter is a sibling of that content
- set a song to Scheduled and scheduled_on date to future.
- verify this lesson is not returned in related_lessons from the function, when the parameter is a song related by that contents genre 

[BEH-457]: https://musora.atlassian.net/browse/BEH-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced related lessons data to include parent and sibling counts, as well as the position of the current lesson among parents and siblings.

- **Bug Fixes**
  - Improved accuracy of related lesson relationships by refining how parent and sibling information is calculated and presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->