### PR TITLE
fix: T3PS-21: Live Stream content cards in the Progress Row and Recent Lessons

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -520,10 +520,12 @@ export async function fetchByRailContentIds(ids, contentType = undefined, brand 
   }
   const idsString = ids.join(',')
   const brandFilter = brand ? ` && brand == "${brand}"` : ''
+  const now = getSanityDate(new Date())
   const query = `*[
     railcontent_id in [${idsString}]${brandFilter}
   ]{
     ${getFieldsForContentType(contentType)}
+   'isLive': live_event_start_time <= "${now}" && live_event_end_time >= "${now}",
   }`
 
   const results = await fetchSanity(query, true)
@@ -2385,6 +2387,7 @@ export async function fetchTabData(
   }
 
   const fieldsString = getFieldsForContentType('tab-data');
+  const now = getSanityDate(new Date())
 
   // Determine the group by clause
   let query = ''
@@ -2396,6 +2399,7 @@ export async function fetchTabData(
   entityFieldsString =
     ` ${fieldsString}
     'children': child[${childrenFilter}]->{'id': railcontent_id},
+    'isLive': live_event_start_time <= "${now}" && live_event_end_time >= "${now}",
     'lesson_count': coalesce(count(child[${childrenFilter}]->), 0),
     'length_in_seconds': coalesce(
       math::sum(

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1073,6 +1073,7 @@ async function processContentItem(item) {
   let data = item.raw;
   const contentType = getFormattedType(data.type, data.brand);
   const status = item.state;
+  const isLive = data.isLive ?? false
   let ctaText = 'Continue';
   if (contentType === 'transcription' || contentType === 'play-along' || contentType === 'jam-track') ctaText = 'Replay Song';
   if (contentType === 'lesson') ctaText = status === 'completed' ? 'Revisit Lesson' : 'Continue';
@@ -1162,10 +1163,11 @@ async function processContentItem(item) {
       progressPercent: item.percent,
       thumbnail:       data.thumbnail,
       title:           data.title,
+      isLive:          isLive,
       badge:           data.badge ?? null,
       isLocked:        data.is_locked ?? false,
       subtitle:        !data.child_count || data.lesson_count === 1
-        ? (contentType === 'lesson') ? `${item.percent}% Complete`: `${data.difficulty_string} • ${data.artist_name}`
+        ? (contentType === 'lesson' && isLive === false) ? `${item.percent}% Complete`: `${data.difficulty_string} • ${data.artist_name}`
         : `${data.completed_children} of ${data.lesson_count ?? data.child_count} Lessons Complete`
     },
     cta:               {

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1160,7 +1160,7 @@ async function processContentItem(item) {
     header:            contentType,
     pinned:            item.pinned ?? false,
     body:              {
-      progressPercent: item.percent,
+      progressPercent: isLive ? undefined: item.percent,
       thumbnail:       data.thumbnail,
       title:           data.title,
       isLive:          isLive,


### PR DESCRIPTION
[T3PS-21](https://musora.atlassian.net/browse/T3PS-21?atlOrigin=eyJpIjoiMTE4NGMxM2NjY2M3NDQ5MTg2NTkzNGIxZTU3NjkwOTgiLCJwIjoiaiJ9)
- Add `isLive` flag to Recent Lessons and Progress Rows  
- Update Progress Rows subtitle to reflect live lessons

[T3PS-21]: https://musora.atlassian.net/browse/T3PS-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an indicator to show whether content is currently live.
  * Updated subtitles for live lessons to display difficulty and artist name instead of progress percentage.

* **Bug Fixes**
  * Improved accuracy of live status display for content items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->