### PR TITLE
feat(MU2-712): Add live_event_start_time and live_event_end_time on fetchUpcomingEvents

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -405,6 +405,8 @@ export async function fetchUpcomingEvents(brand, { page = 1, limit = 10 } = {}) 
         "type": _type,
         web_url_path,
         "permission_id": permission[]->railcontent_id,
+        live_event_start_time,
+        live_event_end_time,
          "isLive": live_event_start_time <= '${now}' && live_event_end_time >= '${now}'`
   const query = buildRawQuery(
     `defined(live_event_start_time) && (!defined(live_event_end_time) || live_event_end_time >= '${now}' ) && brand == '${brand}' && published_on > '${now}' && status == 'scheduled'`,


### PR DESCRIPTION
[Add live_event_start_time and live_event_end_time on fetchUpcomingEvents](https://github.com/railroadmedia/musora-content-services/commit/9e646faf5951b88e9ae6e70e2aee3edab589bd87)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upcoming events now display more accurate live status by considering both event start and end times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->