### PR TITLE
fix: MU2-787 Leaving Soon and Returning should only be set in the future

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -571,6 +571,12 @@ export let contentTypeConfig = {
       `quarter_published`,
       '"thumbnail": thumbnail.asset->url',
     ]
+  },
+  leaving: {
+    fields: [
+      `quarter_removed`,
+      '"thumbnail": thumbnail.asset->url',
+    ]
   }
 }
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -73,11 +73,12 @@ export async function fetchSongById(documentId) {
  * @returns {Promise<Object|null>}
  */
 export async function fetchLeaving(brand, { pageNumber = 1, contentPerPage = 20 } = {}) {
-  const nextQuarter = getNextAndPreviousQuarterDates()['next']
-  const filterString = `brand == '${brand}' && quarter_removed == '${nextQuarter}'`
+  const today = new Date()
+  const isoDateOnly = today.toISOString().split('T')[0]
+  const filterString = `brand == '${brand}' && quarter_removed > '${isoDateOnly}'`
   const startEndOrder = getQueryFromPage(pageNumber, contentPerPage)
   const sortOrder = {
-    sortOrder: 'published_on desc, id desc',
+    sortOrder: 'quarter_removed asc, published_on desc, id desc',
     start: startEndOrder['start'],
     end: startEndOrder['end'],
   }
@@ -99,11 +100,12 @@ export async function fetchLeaving(brand, { pageNumber = 1, contentPerPage = 20 
  * @returns {Promise<Object|null>}
  */
 export async function fetchReturning(brand, { pageNumber = 1, contentPerPage = 20 } = {}) {
-  const nextQuarter = getNextAndPreviousQuarterDates()['next']
-  const filterString = `brand == '${brand}' && quarter_published == '${nextQuarter}'`
+  const today = new Date()
+  const isoDateOnly = today.toISOString().split('T')[0]
+  const filterString = `brand == '${brand}' && quarter_published >= '${isoDateOnly}'`
   const startEndOrder = getQueryFromPage(pageNumber, contentPerPage)
   const sortOrder = {
-    sortOrder: 'published_on desc, id desc',
+    sortOrder: 'quarter_published asc, published_on desc, id desc',
     start: startEndOrder['start'],
     end: startEndOrder['end'],
   }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -85,7 +85,7 @@ export async function fetchLeaving(brand, { pageNumber = 1, contentPerPage = 20 
   const query = await buildQuery(
     filterString,
     { pullFutureContent: false, availableContentStatuses: ['published'] },
-    getFieldsForContentType(),
+    getFieldsForContentType('leaving'),
     sortOrder
   )
   return fetchSanity(query, true)


### PR DESCRIPTION
Leaving Soon and Returning should be set in the future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of leaving and returning content lists by updating filtering to use the current date instead of a fixed quarter.
  * Adjusted sorting to display items in a more logical order based on removal or publication dates.
* **New Features**
  * Added a new content type for "leaving" items, including relevant display fields and thumbnails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->