### PR TITLE
fix: Add live event fallback to unread notifications count

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -261,6 +261,7 @@ import {
 
 import {
 	deleteNotification,
+	fetchLiveEventPollingState,
 	fetchNotificationSettings,
 	fetchNotifications,
 	fetchUnreadCount,
@@ -382,6 +383,7 @@ declare module 'musora-content-services' {
 		fetchLessonsFeaturingThisContent,
 		fetchLikeCount,
 		fetchLiveEvent,
+		fetchLiveEventPollingState,
 		fetchMetadata,
 		fetchMethod,
 		fetchMethodChildren,

--- a/src/index.js
+++ b/src/index.js
@@ -261,6 +261,7 @@ import {
 
 import {
 	deleteNotification,
+	fetchLiveEventPollingState,
 	fetchNotificationSettings,
 	fetchNotifications,
 	fetchUnreadCount,
@@ -381,6 +382,7 @@ export {
 	fetchLessonsFeaturingThisContent,
 	fetchLikeCount,
 	fetchLiveEvent,
+	fetchLiveEventPollingState,
 	fetchMetadata,
 	fetchMethod,
 	fetchMethodChildren,

--- a/src/services/user/notifications.js
+++ b/src/services/user/notifications.js
@@ -138,6 +138,7 @@ export async function deleteNotification(notificationId) {
  *   .catch(error => console.error(error));
  */
 export async function fetchUnreadCount({ brand = 'drumeo'} = {}) {
+  const url = `${baseUrl}/v1/unread-count`
   const notifUnread =  await fetchHandler(url, 'get')
   if (notifUnread.data > 0) {
     return notifUnread// Return early if unread notifications exist
@@ -266,10 +267,10 @@ export async function startLiveEventPolling(brand = 'drumeo') {
  + @returns {Promise<Object>} - Promise resolving to the polling state
  */
 
-  export async function fetchLiveEventPollingState() {
+export async function fetchLiveEventPollingState() {
     const url = `/api/user-management-system/v1/users/polling`
     return fetchHandler(url, 'GET', null)
-  }
+}
 
 
 


### PR DESCRIPTION
Update fetchUnreadCount method: first checks for standard unread notifications. If none are found, it checks if live event polling is active. If so, it will query for any ongoing live events. If a live event is active, it counts as an unread item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved logic for displaying unread notifications, now also indicating unread live event notifications when applicable.
  * Enhanced live event polling behavior to better manage notification read states during active events.

* **Documentation**
  * Updated user-facing documentation to clarify notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->