### PR TITLE
fix: Remove limit for related lessons

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1457,7 +1457,7 @@ export async function fetchRelatedLessons(railContentId, brand) {
       ...(*[${filterSameTypeAndSortOrder}]{${queryFieldsWithSort}}|order(sort asc, title asc)[0...10]),
       ...(*[${filterSameType}]{${queryFields}}|order(published_on desc, title asc)[0...10])
       ,
-      ])[0...10]}`
+      ])}`
   let result = await fetchSanity(query, false)
 
   //there's no way in sanity to retrieve the index of an array, so we must calculate after fetch


### PR DESCRIPTION
Since we need all items for the content, the limit was removed (0...10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now receive a customizable number of related lessons, with the option to adjust the maximum results shown.

* **Refactor**
  * Enhanced flexibility in how related lessons are displayed by allowing dynamic result limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->