### PR TITLE
fix(BEH-873): Lessons Featuring this Song and Other Versions of this Song, restricted to current brand

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1435,9 +1435,8 @@ export async function fetchLessonsFeaturingThisContent(railcontentId, brand, cou
  */
 async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, count) {
   const typeCheck = `@->_type in [${arrayJoinWithQuotes(SONG_TYPES)}]`
-  let typeCheckString = `brand == '${brand}' && `
+  let typeCheckString = `@->brand == '${brand}' && `
   typeCheckString += onlyUseSongTypes ? `${typeCheck}` : `!(${typeCheck})`
-  console.log('typecheckSTring', typeCheckString)
   const contentFromLicenseFilter = `_type == 'license' && references(^._id)].content[${typeCheckString} && @->railcontent_id != ${railcontentId}`
   let filterSongTypesWithSameLicense = await new FilterBuilder(contentFromLicenseFilter, {
     isChildrenFilter: true,
@@ -1454,7 +1453,6 @@ async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, cou
       "related_by_license" :
           *[${filterSongTypesWithSameLicense}]->{${queryFields}}|order(published_on desc, title asc)[0...${count}],
       }[0...1]`
-  console.log('finalquery', query)
   const results = await fetchSanity(query, false)
   return results['related_by_license'] ?? []
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1435,7 +1435,9 @@ export async function fetchLessonsFeaturingThisContent(railcontentId, brand, cou
  */
 async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, count) {
   const typeCheck = `@->_type in [${arrayJoinWithQuotes(SONG_TYPES)}]`
-  const typeCheckString = onlyUseSongTypes ? `${typeCheck}` : `!(${typeCheck})`
+  let typeCheckString = `brand == '${brand}' && `
+  typeCheckString += onlyUseSongTypes ? `${typeCheck}` : `!(${typeCheck})`
+  console.log('typecheckSTring', typeCheckString)
   const contentFromLicenseFilter = `_type == 'license' && references(^._id)].content[${typeCheckString} && @->railcontent_id != ${railcontentId}`
   let filterSongTypesWithSameLicense = await new FilterBuilder(contentFromLicenseFilter, {
     isChildrenFilter: true,
@@ -1452,7 +1454,7 @@ async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, cou
       "related_by_license" :
           *[${filterSongTypesWithSameLicense}]->{${queryFields}}|order(published_on desc, title asc)[0...${count}],
       }[0...1]`
-
+  console.log('finalquery', query)
   const results = await fetchSanity(query, false)
   return results['related_by_license'] ?? []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1961,6 +1961,11 @@ dateformat@^3.0.0:
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.6"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz"


### PR DESCRIPTION
[JIRA](https://musora.atlassian.net/browse/BEH-873)
ANd [this](https://musora.atlassian.net/browse/T3PS-377) which was tested but worked without me doing anything

## Description
- added missing brand restriction argument
- also updated yarn lock for building locally


## Testing

Published/Status restriction
I actually didn't make any changes for this. I checked the queryin the console log and saw the permissions + status restrictions. However, the results are cached briefly, so the bug is related to sanity caching, not the query. The sanity cache lasts a few minutes so you can unlist a piece of content, run the next test then come back :)

I used this as the base: drumeo/songs/transcription/260343
and this content which is related by license (which will show up if in published state and not if unlisted)
https://devapi.musora.com:9443/admin/studio/publishing/structure/__edit__learning-path-lesson_333874%2Ctype%3Dlearning-path-lesson
"C Color Chords"
ID: 333874


Brand restriction
On [Production](https://app.musora.com/drumeo/songs/transcription/260371) (has full version + guitareo versions) for both 
<img width="1070" height="1104" alt="image" src="https://github.com/user-attachments/assets/f47b9ec0-e59b-49ac-a022-e534eb101042" />

On [Local](http://localhost:5173/drumeo/songs/transcription/260371) (should only have the full version)
<img width="1352" height="478" alt="image" src="https://github.com/user-attachments/assets/9e7d6e6d-1a84-4bc1-ab4b-c7f67f7bd2e7" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of related content to ensure results now match the specified brand as well as the content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->