### PR TITLE
feat: MU2-805 Set a pauseLiveEventPollingUntil field when user mark all notificatio…

### DIFF
--- a/src/services/user/notifications.js
+++ b/src/services/user/notifications.js
@@ -3,6 +3,7 @@
  */
 import { fetchHandler } from '../railcontent.js'
 import './types.js'
+import {fetchLiveEvent} from "../sanity";
 
 const baseUrl = `/api/notifications`
 
@@ -68,7 +69,12 @@ export async function markNotificationAsRead(notificationId) {
  *   .then(response => console.log(response))
  *   .catch(error => console.error(error));
  */
-export async function markAllNotificationsAsRead() {
+export async function markAllNotificationsAsRead(brand = 'drumeo') {
+  const liveEvent = await fetchLiveEvent(brand)
+  if(liveEvent){
+    await pauseLiveEventPollingUntil(liveEvent.live_event_end_time)
+  }
+
   const url = `${baseUrl}/v1/read`
   return fetchHandler(url, 'put')
 }
@@ -223,6 +229,26 @@ export async function updateNotificationSetting({ brand, settingName, email, pus
 
   return fetchHandler(url, 'PUT', null, payload);
 }
+
+/**
+  * Pauses live event polling until the specified time.
+  * @param {string|null} [until=null] - ISO timestamp string or null to unpause
+  * @returns {Promise<Object>} - Promise resolving to the API response
+ */
+export async function pauseLiveEventPollingUntil(until = null) {
+    const url = `/api/user-management-system/v1/users/polling${until ? `?until=${until}` : ''}`
+    return fetchHandler(url, 'PUT', null)
+}
+
+/**
+ * Fetches the current live event polling state.
+ + @returns {Promise<Object>} - Promise resolving to the polling state
+ */
+
+  export async function fetchLiveEventPollingState() {
+    const url = `/api/user-management-system/v1/users/polling`
+    return fetchHandler(url, 'GET', null)
+  }
 
 
 

--- a/src/services/user/notifications.js
+++ b/src/services/user/notifications.js
@@ -236,8 +236,17 @@ export async function updateNotificationSetting({ brand, settingName, email, pus
   * @returns {Promise<Object>} - Promise resolving to the API response
  */
 export async function pauseLiveEventPollingUntil(until = null) {
-    const url = `/api/user-management-system/v1/users/polling${until ? `?until=${until}` : ''}`
+    const url = `/api/user-management-system/v1/users/pause-polling${until ? `?until=${until}` : ''}`
     return fetchHandler(url, 'PUT', null)
+}
+
+/**
+ * Start live event polling.
+ * @returns {Promise<Object>} - Promise resolving to the API response
+ */
+export async function startLiveEventPolling() {
+  const url = `/api/user-management-system/v1/users/start-polling`
+  return fetchHandler(url, 'PUT', null)
 }
 
 /**


### PR DESCRIPTION
[MU2-805](https://musora.atlassian.net/browse/MU2-805)
[MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/204)

[MU2-805]: https://musora.atlassian.net/browse/MU2-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to pause or resume live event polling until a specified time.
  * Users can now view the current state of live event polling.

* **Improvements**
  * Marking all notifications as read now considers the current live event and can pause polling as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->