### PR TITLE
feat(BEH-837): update contentAggregator to process parent + children

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -179,7 +179,7 @@ export const lessonTypesMapping = {
   'jam tracks': ['jam-track'],
 };
 
-export const getNextLessonLessonParentTypes = ['course', 'guided-course', 'pack-bundle'];
+export const getNextLessonLessonParentTypes = ['course', 'guided-course', 'pack', 'pack-bundle', 'song-tutorial'];
 
 export const progressTypesMapping = {
   'lesson': [...singleLessonTypes,...practiceAlongsLessonTypes, ...liveArchivesLessonTypes, ...performancesLessonTypes, ...studentArchivesLessonTypes, ...documentariesLessonTypes, 'live'],

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -446,6 +446,7 @@ export let contentTypeConfig = {
         "lesson_count": child_count,
         "children": child[]->{
           "description": ${descriptionField},
+          "children": child[]->{"id": railcontent_id},
           ${getFieldsForContentType()}
         },
         ${getFieldsForContentType()}

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -175,7 +175,7 @@ export async function getContentRows(brand, pageName, contentRowSlug = null, {
 } = {}) {
   const sanityData = await addContextToContent(fetchContentRows, brand, pageName, contentRowSlug, {
     dataField: 'content',
-    iterateDataFieldOnEachArrayElement: true,
+    dataField_parentIsArray: true,
     addProgressStatus: true,
     addProgressPercentage: true,
     addNextLesson: true

--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -16,7 +16,6 @@ import {fetchLastInteractedChild, fetchLikeCount} from "./railcontent"
  * @param dataArgs - Arguments to pass to the dataPramise. The final parameter is expected to take the form of the options object
  * @param options - Options has two categories of flags. Three for defining the incoming data structure, and the rest of which data to add to the results. Unless otherwise specified the field flags use the format add<X> and add the <X> to the results
  * @param options.dataField - the document field to process. (this is often 'children', 'entity', or 'lessons'
- * @param options.dataField_parentIsArray - flag: if set with dataField, used to indicate the parent object is an array, not a single document.
  * @param options.dataField_includeParent - flag: if set with dataField, used to process the same contextual data for the parent object/array as well as the children
  * @param options.addProgressPercentage - add progressPerecentage field
  * @param options.addIsLiked - add isLikedField
@@ -55,7 +54,6 @@ export async function addContextToContent(dataPromise, ...dataArgs)
 
   const {
     dataField = null,
-    dataField_parentIsArray = false,
     dataField_includeParent = false,
     addProgressPercentage = false,
     addIsLiked = false,
@@ -70,8 +68,8 @@ export async function addContextToContent(dataPromise, ...dataArgs)
 
   let data = await dataPromise(...dataParam)
   if(!data) return false
-
-  const items = extractItemsFromData(data, dataField, dataField_parentIsArray, dataField_includeParent)
+  const isDataAnArray = Array.isArray(data)
+  const items = extractItemsFromData(data, dataField, isDataAnArray, dataField_includeParent)
   const ids = items.map(item => item?.id).filter(Boolean)
 
   if(ids.length === 0) return false
@@ -96,7 +94,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
     ...(addNextLesson ? { nextLesson: nextLessonData?.[item.id] } : {}),
   })
 
-  return await processItems(data, addContext, dataField, dataField_parentIsArray, dataField_includeParent)
+  return await processItems(data, addContext, dataField, isDataAnArray, dataField_includeParent)
 }
 
 function extractItemsFromData(data, dataField, isParentArray, includeParent)

--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -11,10 +11,17 @@ import {fetchLastInteractedChild, fetchLikeCount} from "./railcontent"
 /**
  * Combine sanity data with BE contextual data.
  *
+ * Supported dataStructures
+ *   [{}, {}, {}] <-  fetchRelatedLessons || on playback page (side bar)
+ *   {} <- fetchLessonContent || on playback page (main window)
+ *   in the examples below, dataField would be set to `children`
+ *   [{id, children}, {id, children,}] <- getTabData || catalog Page
+ *   {childen, } <- getPackData || pack index page
+ *
  *
  * @param dataPromise - promise or method that provides sanity data
  * @param dataArgs - Arguments to pass to the dataPramise. The final parameter is expected to take the form of the options object
- * @param options - Options has two categories of flags. Three for defining the incoming data structure, and the rest of which data to add to the results. Unless otherwise specified the field flags use the format add<X> and add the <X> to the results
+ * @param options - Options has two categories of flags. two for defining the incoming data structure, and the rest of which data to add to the results. Unless otherwise specified the field flags use the format add<X> and add the <X> to the results
  * @param options.dataField - the document field to process. (this is often 'children', 'entity', or 'lessons'
  * @param options.dataField_includeParent - flag: if set with dataField, used to process the same contextual data for the parent object/array as well as the children
  * @param options.addProgressPercentage - add progressPerecentage field

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -61,8 +61,6 @@ export async function getNextLesson(data)
         nextLessonData[content.id] = children[0]
 
       } else {
-        //if content in progress
-
         const childrenStates = await getProgressStateByIds(children)
 
         //calculate last_engaged
@@ -79,6 +77,8 @@ export async function getNextLesson(data)
 
         } else if (content.type === 'guided-course') {
           nextLessonData[content.id] = findIncompleteLesson(childrenStates, lastInteracted, content.type)
+        } else {
+          nextLessonData[content.id] = lastInteracted
         }
       }
     }

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -75,10 +75,17 @@ export async function getNextLesson(data)
             nextLessonData[content.id] = findIncompleteLesson(childrenStates, lastInteracted, content.type)
           }
 
-        } else if (content.type === 'guided-course') {
+        } else if (content.type === 'guided-course' || content.type === 'song-tutorial') {
           nextLessonData[content.id] = findIncompleteLesson(childrenStates, lastInteracted, content.type)
-        } else {
-          nextLessonData[content.id] = lastInteracted
+        } else if (content.type === 'pack') {
+          const packBundles = content.children ?? []
+          console.log('pack', content)
+          console.log('bundles', packBundles)
+          const packBundleProgressData = await getNextLesson(packBundles)
+          const parentId = await getLastInteractedOf(packBundles.map(bundle => bundle.id));
+          console.log('parentId', parentId)
+          console.log('bundleprogressData', packBundleProgressData)
+          nextLessonData[content.id] = packBundleProgressData[parentId];
         }
       }
     }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1977,9 +1977,9 @@ export async function fetchSanity(
     return null
   }
 
-  if (globalConfig.sanityConfig.debug) {
-    console.log('fetchSanity Query:', query)
-  }
+  // if (globalConfig.sanityConfig.debug) {
+  //   console.log('fetchSanity Query:', query)
+  // }
   const perspective = globalConfig.sanityConfig.perspective ?? 'published'
   const api = globalConfig.sanityConfig.useCachedAPI ? 'apicdn' : 'api'
   const url = `https://${globalConfig.sanityConfig.projectId}.${api}.sanity.io/v${globalConfig.sanityConfig.version}/data/query/${globalConfig.sanityConfig.dataset}?perspective=${perspective}`

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1074,7 +1074,7 @@ async function processContentItem(item) {
   let ctaText = 'Continue';
   if (contentType === 'transcription' || contentType === 'play-along' || contentType === 'jam-track') ctaText = 'Replay Song';
   if (contentType === 'lesson') ctaText = status === 'completed' ? 'Revisit Lesson' : 'Continue';
-  if ((contentType === 'song tutorial' || collectionLessonTypes.includes(contentType)) &&  status === 'completed') ctaText = 'Revisit Lessons' ;
+  if ((contentType === 'song-tutorial' || collectionLessonTypes.includes(contentType)) &&  status === 'completed') ctaText = 'Revisit Lessons' ;
   if (contentType === 'pack' && status === 'completed') {
     ctaText = 'View Lessons';
   }


### PR DESCRIPTION
Tested in devendpoint with and verified the nextLesson was 411422.
```
postContentComplete(411421).then(r => {
  console.log('content complete', r)
  const content = 411418
  addContextToContent(
      fetchPackData,
      content,
      {
        dataField: 'children',
        dataField_includeParent: true,
        addNextLesson: true,
        addProgressStatus: true,
      }
  )
      .then((r) => {
        console.log('expected nextLesson and add progressStatun')
        console.log('response', r)
      })
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional content types ('pack', 'pack-bundle', 'song-tutorial') in the "next lesson" functionality.

* **Improvements**
  * Enhanced handling and flexibility for adding contextual data to nested content with more precise control.
  * Improved logic for determining the next lesson across content types, including recursive handling for packs.

* **Cleanup**
  * Removed unused and commented-out code for better maintainability.
  * Disabled debug logging of query strings for cleaner console output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->