### PR TITLE
fix(T3PS-426): Delete last practice from a session

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -355,9 +355,14 @@ export async function removeUserPractice(id) {
     async function (localContext) {
       if (localContext.data?.[DATA_KEY_PRACTICES]) {
         Object.keys(localContext.data[DATA_KEY_PRACTICES]).forEach((date) => {
-          localContext.data[DATA_KEY_PRACTICES][date] = localContext.data[DATA_KEY_PRACTICES][
-            date
-            ].filter((practice) => practice.id !== id)
+          const filtered = localContext.data[DATA_KEY_PRACTICES][date].filter(
+            (practice) => practice.id !== id
+          )
+          if (filtered.length > 0) {
+            localContext.data[DATA_KEY_PRACTICES][date] = filtered
+          } else {
+            delete localContext.data[DATA_KEY_PRACTICES][date]
+          }
         })
       }
     },


### PR DESCRIPTION
[T3PS-42](https://musora.atlassian.net/browse/T3PS-426?atlOrigin=eyJpIjoiZTFhNzViMWRmNmY4NDdiOGI2MGM1YWUyNzYzMGM5NzQiLCJwIjoiaiJ9)6 -  Deleted practice doesn't reflect in streaks

When we delete last practice from a session, we need to delete session also for streak calculation


[T3PS-42]: https://musora.atlassian.net/browse/T3PS-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved removal of practice sessions to ensure dates with no remaining practices are also cleared from the activity view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->