### PR TITLE
fix(MU2-730): Pagination on fetchNotifications method

### DIFF
--- a/src/services/user/notifications.js
+++ b/src/services/user/notifications.js
@@ -12,6 +12,7 @@ const baseUrl = `/api/notifications`
  * @param {Object} [options={}] - Options for fetching notifications.
  * @param {string} options.brand - The brand to filter notifications by. (Required)
  * @param {number} [options.limit=10] - The maximum number of notifications to fetch.
+ * @param {number} [options.page=1] - The page number for pagination.
  * @param {boolean} [options.onlyUnread=false] - Whether to fetch only unread notifications. If true, adds `unread=1` to the query.
  *
  * @returns {Promise<Array<Object>>} - A promise that resolves to an array of notifications.
@@ -19,7 +20,7 @@ const baseUrl = `/api/notifications`
  * @throws {Error} - Throws an error if the brand is not provided.
  *
  * @example
- * fetchNotifications({ brand: 'drumeo', limit: 5, onlyUnread: true })
+ * fetchNotifications({ brand: 'drumeo', limit: 5, onlyUnread: true,  page: 2  })
  *   .then(notifications => console.log(notifications))
  *   .catch(error => console.error(error));
  */


### PR DESCRIPTION
fix(MU2-730): Pagination on fetchNotifications method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pagination when fetching notifications, allowing users to view notifications by page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->