### PR TITLE
fix: add last engaged fields to homepage progress row playlist card cta

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1237,6 +1237,8 @@ async function processPlaylistItem(item) {
         brand:  playlist.brand,
         id:     playlist.id,
         itemId: nextItem.id,
+        lastEngagedOn: playlist.last_engaged_on,
+        lastEngagedOnItem: playlist.last_engaged_on_item,
         type:   'playlists',
       }
     }


### PR DESCRIPTION
## Changes:
- add playlist `last_engaged_on` (content_id) and `last_engaged_on_item` (playlist item id) to cta field for playlist card on hoomepage progress row

## Testing: 
- make progress on a playlist
- go to homepage
- use vue devtools to inspect the ContentCard for the recent playlist
- look at cta, should have the above fields