### PR TITLE
refactor: addevent field name

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -384,7 +384,7 @@ export async function fetchUpcomingEvents(brand, { page = 1, limit = 10 } = {}) 
         "type": _type,
         web_url_path,
         "permission_id": permission[]->railcontent_id,
-        event_calendar_unique_key`
+        addevent_unique_key`
   const query = buildRawQuery(
     `_type in ${typesString} && brand == '${brand}' && published_on > '${now}' && status == 'scheduled'`,
     fields,


### PR DESCRIPTION
poor naming before
`event_calendar_unique_key` -> `addevent_unique_key`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the unique key used for upcoming events to ensure correct event identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->