### PR TITLE
feat(BEH-662): add pinned guided course to homepage

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -213,7 +213,27 @@ export const recentTypes = {
 
 export let contentTypeConfig = {
   'progress-tracker': {
-    fields: ['"parent_content_data": parent_content_data[].id','"badge" : badge.asset->url','"lessons": child[]->{"id": railcontent_id, "slug":slug.current, "brand":brand, "type": _type, "lessons": child[]->{"id":railcontent_id, "slug":slug.current,  "type": _type,"brand":brand}}'],
+    fields: ['"parent_content_data": parent_content_data[].id',
+      '"badge" : badge.asset->url',
+      '"lessons": child[]->{' +
+        '"id": railcontent_id,' +
+        '"slug":slug.current,' +
+        '"brand":brand,' +
+        '"type": _type,' +
+        '"thumbnail": thumbnail.asset->url,' +
+        'published_on,' +
+        '"lessons": child[]->{' +
+          '"id":railcontent_id,' +
+          '"slug":slug.current,' +
+          '"type": _type,' +
+          '"brand":brand},' +
+          '"thumbnail": thumbnail.asset->url,' +
+          'published_on,' +
+        '}'
+    ],
+
+
+
   },
   song: {
     fields: ['album', 'soundslice', 'instrumentless', `"resources": ${resourcesField}`],

--- a/src/services/content-org/guided-courses.ts
+++ b/src/services/content-org/guided-courses.ts
@@ -40,7 +40,7 @@ export async function guidedCourses() {
   return await fetchHandler(url, 'GET')
 }
 
-export async function pinnedGuidedCourses() {
-  const url: string = `${BASE_PATH}/v1/user/guided-courses/pinned`
+export async function pinnedGuidedCourses(brand) {
+  const url: string = `${BASE_PATH}/v1/user/guided-courses/pinned?brand=${brand}`
   return await fetchHandler(url, 'GET')
 }

--- a/src/services/content-org/guided-courses.ts
+++ b/src/services/content-org/guided-courses.ts
@@ -42,5 +42,7 @@ export async function guidedCourses() {
 
 export async function pinnedGuidedCourses(brand) {
   const url: string = `${BASE_PATH}/v1/user/guided-courses/pinned?brand=${brand}`
-  return await fetchHandler(url, 'GET')
+  let a = await fetchHandler(url, 'GET')
+  console.log('oh no')
+  return a
 }

--- a/src/services/content-org/guided-courses.ts
+++ b/src/services/content-org/guided-courses.ts
@@ -42,7 +42,5 @@ export async function guidedCourses() {
 
 export async function pinnedGuidedCourses(brand) {
   const url: string = `${BASE_PATH}/v1/user/guided-courses/pinned?brand=${brand}`
-  let a = await fetchHandler(url, 'GET')
-  console.log('oh no')
-  return a
+  return await fetchHandler(url, 'GET')
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -513,8 +513,7 @@ export async function fetchByRailContentId(id, contentType) {
  *   .catch(error => console.error(error));
  */
 export async function fetchByRailContentIds(ids, contentType = undefined, brand = undefined) {
-  console.log(ids)
-  if (!ids) {
+  if (!ids?.length) {
     return []
   }
   const idsString = ids.join(',')

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -513,6 +513,7 @@ export async function fetchByRailContentId(id, contentType) {
  *   .catch(error => console.error(error));
  */
 export async function fetchByRailContentIds(ids, contentType = undefined, brand = undefined) {
+  console.log(ids)
   if (!ids) {
     return []
   }

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -8,7 +8,10 @@ import {
   fetchUserPracticeMeta,
   fetchUserPracticeNotes,
   fetchHandler,
-  fetchRecentUserActivities, fetchChallengeLessonData
+  fetchRecentUserActivities,
+  fetchChallengeLessonData,
+  fetchLastInteractedChild,
+  pinnedGuidedCourses,
 } from './railcontent'
 import { DataContext, UserActivityVersionKey } from './dataContext.js'
 import { fetchByRailContentIds, fetchShows } from './sanity'
@@ -16,8 +19,14 @@ import {fetchPlaylist, fetchUserPlaylists} from "./content-org/playlists";
 import {convertToTimeZone, getMonday, getWeekNumber, isSameDate, isNextDay, getTimeRemainingUntilLocal} from './dateUtils.js'
 import { globalConfig } from './config'
 import {collectionLessonTypes, lessonTypesMapping, progressTypesMapping, showsLessonTypes, songs} from "../contentTypeConfig";
-import {getAllStartedOrCompleted, getProgressStateByIds} from "./contentProgress";
+import {
+  getAllStartedOrCompleted,
+  getProgressPercentageByIds,
+  getProgressStateByIds,
+  getResumeTimeSecondsByIds
+} from "./contentProgress";
 import {TabResponseType} from "../contentMetaData";
+import {isContentLikedByIds} from "./contentLikes.js";
 
 const DATA_KEY_PRACTICES = 'practices'
 const DATA_KEY_LAST_UPDATED_TIME = 'u'


### PR DESCRIPTION
## Description
- update getProgressRows to pull pinnedGuidedCourse data
- implement logic for displaying different card states based on [this ](https://docs.google.com/document/d/1-f7byIuyuGbvOTgcWDXtGTYJoZcxFyO8_2Gpxklb3bU/edit?tab=t.824jhxia64ss#heading=h.g0pn3rs0h8cm) document. I'm not feeling super confident that this will be enough. But I think we need to get this into testing to understand the edge cases.


Before merging I will remove the console.log statements. But they're too useful for testing to get rid of at the moment.

## Outstanding/Questions/Unknowns:
- what happens when a playlist contains a GC? For the moment FE/MA is expected to block this behaviour, but it will need to be supported eventually. The logic for this is in getProgressRows the `for (const item of playlistContents)` to remove playlist items from `progressContents` 


## Testing 
Staging dataset.
Verify setup run correctly.
```
r mpb artisan migrate
r mpb composer install
r mpb artisan db:seed --class=GuidedCourseContent
```
Pull the latest MPF and run devapp
.
Clear all your progress for any guided course `delete from railcontent_user_content_progress where user_id = 631736 and content_id > 416441 and content_id < 416449;`
open a fresh incognito browser (to clear local storage).

- enroll in guided-courses 416446 (or 416442). 

I had a hard time getting this to work for me with 416646, so I did it with 416442 (children are next 3 ids). 416646 wasn't showing up in the inprogress items despite being in the database. It's likely a caching issues and I've been testing for a full day now.
The logic ladder for display goes
- locked, not-started, completed, continue. So the published_on dates in sanity have the ability to short circuit the logic ladder. This won't be an issue in production and I may refactor this to be in a different  



1. USHP-1 if lesson locked show unlock in X time
- set the [416447](https://devapi.musora.com:9443/admin/studio/publishing/structure/guided-course;24cc4b1f-850a-4b14-8225-9b5368988c5c;2c2031ce-5675-4905-b992-2562e065af1b%2Ctype%3Dguided-course-part%2CparentRefPath%3Dchild%255B_key%253D%253D%2522d880a84a1746%2522%255D) lesson to published_on in the future


- load home page... wait
- verify the pinned GC (can has cheesburger) is shown. Overlay should be locked, and 
- You can check the console for the "ProgressRows" entry


3. USHP-2 start course if not started
- set 416447 published_on to be in the past
- reload the home page and verify pinned GC shows "start course"

2. USHP-3 in progress for lesson
- complete this content (416447 using devendpoint (or through the frontend lessons page, but I don't think it's running atm)
```
 // you may need to import postContentComplete :)
  //  postContentComplete(416447).then((r) => {
  //   console.log('contentComplete', r)
  //   // You can dump results to the screen if you'd like :D
  //   //results.value = r
  // })
- reload home page. Verify the in progress GC is shown. Overlay should have "Continue". 
```
// USHP-4 completed
- complete the 2nd content 416448 through devendpoint. Refresh the home page
- verify the gc is still pinned and shows "Revisit Lessons"


## Other notes
- other GC: [416443](https://devapi.musora.com:9443/admin/studio/publishing/structure/guided-course;f36acbbd-ad1d-42d4-8fdd-e1b0b0ac7905;378c6712-00eb-4308-8e61-c4d69f05e55e%2Ctype%3Dguided-course-part%2CparentRefPath%3Dchild%255B_key%253D%253D%25221800de0a9b21%2522%255D) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced progress tracking to support pinned guided courses and user-pinned items, providing a more organized and personalized learning experience.
  * Added richer metadata for lessons, including thumbnails and published dates, for improved course detail visibility.

* **Bug Fixes**
  * Improved handling of empty content ID lists to prevent unnecessary processing.

* **Refactor**
  * Streamlined progress row aggregation and pinning logic for better performance and reliability.
  * Improved internal structure for lesson metadata to enhance readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->