### PR TITLE
fix: recent lessons do not displayed children lessons

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -206,7 +206,7 @@ export const filterTypes = {
 }
 
 export const recentTypes = {
-  lessons: [...individualLessonsTypes],
+  lessons: [...individualLessonsTypes, 'course-part', 'pack-bundle-lesson'],
   songs: [...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes],
   home: [...individualLessonsTypes, ...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes,
   'guided-course', 'learning-path', 'live']

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -206,7 +206,7 @@ export const filterTypes = {
 }
 
 export const recentTypes = {
-  lessons: [...individualLessonsTypes, 'course-part', 'pack-bundle-lesson'],
+  lessons: [...individualLessonsTypes, 'course-part', 'pack-bundle-lesson', 'challenge-part', 'guided-course-part'],
   songs: [...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes],
   home: [...individualLessonsTypes, ...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes,
   'guided-course', 'learning-path', 'live']


### PR DESCRIPTION

The following content is not showing up in the Recent Lessons section based on the user history Sheldon seeded:
- 30 Day Drummer (all lessons)
- 10-Day Fills (from intro up until Flams & Fills)

We should display all children's content in the Recent lessons section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the range of lesson types classified as "recent" to include additional lesson and challenge-related types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->