### PR TITLE
feat(TP-947): Clear stored DataContext on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.12.0](https://github.com/railroadmedia/musora-content-services/compare/v2.11.0...v2.12.0) (2025-06-25)
+
+
+### Features
+
+* **MU2-478:** simplified version of getAllStartedOrCompleted method ([b58b97b](https://github.com/railroadmedia/musora-content-services/commit/b58b97bcf95db7ad71019848dbf5e5b508adeeb8))
+
+
+### Bug Fixes
+
+* **MU2-608:** Sort recent lessons by user progress ([e966ffc](https://github.com/railroadmedia/musora-content-services/commit/e966ffcd87847ee6b72d35bed84967ee8fd1db44))
+* **MU2-730:** Pagination on fetchNotifications method ([37e95db](https://github.com/railroadmedia/musora-content-services/commit/37e95dbaacca06a1e408db8a5d6dead3dfb23550))
+* Pagination on fetchNotifications method ([9e613b9](https://github.com/railroadmedia/musora-content-services/commit/9e613b9227bb188814ebc2d8c084c18e115fbcc3))
+
 ### [2.11.1](https://github.com/railroadmedia/musora-content-services/compare/v2.11.0...v2.11.1) (2025-06-24)
 
 ## [2.11.0](https://github.com/railroadmedia/musora-content-services/compare/v2.10.0...v2.11.0) (2025-06-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.11.1](https://github.com/railroadmedia/musora-content-services/compare/v2.11.0...v2.11.1) (2025-06-24)
+
 ## [2.11.0](https://github.com/railroadmedia/musora-content-services/compare/v2.10.0...v2.11.0) (2025-06-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.11.0](https://github.com/railroadmedia/musora-content-services/compare/v2.10.0...v2.11.0) (2025-06-24)
+
+
+### Features
+
+* **MU2-698:** change extra minutes from 15 to 30 ([ccb1a96](https://github.com/railroadmedia/musora-content-services/commit/ccb1a9682c0d75a61743645434fb1ae5398ca509))
+* **MU2-712:** Add live_event_start_time and live_event_end_time on fetchUpcomingEvents ([0de3f8e](https://github.com/railroadmedia/musora-content-services/commit/0de3f8ea68a2a8d29d122f6adf2d893669d3bd25))
+
+
+### Bug Fixes
+
+* Duplicate practice per day in cache ([d44e0f6](https://github.com/railroadmedia/musora-content-services/commit/d44e0f6a384e78b5d515bcafc99cba30b24a535d))
+* **MU2-693:** Fix cache(data versioning) on user practices ([ddc0d3b](https://github.com/railroadmedia/musora-content-services/commit/ddc0d3b3bd180c0f51241112ce7ba2094ff71c8c))
+* User practice cache generation after one practice is restored ([dfb9e27](https://github.com/railroadmedia/musora-content-services/commit/dfb9e271e9efcb18b1d866935e0eb4acb7317b4b))
+
 ## [2.10.0](https://github.com/railroadmedia/musora-content-services/compare/v2.9.5...v2.10.0) (2025-06-23)
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ allowing you to easily retrieve, filter, and manipulate content for use in vario
 
 ## Setup
 To set up the Musora Content Services project for local development, follow these steps:
-- Pull the latest railenvironment `php-8-3-upgrade` branch changes
 - In the railenvironment directory, start up the container with the `./rrr.sh` command
 - Run `r setup musora-content-services`
 - Run `npm install --save-dev jest`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "musora-content-services",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "musora-content-services",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "license": "ISC",
       "dependencies": {
         "@babel/preset-env": "^7.25.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "musora-content-services",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "musora-content-services",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "ISC",
       "dependencies": {
         "@babel/preset-env": "^7.25.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "musora-content-services",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "musora-content-services",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "license": "ISC",
       "dependencies": {
         "@babel/preset-env": "^7.25.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musora-content-services",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "A package for Musoras content services ",
   "main": "src/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musora-content-services",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "A package for Musoras content services ",
   "main": "src/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musora-content-services",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "A package for Musoras content services ",
   "main": "src/index.js",
   "type": "module",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -97,6 +97,11 @@ import {
 } from './services/imageSRCVerify.js';
 
 import {
+	onSignInHandler,
+	onSignOutHandler
+} from './services/local-session.js';
+
+import {
 	assignModeratorToComment,
 	closeComment,
 	createComment,
@@ -446,6 +451,8 @@ declare module 'musora-content-services' {
 		markContentAsNotInterested,
 		markNotificationAsRead,
 		markNotificationAsUnread,
+		onSignInHandler,
+		onSignOutHandler,
 		openComment,
 		otherStats,
 		pinProgressRow,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,6 +59,7 @@ import {
 	getProgressStateByIds,
 	getResumeTimeSeconds,
 	getResumeTimeSecondsByIds,
+	getStartedOrCompletedProgressOnly,
 	recordWatchSession
 } from './services/contentProgress.js';
 
@@ -426,6 +427,7 @@ declare module 'musora-content-services' {
 		getResumeTimeSecondsByIds,
 		getScheduleContentRows,
 		getSortOrder,
+		getStartedOrCompletedProgressOnly,
 		getTabResults,
 		getTimeRemainingUntilLocal,
 		getUserMonthlyStats,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -63,6 +63,7 @@ import {
 } from './services/contentProgress.js';
 
 import {
+	clearAllDataContexts,
 	verifyLocalDataContext
 } from './services/dataContext.js';
 
@@ -245,7 +246,7 @@ import {
 
 import {
 	fetchUserPermissions,
-	reset
+	resetUserPermissions
 } from './services/user/permissions.js';
 
 import {
@@ -292,6 +293,7 @@ declare module 'musora-content-services' {
 		blockUser,
 		buildImageSRC,
 		calculateLongestStreaks,
+		clearAllDataContexts,
 		closeComment,
 		contentStatusCompleted,
 		contentStatusReset,
@@ -472,7 +474,7 @@ declare module 'musora-content-services' {
 		replyToComment,
 		reportComment,
 		reportPlaylist,
-		reset,
+		resetUserPermissions,
 		restoreComment,
 		restoreItemFromPlaylist,
 		restorePracticeSession,

--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,11 @@ import {
 } from './services/imageSRCVerify.js';
 
 import {
+	onSignInHandler,
+	onSignOutHandler
+} from './services/local-session.js';
+
+import {
 	assignModeratorToComment,
 	closeComment,
 	createComment,
@@ -445,6 +450,8 @@ export {
 	markContentAsNotInterested,
 	markNotificationAsRead,
 	markNotificationAsUnread,
+	onSignInHandler,
+	onSignOutHandler,
 	openComment,
 	otherStats,
 	pinProgressRow,

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ import {
 } from './services/contentProgress.js';
 
 import {
+	clearAllDataContexts,
 	verifyLocalDataContext
 } from './services/dataContext.js';
 
@@ -245,7 +246,7 @@ import {
 
 import {
 	fetchUserPermissions,
-	reset
+	resetUserPermissions
 } from './services/user/permissions.js';
 
 import {
@@ -291,6 +292,7 @@ export {
 	blockUser,
 	buildImageSRC,
 	calculateLongestStreaks,
+	clearAllDataContexts,
 	closeComment,
 	contentStatusCompleted,
 	contentStatusReset,
@@ -471,7 +473,7 @@ export {
 	replyToComment,
 	reportComment,
 	reportPlaylist,
-	reset,
+	resetUserPermissions,
 	restoreComment,
 	restoreItemFromPlaylist,
 	restorePracticeSession,

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ import {
 	getProgressStateByIds,
 	getResumeTimeSeconds,
 	getResumeTimeSecondsByIds,
+	getStartedOrCompletedProgressOnly,
 	recordWatchSession
 } from './services/contentProgress.js';
 
@@ -425,6 +426,7 @@ export {
 	getResumeTimeSecondsByIds,
 	getScheduleContentRows,
 	getSortOrder,
+	getStartedOrCompletedProgressOnly,
 	getTabResults,
 	getTimeRemainingUntilLocal,
 	getUserMonthlyStats,

--- a/src/infrastructure/local-cache/adapters/index.ts
+++ b/src/infrastructure/local-cache/adapters/index.ts
@@ -5,7 +5,7 @@ export interface ILocalCache {
   getItem(key: string): Promise<string | null>;
   setItem(key: string, value: string): Promise<void>;
   removeItem(key: string): Promise<void>;
-  getKeys(startsWith: string): Promise<string[]>;
+  getKeys(startsWith?: string): Promise<string[]>;
 }
 
 export { MobileAppCache, WebCache };

--- a/src/infrastructure/local-cache/adapters/index.ts
+++ b/src/infrastructure/local-cache/adapters/index.ts
@@ -1,0 +1,11 @@
+import MobileAppCache from './ma';
+import WebCache from './web';
+
+export interface ILocalCache {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+  getKeys(startsWith: string): Promise<string[]>;
+}
+
+export { MobileAppCache, WebCache };

--- a/src/infrastructure/local-cache/adapters/ma.ts
+++ b/src/infrastructure/local-cache/adapters/ma.ts
@@ -1,0 +1,25 @@
+import { ILocalCache } from './index'
+
+export default class MobileAppCache implements ILocalCache {
+  private storage: any;
+
+  constructor(storage: any) {
+    this.storage = storage;
+  }
+
+  async getItem(key: string) {
+    return await this.storage.getItem(key);
+  }
+
+  async setItem(key: string, value: string) {
+    await this.storage.setItem(key, value);
+  }
+
+  async removeItem(key: string) {
+    await this.storage.removeItem(key)
+  }
+
+  async getKeys(startsWith?: string) {
+    return this.storage.getAllKeys().filter(key => !startsWith || key.startsWith(startsWith))
+  }
+}

--- a/src/infrastructure/local-cache/adapters/ma.ts
+++ b/src/infrastructure/local-cache/adapters/ma.ts
@@ -20,6 +20,7 @@ export default class MobileAppCache implements ILocalCache {
   }
 
   async getKeys(startsWith?: string) {
-    return this.storage.getAllKeys().filter(key => !startsWith || key.startsWith(startsWith))
+    const allKeys = await this.storage.getAllKeys();
+    return allKeys.filter(key => !startsWith || key.startsWith(startsWith));
   }
 }

--- a/src/infrastructure/local-cache/adapters/web.ts
+++ b/src/infrastructure/local-cache/adapters/web.ts
@@ -19,11 +19,11 @@ export default class WebCache implements ILocalCache {
     this.storage.removeItem(key);
   }
 
-  async getKeys(startsWith: string): Promise<string[]> {
+  async getKeys(startsWith?: string): Promise<string[]> {
     const keys: string[] = [];
     for (let i = 0; i < this.storage.length; i++) {
       const key = this.storage.key(i);
-      if (key && key.startsWith(startsWith)) {
+      if (key && (!startsWith || key.startsWith(startsWith))) {
         keys.push(key);
       }
     }

--- a/src/infrastructure/local-cache/adapters/web.ts
+++ b/src/infrastructure/local-cache/adapters/web.ts
@@ -1,0 +1,32 @@
+import { ILocalCache } from './index'
+
+export default class WebCache implements ILocalCache {
+  private storage: Storage;
+
+  constructor(storage: Storage) {
+    this.storage = storage;
+  }
+
+  async getItem(key: string) {
+    return this.storage.getItem(key);
+  }
+
+  async setItem(key: string, value: string) {
+    this.storage.setItem(key, value);
+  }
+
+  async removeItem(key: string) {
+    this.storage.removeItem(key);
+  }
+
+  async getKeys(startsWith: string): Promise<string[]> {
+    const keys: string[] = [];
+    for (let i = 0; i < this.storage.length; i++) {
+      const key = this.storage.key(i);
+      if (key && key.startsWith(startsWith)) {
+        keys.push(key);
+      }
+    }
+    return keys;
+  }
+}

--- a/src/infrastructure/local-cache/index.ts
+++ b/src/infrastructure/local-cache/index.ts
@@ -39,7 +39,7 @@ export default class LocalCache implements ILocalCache {
     return this.createCacheImplementation().removeItem(key);
   }
 
-  async getKeys(startsWith: string) {
+  async getKeys(startsWith?: string) {
     return this.createCacheImplementation().getKeys(startsWith);
   }
 }

--- a/src/infrastructure/local-cache/index.ts
+++ b/src/infrastructure/local-cache/index.ts
@@ -1,0 +1,45 @@
+import { globalConfig } from '../../services/config.js'
+
+import { ILocalCache, MobileAppCache, WebCache } from './adapters/index.js'
+
+export default class LocalCache implements ILocalCache {
+  private config: typeof globalConfig;
+
+  constructor() {
+    this.config = globalConfig;
+  }
+
+  /**
+   * Creates the appropriate cache implementation based on current config
+   * This is called lazily when a method is invoked, not at construction time
+   */
+  private createCacheImplementation(): ILocalCache {
+    if (!this.config.localStorage) {
+      throw new Error(
+        'LocalStorage cache not configured in musora content services initializeService.'
+      );
+    }
+
+    if (this.config.isMA) {
+      return new MobileAppCache(this.config.localStorage);
+    } else {
+      return new WebCache(this.config.localStorage);
+    }
+  }
+
+  async getItem(key: string) {
+    return this.createCacheImplementation().getItem(key);
+  }
+
+  async setItem(key: string, value: string) {
+    return this.createCacheImplementation().setItem(key, value);
+  }
+
+  async removeItem(key: string) {
+    return this.createCacheImplementation().removeItem(key);
+  }
+
+  async getKeys(startsWith: string) {
+    return this.createCacheImplementation().getKeys(startsWith);
+  }
+}

--- a/src/lib/lastUpdated.js
+++ b/src/lib/lastUpdated.js
@@ -1,4 +1,4 @@
-import { globalConfig } from '../services/config'
+import LocalCache from '../infrastructure/local-cache'
 
 /**
  * Exported functions that are excluded from index generation.
@@ -16,7 +16,7 @@ const excludeFromGeneratedIndex = ['wasLastUpdateOlderThanXSeconds', 'setLastUpd
  * @returns {boolean} - True if the last update was older than X seconds, false otherwise.
  */
 export function wasLastUpdateOlderThanXSeconds(seconds, key) {
-  let lastUpdated = globalConfig.localStorage.getItem(key)
+  let lastUpdated = new LocalCache().getItem(key)
   if (!lastUpdated) return false
   const verifyServerTime = seconds * 1000
   return new Date().getTime() - lastUpdated > verifyServerTime
@@ -30,7 +30,7 @@ export function wasLastUpdateOlderThanXSeconds(seconds, key) {
  * @returns {void}
  */
 export function setLastUpdatedTime(key) {
-  globalConfig.localStorage.setItem(key, new Date().getTime()?.toString())
+  new LocalCache().setItem(key, new Date().getTime()?.toString())
 }
 
 /**
@@ -41,5 +41,5 @@ export function setLastUpdatedTime(key) {
  * @returns {void}
  */
 export function clearLastUpdatedTime(key) {
-  globalConfig.localStorage.removeItem(key)
+  new LocalCache().removeItem(key)
 }

--- a/src/lib/lastUpdated.js
+++ b/src/lib/lastUpdated.js
@@ -29,8 +29,8 @@ export function wasLastUpdateOlderThanXSeconds(seconds, key) {
  *
  * @returns {void}
  */
-export function setLastUpdatedTime(key) {
-  new LocalCache().setItem(key, new Date().getTime()?.toString())
+export async function setLastUpdatedTime(key) {
+  await new LocalCache().setItem(key, new Date().getTime()?.toString())
 }
 
 /**
@@ -40,6 +40,6 @@ export function setLastUpdatedTime(key) {
  *
  * @returns {void}
  */
-export function clearLastUpdatedTime(key) {
-  new LocalCache().removeItem(key)
+export async function clearLastUpdatedTime(key) {
+  await new LocalCache().removeItem(key)
 }

--- a/src/lib/lastUpdated.js
+++ b/src/lib/lastUpdated.js
@@ -32,3 +32,14 @@ export function wasLastUpdateOlderThanXSeconds(seconds, key) {
 export function setLastUpdatedTime(key) {
   globalConfig.localStorage.setItem(key, new Date().getTime()?.toString())
 }
+
+/**
+ * Clears the last updated time.
+ *
+ * @param {string} key - The key to clear the last updated time.
+ *
+ * @returns {void}
+ */
+export function clearLastUpdatedTime(key) {
+  globalConfig.localStorage.removeItem(key)
+}

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -19,7 +19,7 @@ import {recommendations} from "./recommendations";
 
 
 export async function getLessonContentRows (brand='drumeo', pageName = 'lessons') {
-  let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent' });
+  let recentContentIds = await fetchRecent(brand, pageName, { progress: 'recent', limit: 10 });
 
   let contentRows = await getContentRows(brand, pageName);
   contentRows = Array.isArray(contentRows) ? contentRows : [];

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -151,6 +151,40 @@ export async function getAllStartedOrCompleted({ limit = null, onlyIds = true, b
   }
 }
 
+/**
+ * Simplified version of `getAllStartedOrCompleted`.
+ *
+ * Fetches content IDs and progress percentages for items that were
+ * started or completed.
+ *
+ * @param {Object} [options={}] - Optional filtering options.
+ * @param {string|null} [options.brand=null] - Brand to filter by (e.g., 'drumeo').
+ * @returns {Promise<Object>} - A map of content ID to progress value:
+ *   {
+ *     [id]: progressPercentage
+ *   }
+ *
+ * @example
+ * const progressMap = await getStartedOrCompletedProgressOnly({ brand: 'drumeo' });
+ * console.log(progressMap[123]); // => 52
+ */
+export async function getStartedOrCompletedProgressOnly({ brand = null} = {}) {
+  const data = await dataContext.getData()
+  const result = {}
+
+  Object.entries(data).forEach(([key, item]) => {
+    const id = parseInt(key)
+    const isRelevantStatus = item[DATA_KEY_STATUS] === STATE_STARTED || item[DATA_KEY_STATUS] === STATE_COMPLETED
+    const isCorrectBrand = !brand || item.b === brand
+
+    if (isRelevantStatus && isCorrectBrand) {
+      result[id] = item?.[DATA_KEY_PROGRESS] ?? 0
+    }
+  })
+
+  return result
+}
+
 export async function assignmentStatusCompleted(assignmentId, parentContentId) {
   await dataContext.update(
     async function (localContext) {

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -118,7 +118,7 @@ export async function getAllStartedOrCompleted({ limit = null, onlyIds = true, b
       const isRelevantStatus =
         item[DATA_KEY_STATUS] === STATE_STARTED || item[DATA_KEY_STATUS] === STATE_COMPLETED
       const isRecent = item[DATA_KEY_LAST_UPDATED_TIME] >= oneMonthAgoInSeconds
-      const isCorrectBrand = !brand || item.b === brand
+      const isCorrectBrand = !brand || !item.b || item.b === brand
       const isNotExcluded = !excludedSet.has(id)
       return isRelevantStatus && isRecent && isCorrectBrand && isNotExcluded
     })

--- a/src/services/dataContext.js
+++ b/src/services/dataContext.js
@@ -44,9 +44,8 @@ export class DataContext {
    */
   static async clearAll() {
     const cache = new LocalCache()
-    cache.getKeys(this.PREFIX).then(keys => {
-      keys.forEach(key => cache.removeItem(key))
-    })
+    const keys = await cache.getKeys(DataContext.PREFIX)
+    await Promise.all(keys.map(key => cache.removeItem(key)))
   }
 
   constructor(dataVersionKey, fetchDataFunction) {

--- a/src/services/dataContext.js
+++ b/src/services/dataContext.js
@@ -101,7 +101,7 @@ export class DataContext {
 
   clearCache() {
     this.clearContext()
-    if (cache) {
+    if (this.cache) {
       this.cache.removeItem(this.localStorageKey)
       this.cache.removeItem(this.localStorageLastUpdatedKey)
     }

--- a/src/services/dataContext.js
+++ b/src/services/dataContext.js
@@ -25,7 +25,7 @@ export async function verifyLocalDataContext(dataVersionKey, currentVersion) {
   if (currentVersion !== tempContext.version()) {
     tempContext.clearCache()
   } else {
-    tempContext.setLastUpdatedTime()
+    await tempContext.setLastUpdatedTime()
   }
 }
 
@@ -74,7 +74,7 @@ export class DataContext {
         this.context = data
         this.cache.setItem(this.localStorageKey, JSON.stringify(data))
       }
-      this.setLastUpdatedTime()
+      await this.setLastUpdatedTime()
     }
     this.dataPromise = null
     return this.context.data
@@ -99,11 +99,11 @@ export class DataContext {
     return new Date().getTime() - lastUpdated > verifyServerTime
   }
 
-  clearCache() {
+  async clearCache() {
     this.clearContext()
     if (this.cache) {
-      this.cache.removeItem(this.localStorageKey)
-      this.cache.removeItem(this.localStorageLastUpdatedKey)
+      await this.cache.removeItem(this.localStorageKey)
+      await this.cache.removeItem(this.localStorageLastUpdatedKey)
     }
   }
 
@@ -111,8 +111,8 @@ export class DataContext {
     this.context = null
   }
 
-  setLastUpdatedTime() {
-    this.cache.setItem(this.localStorageLastUpdatedKey, new Date().getTime().toString())
+  async setLastUpdatedTime() {
+    await this.cache.setItem(this.localStorageLastUpdatedKey, new Date().getTime().toString())
   }
 
   async update(localUpdateFunction, serverUpdateFunction) {
@@ -122,12 +122,12 @@ export class DataContext {
       if (this.context) this.context.version++
       let data = JSON.stringify(this.context)
       this.cache.setItem(this.localStorageKey, data)
-      this.setLastUpdatedTime()
+      await this.setLastUpdatedTime()
     }
     const updatePromise = serverUpdateFunction()
     updatePromise.then((response) => {
       if (response?.version !== this.version()) {
-        this.clearCache()
+        return this.clearCache()
       }
     })
     return updatePromise
@@ -143,7 +143,7 @@ export class DataContext {
       if (this.context) this.context.version++
       let data = JSON.stringify(this.context)
       this.cache.setItem(this.localStorageKey, data)
-      this.setLastUpdatedTime()
+      await this.setLastUpdatedTime()
     }
   }
 }

--- a/src/services/local-session.js
+++ b/src/services/local-session.js
@@ -1,0 +1,19 @@
+import { clearAllDataContexts } from "./dataContext";
+import { resetUserPermissions } from "./user/permissions";
+
+// clear possibly stale data on sign in
+export async function onSignInHandler() {
+  await clearLocalSessionData()
+}
+
+// explicitly clear all data on sign out
+export async function onSignOutHandler() {
+  await clearLocalSessionData()
+}
+
+async function clearLocalSessionData() {
+  await Promise.all([
+    clearAllDataContexts(),
+    resetUserPermissions()
+  ])
+}

--- a/src/services/railcontent.js
+++ b/src/services/railcontent.js
@@ -755,7 +755,7 @@ export async function reportComment(commentId, issue) {
   return await postDataHandler(url, data)
 }
 
-export async function fetchUserPractices({ currentVersion, userId } = {}) {
+export async function fetchUserPractices(currentVersion = 0, { userId } = {}) {
   const params = new URLSearchParams();
   if (userId) params.append('user_id', userId);
   const query = params.toString() ? `?${params.toString()}` : '';
@@ -763,6 +763,9 @@ export async function fetchUserPractices({ currentVersion, userId } = {}) {
   const response = await fetchDataHandler(url, currentVersion);
   const { data, version } = response;
   const userPractices = data;
+  if(!userPractices ) {
+    return { data: { practices: {} }, version };
+  }
 
   const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -512,7 +512,7 @@ export async function fetchByRailContentId(id, contentType) {
  *   .then(contents => console.log(contents))
  *   .catch(error => console.error(error));
  */
-export async function fetchByRailContentIds(ids, contentType = undefined, brand= undefined) {
+export async function fetchByRailContentIds(ids, contentType = undefined, brand = undefined) {
   if (!ids) {
     return []
   }
@@ -1320,7 +1320,7 @@ export async function fetchLessonContent(railContentId) {
   })
   const chapterProcess = (result) => {
     const now = getSanityDate(new Date(), false)
-    if(result.live_event_start_time && result.live_event_start_time){
+    if (result.live_event_start_time && result.live_event_end_time) {
       result.isLive = result.live_event_start_time <= now && result.live_event_end_time >= now
     }
     const chapters = result.chapters ?? []
@@ -1336,15 +1336,23 @@ export async function fetchLessonContent(railContentId) {
 }
 
 /**
+ * Returns a list of recommended content based on the provided railContentId.
+ * If no recommendations found in recsys, falls back to fetching related lessons.
  *
  * @param railContentId
  * @param brand
  * @param count
- * @returns {Promise<Array<Object>|null>}
+ * @returns {Promise<Array<Object>>}
  */
 export async function fetchRelatedRecommendedContent(railContentId, brand, count = 10) {
   const recommendedItems = await fetchSimilarItems(railContentId, brand, count)
-  return fetchByRailContentIds(recommendedItems)
+  if (recommendedItems && recommendedItems.length > 0) {
+    return fetchByRailContentIds(recommendedItems)
+  }
+
+  return await fetchRelatedLessons(railContentId, brand).then((result) =>
+    result.related_lessons?.splice(0, count)
+  )
 }
 
 /**
@@ -1414,18 +1422,20 @@ async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, cou
  */
 export async function fetchRelatedLessons(railContentId, brand) {
   const filterSameTypeAndSortOrder = await new FilterBuilder(
-    `_type==^._type &&  _type in ${JSON.stringify(typeWithSortOrder)} && brand == "${brand}" && railcontent_id !=${railContentId}`,
+    `_type==^._type &&  _type in ${JSON.stringify(typeWithSortOrder)} && brand == "${brand}" && railcontent_id !=${railContentId}`
   ).buildFilter()
   const filterSameType = await new FilterBuilder(
-    `_type==^._type && !(_type in ${JSON.stringify(typeWithSortOrder)}) && !(defined(parent_type)) && brand == "${brand}" && railcontent_id !=${railContentId}`,
+    `_type==^._type && !(_type in ${JSON.stringify(typeWithSortOrder)}) && !(defined(parent_type)) && brand == "${brand}" && railcontent_id !=${railContentId}`
   ).buildFilter()
   const filterSongSameArtist = await new FilterBuilder(
-    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.artist->_id) && railcontent_id !=${railContentId}`,
+    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.artist->_id) && railcontent_id !=${railContentId}`
   ).buildFilter()
   const filterSongSameGenre = await new FilterBuilder(
-    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.genre[]->_id) && railcontent_id !=${railContentId}`,
+    `_type=="song" && _type==^._type && brand == "${brand}" && references(^.genre[]->_id) && railcontent_id !=${railContentId}`
   ).buildFilter()
-  const filterNeighbouringSiblings = await new FilterBuilder(`references(^._id)`, {pullFutureContent: true}).buildFilter()
+  const filterNeighbouringSiblings = await new FilterBuilder(`references(^._id)`, {
+    pullFutureContent: true,
+  }).buildFilter()
   const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
   const queryFields = `_id, "id":railcontent_id, published_on, "instructor": instructor[0]->name, title, "thumbnail":thumbnail.asset->url, length_in_seconds, web_url_path, "type": _type, difficulty, difficulty_string, railcontent_id, artist->,"permission_id": permission[]->railcontent_id,_type, "genre": genre[]->name`
   const queryFieldsWithSort = queryFields + ', sort'
@@ -1446,15 +1456,15 @@ export async function fetchRelatedLessons(railContentId, brand) {
   let result = await fetchSanity(query, false)
 
   //there's no way in sanity to retrieve the index of an array, so we must calculate after fetch
-  if (result['for-calculations']['parents-list']) {
+  if (result['for-calculations'] && result['for-calculations']['parents-list']) {
     const calc = result['for-calculations']
     const parentCount = calc['parents-list'].length
-    const currentParent = (calc['parents-list'].indexOf(result['parent_id']) + 1)
+    const currentParent = calc['parents-list'].indexOf(result['parent_id']) + 1
     const siblingCount = calc['siblings-list'].length
-    const currentSibling = (calc['siblings-list'].indexOf(result['railcontent_id']) + 1)
+    const currentSibling = calc['siblings-list'].indexOf(result['railcontent_id']) + 1
 
     delete result['for-calculations']
-    result = {...result, parentCount, currentParent, siblingCount, currentSibling}
+    result = { ...result, parentCount, currentParent, siblingCount, currentSibling }
     return result
   } else {
     delete result['for-calculations']
@@ -1504,7 +1514,7 @@ export async function fetchPackAll(railcontentId, type = 'pack') {
 }
 
 export async function fetchLiveEvent(brand, forcedContentId = null) {
-  const LIVE_EXTRA_MINUTES = 30;
+  const LIVE_EXTRA_MINUTES = 30
   //calendarIDs taken from addevent.php
   // TODO import instructor calendars to Sanity
   let defaultCalendarID = ''
@@ -1526,8 +1536,10 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
   }
   let startDateTemp = new Date()
   let endDateTemp = new Date()
- 
-  startDateTemp = new Date(startDateTemp.setMinutes(startDateTemp.getMinutes() + LIVE_EXTRA_MINUTES))
+
+  startDateTemp = new Date(
+    startDateTemp.setMinutes(startDateTemp.getMinutes() + LIVE_EXTRA_MINUTES)
+  )
   endDateTemp = new Date(endDateTemp.setMinutes(endDateTemp.getMinutes() - LIVE_EXTRA_MINUTES))
 
   // See LiveStreamEventService.getCurrentOrNextLiveEvent for some nice complicated logic which I don't think is actually importart
@@ -2394,17 +2406,13 @@ export async function fetchScheduledAndNewReleases(
   return fetchSanity(query, true)
 }
 
-export async function fetchShows(
-  brand,
-  type,
-  sort = 'sort'
-) {
+export async function fetchShows(brand, type, sort = 'sort') {
   const sortOrder = getSortOrder(sort, brand)
   const filter = `_type == '${type}'  && brand == '${brand}'`
   const filterParams = {}
 
   const query = await buildQuery(filter, filterParams, getFieldsForContentType(type), {
-    sortOrder: sortOrder
+    sortOrder: sortOrder,
   })
   return fetchSanity(query, true)
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -405,6 +405,8 @@ export async function fetchUpcomingEvents(brand, { page = 1, limit = 10 } = {}) 
         "type": _type,
         web_url_path,
         "permission_id": permission[]->railcontent_id,
+        live_event_start_time,
+        live_event_end_time,
          "isLive": live_event_start_time <= '${now}' && live_event_end_time >= '${now}'`
   const query = buildRawQuery(
     `defined(live_event_start_time) && (!defined(live_event_end_time) || live_event_end_time >= '${now}' ) && brand == '${brand}' && published_on > '${now}' && status == 'scheduled'`,

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1504,6 +1504,7 @@ export async function fetchPackAll(railcontentId, type = 'pack') {
 }
 
 export async function fetchLiveEvent(brand, forcedContentId = null) {
+  const LIVE_EXTRA_MINUTES = 30;
   //calendarIDs taken from addevent.php
   // TODO import instructor calendars to Sanity
   let defaultCalendarID = ''
@@ -1525,8 +1526,9 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
   }
   let startDateTemp = new Date()
   let endDateTemp = new Date()
-  startDateTemp = new Date(startDateTemp.setMinutes(startDateTemp.getMinutes() + 15))
-  endDateTemp = new Date(endDateTemp.setMinutes(endDateTemp.getMinutes() - 15))
+ 
+  startDateTemp = new Date(startDateTemp.setMinutes(startDateTemp.getMinutes() + LIVE_EXTRA_MINUTES))
+  endDateTemp = new Date(endDateTemp.setMinutes(endDateTemp.getMinutes() - LIVE_EXTRA_MINUTES))
 
   // See LiveStreamEventService.getCurrentOrNextLiveEvent for some nice complicated logic which I don't think is actually importart
   // this has some +- on times

--- a/src/services/user/notifications.js
+++ b/src/services/user/notifications.js
@@ -23,13 +23,13 @@ const baseUrl = `/api/notifications`
  *   .then(notifications => console.log(notifications))
  *   .catch(error => console.error(error));
  */
-export async function fetchNotifications({ brand = null, limit = 10, onlyUnread = false } = {}) {
+export async function fetchNotifications({ brand = null, limit = 10, onlyUnread = false, page = 1 } = {}) {
   if (!brand) {
     throw new Error('brand is required')
   }
 
   const unreadParam = onlyUnread ? '&unread=1' : ''
-  const url = `${baseUrl}/v1?brand=${brand}${unreadParam}&limit=${limit}`
+  const url = `${baseUrl}/v1?brand=${brand}${unreadParam}&limit=${limit}&page=${page}`
   return fetchHandler(url, 'get')
 }
 

--- a/src/services/user/notifications.js
+++ b/src/services/user/notifications.js
@@ -12,6 +12,7 @@ const baseUrl = `/api/notifications`
  * @param {Object} [options={}] - Options for fetching notifications.
  * @param {string} options.brand - The brand to filter notifications by. (Required)
  * @param {number} [options.limit=10] - The maximum number of notifications to fetch.
+ * @param {number} [options.page=1] - The page number for pagination.
  * @param {boolean} [options.onlyUnread=false] - Whether to fetch only unread notifications. If true, adds `unread=1` to the query.
  *
  * @returns {Promise<Array<Object>>} - A promise that resolves to an array of notifications.
@@ -19,7 +20,7 @@ const baseUrl = `/api/notifications`
  * @throws {Error} - Throws an error if the brand is not provided.
  *
  * @example
- * fetchNotifications({ brand: 'drumeo', limit: 5, onlyUnread: true })
+ * fetchNotifications({ brand: 'drumeo', limit: 5, onlyUnread: true,  page: 2  })
  *   .then(notifications => console.log(notifications))
  *   .catch(error => console.error(error));
  */

--- a/src/services/user/permissions.js
+++ b/src/services/user/permissions.js
@@ -1,7 +1,7 @@
 /**
  * @module Permissions
  */
-import { setLastUpdatedTime, wasLastUpdateOlderThanXSeconds } from '../../lib/lastUpdated.js'
+import { setLastUpdatedTime, clearLastUpdatedTime, wasLastUpdateOlderThanXSeconds } from '../../lib/lastUpdated.js'
 import { fetchUserPermissionsData } from '../railcontent.js'
 import './types.js'
 
@@ -33,6 +33,7 @@ export async function fetchUserPermissions() {
  *
  * @returns {Promise<void>}
  */
-export async function reset() {
+export async function resetUserPermissions() {
   userPermissionsPromise = null
+  clearLastUpdatedTime(lastUpdatedKey)
 }

--- a/src/services/user/permissions.js
+++ b/src/services/user/permissions.js
@@ -22,7 +22,7 @@ let lastUpdatedKey = `userPermissions_lastUpdated`
 export async function fetchUserPermissions() {
   if (!userPermissionsPromise || wasLastUpdateOlderThanXSeconds(10, lastUpdatedKey)) {
     userPermissionsPromise = fetchUserPermissionsData()
-    setLastUpdatedTime(lastUpdatedKey)
+    await setLastUpdatedTime(lastUpdatedKey)
   }
 
   return await userPermissionsPromise
@@ -35,5 +35,5 @@ export async function fetchUserPermissions() {
  */
 export async function resetUserPermissions() {
   userPermissionsPromise = null
-  clearLastUpdatedTime(lastUpdatedKey)
+  await clearLastUpdatedTime(lastUpdatedKey)
 }

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -376,20 +376,28 @@ export async function removeUserPractice(id) {
 export async function restoreUserPractice(id) {
   let url = `/api/user/practices/v1/practices/restore${buildQueryString([id])}`
   const response = await fetchHandler(url, 'put')
-  if (response?.data) {
+  if (response?.data?.length) {
     await userActivityContext.updateLocal(async function (localContext) {
       const restoredPractice = response.data
-      const { date } = restoredPractice
+      const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+      const utcDate = new Date(restoredPractice[0].day)
+      const localDate = convertToTimeZone(utcDate, userTimeZone)
+      const date =
+        localDate.getFullYear() + '-' +
+        String(localDate.getMonth() + 1).padStart(2, '0') + '-' +
+        String(localDate.getDate()).padStart(2, '0')
       if (!localContext.data[DATA_KEY_PRACTICES][date]) {
         localContext.data[DATA_KEY_PRACTICES][date] = []
       }
-      localContext.data[DATA_KEY_PRACTICES][date].push({
-        id: restoredPractice.id,
-        duration_seconds: restoredPractice.duration_seconds,
-      })
+      for (const practice of restoredPractice) {
+        localContext.data[DATA_KEY_PRACTICES][date].push({
+          id: practice.id,
+          duration_seconds: practice.duration_seconds,
+        })
+      }
     })
   }
-  const formattedMeta = await formatPracticeMeta(response.data)
+  const formattedMeta = await formatPracticeMeta(response.data || [])
   const practiceDuration = formattedMeta.reduce(
     (total, practice) => total + (practice.duration || 0),
     0

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -55,7 +55,7 @@ function getIndefiniteArticle(streak) {
 
 export async function getUserPractices(userId = globalConfig.sessionConfig.userId) {
   if (userId !== globalConfig.sessionConfig.userId) {
-    let data = await fetchUserPractices({ userId })
+    let data = await fetchUserPractices(0, { userId: userId })
     return data?.['data']?.[DATA_KEY_PRACTICES] ?? {}
   } else {
     let data = await userActivityContext.getData()
@@ -603,7 +603,7 @@ function getStreaksAndMessage(practices) {
 async function getUserPracticeIds(day = new Date().toISOString().split('T')[0], userId = null) {
   let practices = {}
   if (userId !== globalConfig.sessionConfig.userId) {
-    let data = await fetchUserPractices({ userId })
+    let data = await fetchUserPractices(0, { userId: userId })
     practices = data?.['data']?.[DATA_KEY_PRACTICES] ?? {}
   } else {
     let data = await userActivityContext.getData()

--- a/test/lib/lastUpdated.test.js
+++ b/test/lib/lastUpdated.test.js
@@ -7,7 +7,7 @@ describe('lastUpdated', function () {
   })
 
   test('lastUpdated', async () => {
-    setLastUpdatedTime('testKey')
+    await setLastUpdatedTime('testKey')
     let test1 = wasLastUpdateOlderThanXSeconds(1, 'testKey')
     await new Promise((r) => setTimeout(r, 800))
     let test2 = wasLastUpdateOlderThanXSeconds(1, 'testKey')


### PR DESCRIPTION
JIRA epic: https://musora.atlassian.net/browse/TP-943
JIRA ticket: https://musora.atlassian.net/browse/TP-947

This work creates a new method around `DataContext` to clear all existing keys created by it. A [corresponding PR](https://github.com/railroadmedia/musora-platform-frontend/pull/480) exists in `mpf` to call this method (`clearAllDataContexts`) when a user logs out. (Two more PRs for v1 (one on `mwp`, and another on `mcs` against the `main` branch) will be added once this and that PR are reviewed.)

Also, a new `local-cache` infrastructure service was created to simplify some logic `localStorage`/`AsyncStorage` access patterns. Previously, `DataContext` itself would consult `globalConfig.isMA` to see if it needed to use (the React Native style) asynchronous methods for getting/setting keys. Now it just reaches out to the `LocalCache` service, whose methods are asynchronous by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a unified local cache system supporting mobile app and web environments.
	- Added the ability to clear all cached data contexts simultaneously.
	- Added a function to clear last updated timestamps for specific keys.
	- Added exports for clearing all data contexts and improved naming for user permissions reset.

- **Improvements**
	- Renamed the user permissions reset function for improved clarity.
	- Updated storage operations to use the new local cache abstraction, simplifying cache management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->