### PR TITLE
refactor(MU2-724): Add fallback to recommended content if none are returned from recsys

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1345,7 +1345,7 @@ export async function fetchLessonContent(railContentId) {
  * @returns {Promise<Array<Object>>}
  */
 export async function fetchRelatedRecommendedContent(railContentId, brand, count = 10) {
-  const recommendedItems = null // await fetchSimilarItems(railContentId, brand, count)
+  const recommendedItems = await fetchSimilarItems(railContentId, brand, count)
   if (recommendedItems && recommendedItems.length > 0) {
     return fetchByRailContentIds(recommendedItems)
   }
@@ -1514,7 +1514,7 @@ export async function fetchPackAll(railcontentId, type = 'pack') {
 }
 
 export async function fetchLiveEvent(brand, forcedContentId = null) {
-  const LIVE_EXTRA_MINUTES = 30;
+  const LIVE_EXTRA_MINUTES = 30
   //calendarIDs taken from addevent.php
   // TODO import instructor calendars to Sanity
   let defaultCalendarID = ''
@@ -1536,8 +1536,10 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
   }
   let startDateTemp = new Date()
   let endDateTemp = new Date()
- 
-  startDateTemp = new Date(startDateTemp.setMinutes(startDateTemp.getMinutes() + LIVE_EXTRA_MINUTES))
+
+  startDateTemp = new Date(
+    startDateTemp.setMinutes(startDateTemp.getMinutes() + LIVE_EXTRA_MINUTES)
+  )
   endDateTemp = new Date(endDateTemp.setMinutes(endDateTemp.getMinutes() - LIVE_EXTRA_MINUTES))
 
   // See LiveStreamEventService.getCurrentOrNextLiveEvent for some nice complicated logic which I don't think is actually importart


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [MU2-724](https://musora.atlassian.net/browse/MU2-724)

## Description/Design

- Add a fallback to `fetchRelatedLessons` in case RecSys doesn't return recommendations.
- Fix a check on live metadata when fetching lesson data from sanity
## Testing

Using FE devendpoint (https://devapp.musora.com:5174/devendpoint):
- Use `fetchRelatedRecommendedContent` to fetch recommendations for content_id 416440 on staging dataset;
  - `fetchSimilarItems` returns 0 recommendations from recsys
- Check `fetchRelatedRecommendedContent` returned recommended items based on `fetchRelatedLessons`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of content recommendations by adding a fallback mechanism when no similar items are found.
	- Fixed a redundant condition in lesson content retrieval to ensure accurate event checks.

- **Style**
	- Enhanced code readability through consistent formatting and spacing adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MU2-724]: https://musora.atlassian.net/browse/MU2-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ