### PR TITLE
fix(BEH-705): handle pack index page data

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -424,6 +424,10 @@ export let contentTypeConfig = {
       `"children": child[]->{
         "description": ${descriptionField},
         "lesson_count": child_count,
+        "instructors": select(
+          instructor != null => instructor[]->name,
+          ^.instructor[]->name
+        ),
         "children": child[]->{
           "description": ${descriptionField},
           ${getFieldsForContentType()}


### PR DESCRIPTION
## JIRA
[BEH-705](https://musora.atlassian.net/browse/BEH-705)

## Design/Changes
we only needed to add instructor field to each children field for displaying name on pack index page, if doesnt already exist

## Testing
- pack id where children do not have instructor: 265354
- run `fetchPackData(265354)` in FE devendpoint
- verify children field have instructor field
## notes
- there are no documents with an instructor that have children with an instructor as well. checked with `*[defined(instructor) && defined(child->instructor)]`


[BEH-705]: https://musora.atlassian.net/browse/BEH-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "instructors" field for pack children, displaying instructor names with a fallback to parent instructors when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->