### PR TITLE
fix: T3PS-501: Homepage progress rows - content types

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -963,11 +963,14 @@ export async function getProgressRows({ brand = null, limit = 8 } = {}) {
     }
   });
 
+  const allRecentTypeSet = new Set(
+    Object.values(recentTypes).flat()
+  )
   const progressMap = new Map();
   for (const [idStr, progress] of Object.entries(progressContents)) {
     const id = parseInt(idStr);
     const content = contentsMap[id];
-    if (!content || excludedTypes.has(content.type)  || !recentTypes.has(content.type) ) continue;
+    if (!content || excludedTypes.has(content.type)  || !allRecentTypeSet.has(content.type) ) continue;
     const parentId = childToParentMap[id];
     // Handle children with parents
     if (parentId) {

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -18,7 +18,7 @@ import {fetchPlaylist, fetchUserPlaylists} from "./content-org/playlists"
 import {pinnedGuidedCourses} from "./content-org/guided-courses"
 import {convertToTimeZone, getMonday, getWeekNumber, isSameDate, isNextDay, getTimeRemainingUntilLocal, toDayjs} from './dateUtils.js'
 import { globalConfig } from './config'
-import {collectionLessonTypes, lessonTypesMapping, progressTypesMapping, showsLessonTypes, songs} from "../contentTypeConfig";
+import {collectionLessonTypes, lessonTypesMapping, progressTypesMapping, recentTypes, showsLessonTypes, songs} from "../contentTypeConfig";
 import {
   getAllStartedOrCompleted,
   getProgressPercentageByIds,
@@ -967,7 +967,7 @@ export async function getProgressRows({ brand = null, limit = 8 } = {}) {
   for (const [idStr, progress] of Object.entries(progressContents)) {
     const id = parseInt(idStr);
     const content = contentsMap[id];
-    if (!content || excludedTypes.has(content.type)) continue;
+    if (!content || excludedTypes.has(content.type)  || !recentTypes.has(content.type) ) continue;
     const parentId = childToParentMap[id];
     // Handle children with parents
     if (parentId) {


### PR DESCRIPTION
The progress section (from the last card in the Progress Row) is showing two layers of the same content. It should only show the parent for a collection, not the children as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of user activity to display only relevant and recent content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->