### PR TITLE
fix(BEH-706): fix addLastInteractedParent field

### DIFF
--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -80,7 +80,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
   })
 
   if (addLastInteractedParent) {
-    const parentId = await getLastInteractedOf(data.children.map(content => content.id));
+    const parentId = await getLastInteractedOf(ids);
     data['nextLesson'] = nextLessonData[parentId];
   }
 


### PR DESCRIPTION
allows for addLastInteractedParent to be used on all possible data hierarchies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in determining the next lesson by updating how item IDs are handled internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->