### PR TITLE
fix: Song Tutorials are showing up in Recent Songs as collections

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -207,7 +207,7 @@ export const filterTypes = {
 
 export const recentTypes = {
   lessons: [...individualLessonsTypes, 'course-part', 'pack-bundle-lesson', 'challenge-part', 'guided-course-part', 'quick-tips'],
-  songs: [...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes],
+  songs: [...transcriptionsLessonTypes, ...playAlongLessonTypes, 'song-tutorial-children'],
   home: [...individualLessonsTypes, ...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes,
   'guided-course', 'learning-path', 'live']
 }

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -191,7 +191,7 @@ export async function getAllStartedOrCompleted({ limit = null, onlyIds = true, b
       const isRecent = item[DATA_KEY_LAST_UPDATED_TIME] >= oneMonthAgoInSeconds
       const isCorrectBrand = !brand || !item.b || item.b === brand
       const isNotExcluded = !excludedSet.has(id)
-      return isRelevantStatus && isRecent && isCorrectBrand && isNotExcluded
+      return isRelevantStatus && isCorrectBrand && isNotExcluded
     })
     .sort(([, a], [, b]) => {
       const v1 = a[DATA_KEY_LAST_UPDATED_TIME]


### PR DESCRIPTION
[T3PS-434](https://musora.atlassian.net/browse/T3PS-434?atlOrigin=eyJpIjoiMmRlZGI5MzA2MmY4NGE0NDg3YzViMTNmZGY5ZDVkNDAiLCJwIjoiaiJ9)
'Recent Songs' shows the whole Song Tutorial collection rather than just song-tut-part info