### PR TITLE
fix(MU2-608): Sort recent lessons by user progress

### DIFF
--- a/src/services/content.js
+++ b/src/services/content.js
@@ -19,7 +19,7 @@ import {recommendations} from "./recommendations";
 
 
 export async function getLessonContentRows (brand='drumeo', pageName = 'lessons') {
-  let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent' });
+  let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent', limit: 10 });
 
   let contentRows = await getContentRows(brand, pageName);
   contentRows = Array.isArray(contentRows) ? contentRows : [];

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -118,7 +118,7 @@ export async function getAllStartedOrCompleted({ limit = null, onlyIds = true, b
       const isRelevantStatus =
         item[DATA_KEY_STATUS] === STATE_STARTED || item[DATA_KEY_STATUS] === STATE_COMPLETED
       const isRecent = item[DATA_KEY_LAST_UPDATED_TIME] >= oneMonthAgoInSeconds
-      const isCorrectBrand = !brand || item.b === brand
+      const isCorrectBrand = !brand || !item.b || item.b === brand
       const isNotExcluded = !excludedSet.has(id)
       return isRelevantStatus && isRecent && isCorrectBrand && isNotExcluded
     })

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -888,11 +888,11 @@ async function getProgressFilter(progress, progressIds) {
       return `&& !(railcontent_id in [${ids.join(',')}])`
     }
     case 'recent': {
-      const ids = await getAllStartedOrCompleted()
+      const ids = progressIds !== undefined ? progressIds : await getAllStartedOrCompleted()
       return `&& (railcontent_id in [${ids.join(',')}])`
     }
     case 'incomplete': {
-      const ids = await getAllStarted()
+      const ids = progressIds !== undefined ? progressIds :await getAllStarted()
       return `&& railcontent_id in [${ids.join(',')}]`
     }
     default:
@@ -2175,12 +2175,12 @@ async function buildQuery(
 function buildEntityAndTotalQuery(
   filter = '',
   fields = '...',
-  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false }
+  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false, withoutPagination = false }
 ) {
-  const sortString = sortOrder ? `order(${sortOrder})` : ''
-  const countString = isSingle ? '[0...1]' : `[${start}...${end}]`
+  const sortString = sortOrder ? ` | order(${sortOrder})` : ''
+  const countString = isSingle ? '[0...1]' : (withoutPagination ? ``: `[${start}...${end}]`)
   const query = `{
-      "entity": *[${filter}] | ${sortString}${countString}
+      "entity": *[${filter}]  ${sortString}${countString}
       {
         ${fields}
       },
@@ -2299,16 +2299,31 @@ export async function fetchTabData(
 ) {
   const start = (page - 1) * limit
   const end = start + limit
-
+  let withoutPagination = false
   // Construct the included fields filter, replacing 'difficulty' with 'difficulty_string'
   const includedFieldsFilter =
     includedFields.length > 0 ? filtersToGroq(includedFields, [], pageName) : ''
 
+  let sortOrder = getSortOrder(sort, brand, '')
+
+  switch (progress) {
+    case 'recent':
+      progressIds = await getAllStartedOrCompleted({ brand, onlyIds: true });
+      sortOrder = null;
+      withoutPagination = true;
+      break;
+    case 'incomplete':
+      progressIds = await getAllStarted();
+      sortOrder = null;
+      break;
+    case 'completed':
+      progressIds = await getAllCompleted();
+      sortOrder = null;
+      break;
+  }
+
   // limits the results to supplied progressIds for started & completed filters
   const progressFilter = await getProgressFilter(progress, progressIds)
-
-  // Determine the sort order
-  const sortOrder = getSortOrder(sort, brand, '')
 
   let fields = DEFAULT_FIELDS
   let fieldsString = fields.join(',')
@@ -2336,9 +2351,23 @@ export async function fetchTabData(
     sortOrder: sortOrder,
     start: start,
     end: end,
+    withoutPagination: withoutPagination,
   })
 
-  return fetchSanity(query, true)
+  let results = await fetchSanity(query, true);
+
+  if (['recent', 'incomplete', 'completed'].includes(progress) && results.entity.length > 1) {
+    const orderMap = new Map(progressIds.map((id, index) => [id, index]))
+    results.entity = results.entity
+      .sort((a, b) => {
+        const aIdx = orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+        const bIdx = orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+        return aIdx - bIdx || new Date(b.published_on) - new Date(a.published_on);
+      })
+      .slice(start, end);
+  }
+
+  return results;
 }
 
 export async function fetchRecent(


### PR DESCRIPTION
MU2-608: Sort recent lessons by user progress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering and sorting options for progress-based content, including improved handling of recent, incomplete, and completed progress states.
  - Results for certain progress filters are now ordered to match user progress and sliced for pagination after sorting.

- **Bug Fixes**
  - Broadened brand filtering to include items without a brand when a brand filter is applied.

- **Improvements**
  - Limited the number of recent content items shown to 10 for a more focused experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->