### PR TITLE
feat(BEH-802): getting rid of V1 cert and badges and adding it from the correct "content-award" type

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -49,6 +49,11 @@ export const resourcesField = `[
           ... *[railcontent_id == ^.parent_content_data[0].id] [0].resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )},
           ]`
 
+export const awardField = " *[_type == 'content-award' && references(^._id)] {\n" +
+  "    'badgeUrl': badge.asset->url,\n" +
+  "    'awardUrl': award.asset->url\n" +
+  "  }"
+
 /*
  *  NOTE: TP-366 - Arrays can be either arrays of different objects or arrays of different primitives, not both
  *  updated query so assignment_sheet_music_image can be either an image or a URL

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -16,6 +16,7 @@ import {
   coachLessonsTypes,
   getChildFieldsForContentType,
   SONG_TYPES,
+  awardField,
 } from '../contentTypeConfig.js'
 import {fetchSimilarItems, recommendations} from './recommendations.js'
 import { processMetadata, typeWithSortOrder } from '../contentMetaData.js'
@@ -1283,6 +1284,7 @@ export async function fetchLessonContent(railContentId) {
           published_on,
           "type":_type,
           "resources": ${resourcesField},
+          "award": ${awardField}
           difficulty,
           difficulty_string,
           brand,


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

[BEH-802](https://musora.atlassian.net/browse/BEH-802)
[mpb](https://github.com/railroadmedia/musora-platform-backend/pull/208)

## Description/Design
Award material is being pulled from the award document instead of the guide course document in 3 locations:
- [Enrollment page data (`getGuidedCourseEnrollmentPageData() && getChallengeEnrollmentPageData()`)
](https://github.com/railroadmedia/musora-platform-backend/pull/208)
- Playback page (`fetchLessonContent()`)
- Home page (`getProgressRows()`)

[BEH-802]: https://musora.atlassian.net/browse/BEH-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Lesson content now includes award information, providing access to related badge and award URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->