### PR TITLE
fix: (BR-286) fetchLessonContent for users without access

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1293,7 +1293,7 @@ export async function fetchLessonContent(railContentId) {
     isSingle: true,
   })
   const chapterProcess = (result) => {
-    const chapters = result.chapters ?? []
+    const chapters = result?.chapters ?? []
     if (chapters.length == 0) return result
     result.chapters = chapters.map((chapter, index) => ({
       ...chapter,
@@ -1995,6 +1995,9 @@ export async function fetchSanity(
 }
 
 function needsAccessDecorator(results, userPermissions, isAdmin) {
+  if (!results || (Array.isArray(results) && results.length === 0)) {
+    return results; // nothing to decorate
+  }
   userPermissions = new Set(userPermissions)
 
   if (Array.isArray(results)) {


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading 'entity') on deeplinks for users without access 

- update fetchLessonContent to decorate results and process  chapters only when results exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading lesson content by handling missing or undefined data more safely.
  * Prevented unnecessary processing when there is no data to display, reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->