### PR TITLE
fix(nullcheck): patch for null sanity results and null check in relatedByLicense

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -565,15 +565,17 @@ export async function fetchContentRows(brand, pageName, contentRowSlug)
   if (pageName === 'lessons') pageName = 'lesson'
   if (pageName === 'songs') pageName = 'song'
   const rowString = contentRowSlug ? ` && slug.current == "${contentRowSlug.toLowerCase()}"` : ''
-  return fetchSanity(`*[_type == 'recommended-content-row' && brand == '${brand}' && type == '${pageName}'${rowString}]{
+  const childFilter = await new FilterBuilder('', {isChildrenFilter: true}).buildFilter()
+  const query = `*[_type == 'recommended-content-row' && brand == '${brand}' && type == '${pageName}'${rowString}]{
     brand,
     name,
     'slug': slug.current,
-    'content': content[]->{
-        'children': child[]->{ 'id': railcontent_id, 'children': child[]->{'id': railcontent_id}, },
+    'content': content[${childFilter}]->{
+        'children': child[${childFilter}]->{ 'id': railcontent_id, 'children': child[${childFilter}]->{'id': railcontent_id}, },
         ${getFieldsForContentType('tab-data')}
     },
-  }`, true)
+  }`
+  return fetchSanity(query, true)
 }
 
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1265,7 +1265,7 @@ async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, cou
           *[${filterSongTypesWithSameLicense}]->{${queryFields}}|order(published_on desc, title asc)[0...${count}],
       }[0...1]`
   const results = await fetchSanity(query, false)
-  return results['related_by_license'] ?? []
+  return results ? results['related_by_license'] ?? [] : []
 }
 
 /**
@@ -1862,6 +1862,9 @@ export async function fetchSanity(
         console.log('fetchSanity Results:', result)
       }
       let results = isList ? result.result : result.result[0]
+      if (!results) {
+        throw new Error('No results found')
+      }
       results = processNeedAccess
         ? await needsAccessDecorator(results, userPermissions, isAdmin)
         : results


### PR DESCRIPTION
Testing:
- this page should load. There are errors in console. But they should be "Not Sanity Results Found" ... because this content is deleted.
- 
- https://devapp.musora.com:5174/drumeo/songs/play-along/224279

Drumeo "For you" has a deleted Play along "Quest For Pocket"
https://devapi.musora.com:9443/admin/studio/publishing/structure/play-along;play-along_224279
Verify this isn't shown on the [For you page](https://devapp.musora.com:5174/drumeo/lessons)
I manually did this and check the console.log has the correct child filters for status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or null data when fetching related items, preventing potential errors.
  * Added clearer error messaging if no results are found during data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->