### PR TITLE
feat(navigateTo): Add navigateTo context and update homepageprogress rows to pull the same data as other locations

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -1,5 +1,6 @@
 //import {AWSUrl, CloudFrontURl} from "./services/config";
 import {Tabs} from "./contentMetaData.js";
+import {FilterBuilder} from "./filterBuilder.js";
 
 export const AWSUrl = 'https://s3.us-east-1.amazonaws.com/musora-web-platform'
 export const CloudFrontURl = 'https://d3fzm1tzeyr5n3.cloudfront.net'
@@ -34,12 +35,27 @@ export const DEFAULT_FIELDS = [
   '"lesson_count": coalesce(count(child[]->.child[]->), child_count)',
   '"parent_id": parent_content_data[0].id',
 ]
+
 export const DEFAULT_CHILD_FIELDS = [
-  `"id": railcontent_id`,
-  `title`,
-  `"image": thumbnail.asset->url`,
-  `"instructors": instructor[]->name`,
-  `length_in_seconds`,
+  "'id': railcontent_id",
+  'railcontent_id',
+  artistOrInstructorName(),
+  "'artist': artist->{ 'name': name, 'thumbnail': thumbnail_url.asset->url}",
+  'title',
+  "'image': thumbnail.asset->url",
+  "'thumbnail': thumbnail.asset->url",
+  'difficulty',
+  'difficulty_string',
+  'published_on',
+  "'type': _type",
+  "'length_in_seconds' : coalesce(length_in_seconds, soundslice[0].soundslice_length_in_second)",
+  'brand',
+  "'genre': genre[]->name",
+  'status',
+  "'slug' : slug.current",
+  "'permission_id': permission[]->railcontent_id",
+  'child_count',
+  '"parent_id": parent_content_data[0].id',
 ]
 
 export const instructorField = `instructor[]->{
@@ -240,22 +256,8 @@ export let contentTypeConfig = {
     fields: [
       '"parent_content_data": parent_content_data[].id',
       '"badge" : badge.asset->url',
-      '"children": child[]->{' +
-        '"id": railcontent_id,' +
-        '"slug":slug.current,' +
-        '"brand":brand,' +
-        '"type": _type,' +
-        '"thumbnail": thumbnail.asset->url,' +
-        'published_on,' +
-        '"children": child[]->{' +
-          '"id":railcontent_id,' +
-          '"slug":slug.current,' +
-          '"type": _type,' +
-          '"brand":brand},' +
-          '"thumbnail": thumbnail.asset->url,' +
-          'published_on,' +
-        '}',
     ],
+    includeChildFields: true,
   },
   song: {
     fields: ['album', 'soundslice', 'instrumentless', `"resources": ${resourcesField}`],
@@ -279,6 +281,7 @@ export let contentTypeConfig = {
             }`,
       '"instructors": instructor[]->name',
     ],
+    includeChildFields: true,
     relationships: {
       artist: {
         isOneToOne: true,
@@ -421,25 +424,19 @@ export let contentTypeConfig = {
       '"instructors": instructor[]->{ "id": railcontent_id, name, "thumbnail_url": thumbnail_url.asset->url }',
       '"logo_image_url": logo_image_url.asset->url',
       'total_xp',
-      `"children": child[]->{
-        "description": ${descriptionField},
-        "lesson_count": child_count,
-        "instructors": select(
-          instructor != null => instructor[]->name,
-          ^.instructor[]->name
-        ),
-        "children": child[]->{
-          "description": ${descriptionField},
-          "children": child[]->{"id": railcontent_id},
-          ${getFieldsForContentType()}
-        },
-        ${getFieldsForContentType()}
-      }`,
       `"resources": ${resourcesField}`,
       '"thumbnail": thumbnail.asset->url',
       '"light_mode_logo": light_mode_logo_url.asset->url',
       '"dark_mode_logo": dark_mode_logo_url.asset->url',
       `"description": ${descriptionField}`,
+    ],
+    childFields: [
+      `'description': ${descriptionField}`,
+      "'lesson_count': child_count",
+      `'instructors': select(
+        instructor != null => instructor[]->name,
+        ^.instructor[]->name
+      )`,
     ],
   },
   rudiment: {
@@ -453,10 +450,6 @@ export let contentTypeConfig = {
   'pack-children': {
     fields: [
       'child_count',
-      `"children": child[]->{
-                "description": ${descriptionField},
-                ${getFieldsForContentType()}
-            }`,
       `"resources": ${resourcesField}`,
       '"image": logo_image_url.asset->url',
       '"thumbnail": thumbnail.asset->url',
@@ -465,6 +458,9 @@ export let contentTypeConfig = {
       `"description": ${descriptionField}`,
       'total_xp',
     ],
+    childFields: [
+      `"description": ${descriptionField}`,
+    ]
   },
   'pack-bundle-lesson': {
     fields: [`"resources": ${resourcesField}`],
@@ -678,17 +674,39 @@ export function artistOrInstructorNameAsArray(key = 'artists') {
   return `'${key}': select(artist->name != null => [artist->name], instructor[]->name)`
 }
 
-export function getFieldsForContentType(contentType, asQueryString = true) {
+export async function getFieldsForContentTypeWithFilteredChildren(contentType, asQueryString = true) {
+  const childFields = getChildFieldsForContentType(contentType, true)
+  const parentFields = getFieldsForContentType(contentType, false)
+  if (childFields) {
+    const childFilter = await new FilterBuilder('', {isChildrenFilter: true}).buildFilter()
+    parentFields.push(
+      `"children": child[${childFilter}] {
+        ${childFields}
+        "children": child[${childFilter}] {
+          ${childFields}
+        },
+      }`
+    )
+  }
+  return asQueryString ? parentFields.toString() + ',' : parentFields
+}
+
+export function getChildFieldsForContentType(contentType, asQueryString = true)
+{
+  if (contentTypeConfig[contentType]?.childFields || contentTypeConfig[contentType]?.includeChildFields) {
+    const childFields = contentType
+      ? DEFAULT_CHILD_FIELDS.concat(contentTypeConfig?.[contentType]?.childFields ?? [])
+      : DEFAULT_CHILD_FIELDS
+    return asQueryString ? childFields.toString() + ',' : childFields
+  } else {
+    return asQueryString ? '' : []
+  }
+}
+
+export function getFieldsForContentType(contentType, asQueryString = true, includeChildren = false) {
   const fields = contentType
     ? DEFAULT_FIELDS.concat(contentTypeConfig?.[contentType]?.fields ?? [])
     : DEFAULT_FIELDS
-  return asQueryString ? fields.toString() + ',' : fields
-}
-
-export function getChildFieldsForContentType(contentType, asQueryString = true) {
-  const fields = contentType
-    ? DEFAULT_CHILD_FIELDS.concat(childContentTypeConfig?.[contentType] ?? [])
-    : DEFAULT_CHILD_FIELDS
   return asQueryString ? fields.toString() + ',' : fields
 }
 

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -291,6 +291,9 @@ export let contentTypeConfig = {
   'song-tutorial-children': {
     fields: [`"resources": ${resourcesField}`],
   },
+  'guided-course': {
+    includeChildFields: true,
+  },
   course: {
     fields: [
       '"lesson_count": child_count',

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -707,7 +707,7 @@ export function getChildFieldsForContentType(contentType, asQueryString = true)
   }
 }
 
-export function getFieldsForContentType(contentType, asQueryString = true, includeChildren = false) {
+export function getFieldsForContentType(contentType, asQueryString = true) {
   const fields = contentType
     ? DEFAULT_FIELDS.concat(contentTypeConfig?.[contentType]?.fields ?? [])
     : DEFAULT_FIELDS

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -202,7 +202,7 @@ export const progressTypesMapping = {
   'show': showsLessonTypes,
   'song tutorial': [...tutorialsLessonTypes, 'song-tutorial-children'],
   'songs': transcriptionsLessonTypes,
-  'play-along': playAlongLessonTypes,
+  'play along': playAlongLessonTypes,
   'guided course': ['guided-course'],
   'pack': ['pack', 'semester-pack'],
   'method': ['learning-path'],
@@ -240,14 +240,14 @@ export let contentTypeConfig = {
     fields: [
       '"parent_content_data": parent_content_data[].id',
       '"badge" : badge.asset->url',
-      '"lessons": child[]->{' +
+      '"children": child[]->{' +
         '"id": railcontent_id,' +
         '"slug":slug.current,' +
         '"brand":brand,' +
         '"type": _type,' +
         '"thumbnail": thumbnail.asset->url,' +
         'published_on,' +
-        '"lessons": child[]->{' +
+        '"children": child[]->{' +
           '"id":railcontent_id,' +
           '"slug":slug.current,' +
           '"type": _type,' +
@@ -256,9 +256,6 @@ export let contentTypeConfig = {
           'published_on,' +
         '}',
     ],
-
-
-
   },
   song: {
     fields: ['album', 'soundslice', 'instrumentless', `"resources": ${resourcesField}`],

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -251,6 +251,7 @@ export let contentTypeConfig = {
       'enrollment_start_time',
       'enrollment_end_time',
     ],
+    includeChildFields: true,
   },
   'progress-tracker': {
     fields: [
@@ -683,9 +684,9 @@ export async function getFieldsForContentTypeWithFilteredChildren(contentType, a
   if (childFields) {
     const childFilter = await new FilterBuilder('', {isChildrenFilter: true}).buildFilter()
     parentFields.push(
-      `"children": child[${childFilter}] {
+      `"children": child[${childFilter}]->{
         ${childFields}
-        "children": child[${childFilter}] {
+        "children": child[${childFilter}]->{
           ${childFields}
         },
       }`

--- a/src/services/content-org/playlists.js
+++ b/src/services/content-org/playlists.js
@@ -3,7 +3,7 @@
  */
 import { globalConfig } from '../config.js'
 import { fetchHandler } from '../railcontent.js'
-import { getNextLessonForPlaylists } from '../contentAggregator.js'
+import { getNavigateToForPlaylists } from '../contentAggregator.js'
 import './playlists-types.js'
 
 /**
@@ -43,7 +43,7 @@ export async function fetchUserPlaylists(
   const content = content_id ? `&content_id=${content_id}` : ''
   const brandString = brand ? `&brand=${brand}` : ''
   const url = `${BASE_PATH}/v1/user/playlists${pageString}${brandString}${limitString}${sortString}${content}`
-  return await getNextLessonForPlaylists(await fetchHandler(url), {dataField: 'data'})
+  return await getNavigateToForPlaylists(await fetchHandler(url), {dataField: 'data'})
 }
 
 /**
@@ -345,7 +345,7 @@ export async function duplicatePlaylist(playlistId, playlistData) {
  */
 export async function fetchPlaylist(playlistId) {
   const url = `${BASE_PATH}/v1/user/playlists/${playlistId}`
-  return await getNextLessonForPlaylists(await fetchHandler(url))
+  return await getNavigateToForPlaylists(await fetchHandler(url))
 }
 
 /**

--- a/src/services/content-org/playlists.js
+++ b/src/services/content-org/playlists.js
@@ -3,6 +3,7 @@
  */
 import { globalConfig } from '../config.js'
 import { fetchHandler } from '../railcontent.js'
+import { getNextLessonForPlaylists } from '../contentAggregator.js'
 import './playlists-types.js'
 
 /**
@@ -42,7 +43,7 @@ export async function fetchUserPlaylists(
   const content = content_id ? `&content_id=${content_id}` : ''
   const brandString = brand ? `&brand=${brand}` : ''
   const url = `${BASE_PATH}/v1/user/playlists${pageString}${brandString}${limitString}${sortString}${content}`
-  return await fetchHandler(url)
+  return await getNextLessonForPlaylists(await fetchHandler(url), {dataField: 'data'})
 }
 
 /**
@@ -344,7 +345,7 @@ export async function duplicatePlaylist(playlistId, playlistData) {
  */
 export async function fetchPlaylist(playlistId) {
   const url = `${BASE_PATH}/v1/user/playlists/${playlistId}`
-  return await fetchHandler(url, 'GET')
+  return await getNextLessonForPlaylists(await fetchHandler(url))
 }
 
 /**

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -384,7 +384,7 @@ export async function getRecommendedForYou(brand, rowId = null, {
   limit = 10,
 } = {}) {
   const requiredItems = page * limit;
-  const data = recommendations( brand, {limit: requiredItems})
+  const data = await recommendations( brand, {limit: requiredItems})
   if (!data || !data.length) {
     return { id: 'recommended', title: 'Recommended For You', items: [] };
   }
@@ -392,13 +392,11 @@ export async function getRecommendedForYou(brand, rowId = null, {
   // Apply pagination before calling fetchByRailContentIds
   const startIndex = (page - 1) * limit;
   const paginatedData = data.slice(startIndex, startIndex + limit);
-
-  const contents = await addContextToContent(fetchByRailContentIds, paginatedData,
+  const contents = await addContextToContent(fetchByRailContentIds, paginatedData, 'tab-data',
     {
       addNextLesson: true,
       addNavigateTo: true,
     })
-
   if (rowId) {
     return {
       type: TabResponseType.CATALOG,

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -80,6 +80,7 @@ export async function getTabResults(brand, pageName, tabName, {
     results = await addContextToContent(getLessonContentRows, brand, pageName, {
       dataField: 'items',
       addNextLesson: true,
+      addNavigateTo: true,
       addProgressPercentage: true,
       addProgressStatus: true
     })
@@ -87,6 +88,7 @@ export async function getTabResults(brand, pageName, tabName, {
     let temp =  await fetchTabData(brand, pageName, { page, limit, sort, includedFields: mergedIncludedFields, progress: progressValue });
     results = await addContextToContent(() => temp.entity, {
       addNextLesson: true,
+      addNavigateTo: true,
       addProgressPercentage: true,
       addProgressStatus: true
     })
@@ -382,7 +384,7 @@ export async function getRecommendedForYou(brand, rowId = null, {
   limit = 10,
 } = {}) {
   const requiredItems = page * limit;
-  const data = await recommendations(brand, {limit: requiredItems});
+  const data = recommendations( brand, {limit: requiredItems})
   if (!data || !data.length) {
     return { id: 'recommended', title: 'Recommended For You', items: [] };
   }
@@ -391,12 +393,11 @@ export async function getRecommendedForYou(brand, rowId = null, {
   const startIndex = (page - 1) * limit;
   const paginatedData = data.slice(startIndex, startIndex + limit);
 
-  const contents = await fetchByRailContentIds(paginatedData);
-  const result = {
-    id: 'recommended',
-    title: 'Recommended For You',
-    items: contents
-  };
+  const contents = await addContextToContent(fetchByRailContentIds, paginatedData,
+    {
+      addNextLesson: true,
+      addNavigateTo: true,
+    })
 
   if (rowId) {
     return {

--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -1,5 +1,5 @@
 import {
-  getLastInteractedOf,
+  getLastInteractedOf, getNavigateTo,
   getNextLesson, getProgressDateByIds,
   getProgressPercentageByIds,
   getProgressStateByIds,
@@ -71,6 +71,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
     addResumeTimeSeconds = false,
     addLastInteractedChild = false,
     addNextLesson = false,
+    addNavigateTo = false,
   } = options
 
   const dataParam = lastArg === options ? dataArgs.slice(0, -1) : dataArgs
@@ -83,12 +84,13 @@ export async function addContextToContent(dataPromise, ...dataArgs)
 
   if(ids.length === 0) return false
 
-  const [progressData, isLikedData, resumeTimeData, lastInteractedChildData, nextLessonData] = await Promise.all([
+  const [progressData, isLikedData, resumeTimeData, lastInteractedChildData, nextLessonData, navigateToData] = await Promise.all([
     addProgressPercentage || addProgressStatus || addProgressTimestamp ? getProgressDateByIds(ids) : Promise.resolve(null),
     addIsLiked ? isContentLikedByIds(ids) : Promise.resolve(null),
     addResumeTimeSeconds ? getResumeTimeSecondsByIds(ids) : Promise.resolve(null),
     addLastInteractedChild ? fetchLastInteractedChild(ids)  : Promise.resolve(null),
     addNextLesson ? getNextLesson(items) : Promise.resolve(null),
+    addNavigateTo ? getNavigateTo(items) : Promise.resolve(null),
   ])
 
   const addContext = async (item) => ({
@@ -101,6 +103,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
     ...(addResumeTimeSeconds ? { resumeTime: resumeTimeData?.[item.id] } : {}),
     ...(addLastInteractedChild ? { lastInteractedChild: lastInteractedChildData?.[item.id] } : {}),
     ...(addNextLesson ? { nextLesson: nextLessonData?.[item.id] } : {}),
+    ...(addNavigateTo ? { navigateTo: navigateToData?.[item.id] } : {}),
   })
 
   return await processItems(data, addContext, dataField, isDataAnArray, dataField_includeParent)

--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -114,7 +114,7 @@ export async function getNavigateToForPlaylists(data, {dataField = null} = {} )
 {
   let playlists = extractItemsFromData(data, dataField, false, false)
   let allIds = []
-  playlists.forEach((playlist) => allIds = [...allIds, playlist.items.map(a => a.content_id)])
+  playlists.forEach((playlist) => allIds = [...allIds, ...playlist.items.map(a => a.content_id)])
   const progressOnItems = await getProgressStateByIds(allIds);
   const addContext = async (playlist) => {
     const allItemsCompleted = playlist.items.every(i => {

--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -67,7 +67,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
     addIsLiked = false,
     addLikeCount = false,
     addProgressStatus = false,
-    addProgressTimeStamp = false,
+    addProgressTimestamp = false,
     addResumeTimeSeconds = false,
     addLastInteractedChild = false,
     addNextLesson = false,
@@ -84,7 +84,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
   if(ids.length === 0) return false
 
   const [progressData, isLikedData, resumeTimeData, lastInteractedChildData, nextLessonData] = await Promise.all([
-    addProgressPercentage || addProgressStatus || addProgressTimeStamp ? getProgressDateByIds(ids) : Promise.resolve(null),
+    addProgressPercentage || addProgressStatus || addProgressTimestamp ? getProgressDateByIds(ids) : Promise.resolve(null),
     addIsLiked ? isContentLikedByIds(ids) : Promise.resolve(null),
     addResumeTimeSeconds ? getResumeTimeSecondsByIds(ids) : Promise.resolve(null),
     addLastInteractedChild ? fetchLastInteractedChild(ids)  : Promise.resolve(null),
@@ -95,7 +95,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
     ...item,
     ...(addProgressPercentage ? { progressPercentage: progressData?.[item.id]['progress'] } : {}),
     ...(addProgressStatus ? { progressStatus: progressData?.[item.id]['status'] } : {}),
-    ...(addProgressTimeStamp ? { progressTimestamp: progressData?.[item.id]['last_update'] } : {}),
+    ...(addProgressTimestamp ? { progressTimestamp: progressData?.[item.id]['last_update'] } : {}),
     ...(addIsLiked ? { isLiked: isLikedData?.[item.id] } : {}),
     ...(addLikeCount && ids.length === 1 ? { likeCount: await fetchLikeCount(item.id) } : {}),
     ...(addResumeTimeSeconds ? { resumeTime: resumeTimeData?.[item.id] } : {}),

--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -92,6 +92,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
     addNextLesson ? getNextLesson(items) : Promise.resolve(null),
     addNavigateTo ? getNavigateTo(items) : Promise.resolve(null),
   ])
+  if (addNextLesson) console.log('AddNextLesson is depreciated in favour of addNavigateTo')
 
   const addContext = async (item) => ({
     ...item,
@@ -109,10 +110,9 @@ export async function addContextToContent(dataPromise, ...dataArgs)
   return await processItems(data, addContext, dataField, isDataAnArray, dataField_includeParent)
 }
 
-export async function getNextLessonForPlaylists(data, {dataField = null} = {} )
+export async function getNavigateToForPlaylists(data, {dataField = null} = {} )
 {
   let playlists = extractItemsFromData(data, dataField, false, false)
-  console.log('ps', playlists)
   let allIds = []
   playlists.forEach((playlist) => allIds = [...allIds, playlist.items.map(a => a.content_id)])
   const progressOnItems = await getProgressStateByIds(allIds);
@@ -132,7 +132,10 @@ export async function getNextLessonForPlaylists(data, {dataField = null} = {} )
         nextItem = playlist.items[index] ?? nextItem;
       }
     }
-    playlist.nextLesson = nextItem
+    playlist.navigateTo = {
+      ...nextItem,
+      playlist_id: playlist.id,
+    }
     return playlist
   }
   return await processItems(data, addContext, dataField, false, false,)

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -109,7 +109,6 @@ export async function getNavigateTo(data)
           children.set(child.id, child)
         }
       )
-      console.log('chisaonthu', children)
       //return first child if parent-content is complete or no progress
       const contentState = await getProgressState(content.id)
       if (contentState !== STATE_STARTED) {
@@ -136,7 +135,8 @@ export async function getNavigateTo(data)
         } else if (twoDepthContentTypes.includes(content.type)) {
           const firstChildren = content.children ?? []
           const lastInteractedChild = await getLastInteractedOf(firstChildren.map(child => child.id));
-          const lastInteractedChildNavToData = await getNavigateTo([lastInteractedChild])[lastInteractedChild] ?? null
+          let lastInteractedChildNavToData = await getNavigateTo([children.get(lastInteractedChild)])
+          lastInteractedChildNavToData = lastInteractedChildNavToData[lastInteractedChild]
           navigateToData[content.id] = buildNavigateTo(children.get(lastInteractedChild), lastInteractedChildNavToData);
         }
       }

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -113,7 +113,7 @@ export async function getNavigateTo(data)
       const contentState = await getProgressState(content.id)
       if (contentState !== STATE_STARTED) {
         const firstChild = content.children[0]
-        let lastInteractedChildNavToData = buildNavigateTo([firstChild])[firstChild.id] ?? null
+        let lastInteractedChildNavToData = await getNavigateTo([firstChild])[firstChild.id] ?? null
         navigateToData[content.id] = buildNavigateTo(content.children[0], lastInteractedChildNavToData)
       } else {
         const childrenStates = await getProgressStateByIds(childrenIds)

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -90,6 +90,72 @@ export async function getNextLesson(data)
   return nextLessonData
 }
 
+export async function getNavigateTo(data)
+{
+  let navigateToData = {}
+  const twoDepthContentTypes = ['pack'] //TODO add method when we know what it's called
+  //TODO add parent hierarchy upwards as well
+  // data structure is the same but instead of child{} we use parent{}
+  for (const content of data) {
+
+    //only calculate nextLesson if needed, based on content type
+    if (!getNextLessonLessonParentTypes.includes(content.type) || !content.children) {
+      navigateToData[content.id] = null
+    } else {
+      const children = new Map()
+      const childrenIds = []
+      content.children.forEach(child => {
+          childrenIds.push(child.id)
+          children.set(child.id, child)
+        }
+      )
+      console.log('chisaonthu', children)
+      //return first child if parent-content is complete or no progress
+      const contentState = await getProgressState(content.id)
+      if (contentState !== STATE_STARTED) {
+        navigateToData[content.id] = buildNavigateTo(content.children[0])
+
+      } else {
+        const childrenStates = await getProgressStateByIds(childrenIds)
+
+        //calculate last_engaged
+        const lastInteracted = await getLastInteractedOf(childrenIds)
+        const lastInteractedStatus = childrenStates[lastInteracted]
+
+        //different nextLesson behaviour for different content types
+        if (content.type === 'course' || content.type === 'pack-bundle') {
+          if (lastInteractedStatus === STATE_STARTED) {
+            navigateToData[content.id] = buildNavigateTo(children.get(lastInteracted))
+          } else {
+            let incompleteChild = findIncompleteLesson(childrenStates, lastInteracted, content.type)
+            navigateToData[content.id] = buildNavigateTo(children.get(incompleteChild))
+          }
+        } else if (content.type === 'guided-course' || content.type === 'song-tutorial') {
+          let incompleteChild = findIncompleteLesson(childrenStates, lastInteracted, content.type)
+          navigateToData[content.id] = buildNavigateTo(children.get(incompleteChild))
+        } else if (twoDepthContentTypes.includes(content.type)) {
+          const firstChildren = content.children ?? []
+          const lastInteractedChild = await getLastInteractedOf(firstChildren.map(child => child.id));
+          const lastInteractedChildNavToData = await getNavigateTo([lastInteractedChild])[lastInteractedChild] ?? null
+          navigateToData[content.id] = buildNavigateTo(children.get(lastInteractedChild), lastInteractedChildNavToData);
+        }
+      }
+    }
+  }
+  return navigateToData
+}
+
+function buildNavigateTo(content, child = null)
+{
+  return {
+    brand: content.brand,
+    thumbnail: content.thumbnail ?? '',
+    id: content.id,
+    type: content.type,
+    child: child,
+  }
+}
+
 /**
  * filter through contents, only keeping the most recent
  * @param {array} contentIds

--- a/src/services/recommendations.js
+++ b/src/services/recommendations.js
@@ -90,8 +90,17 @@ export async function rankCategories(brand, categories) {
     }
     return rankedCategories
   } catch (error) {
-    console.error('Fetch error:', error)
-    return null
+    console.error('RankCategories fetch error:', error)
+    const defaultSorting = []
+    for (const slug in categories) {
+      defaultSorting.push(
+        {
+          slug: slug,
+          items: categories[slug],
+        }
+      )
+    }
+    return defaultSorting
   }
 }
 
@@ -124,8 +133,8 @@ export async function rankItems(brand, content_ids) {
     const response = await httpClient.post(url, data)
     return response['ranked_content_ids']
   } catch (error) {
-    console.error('Fetch error:', error)
-    return null
+    console.error('rankItems fetch error:', error)
+    return content_ids
   }
 }
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -2327,6 +2327,7 @@ export async function fetchShows(brand, type, sort = 'sort') {
 
   const query = await buildQuery(filter, filterParams, getFieldsForContentType(type), {
     sortOrder: sortOrder,
+    end: 100, // Adrian: added for homepage progress rows, this should be handled gracefully
   })
   return fetchSanity(query, true)
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -478,7 +478,7 @@ export async function fetchScheduledReleases(brand, { page = 1, limit = 10 }) {
  *   .catch(error => console.error(error));
  */
 export async function fetchByRailContentId(id, contentType) {
-  const fields = getFieldsForContentTypeWithFilteredChildren(contentType)
+  const fields = await getFieldsForContentTypeWithFilteredChildren(contentType)
   const lessonFields = getChildFieldsForContentType(contentType)
   const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
   const entityFieldsString = ` ${fields}
@@ -520,6 +520,7 @@ export async function fetchByRailContentIds(ids, contentType = undefined, brand 
   if (!ids?.length) {
     return []
   }
+  ids = [...new Set(ids.filter(item => item !== null && item !== undefined))];
   const idsString = ids.join(',')
   const brandFilter = brand ? ` && brand == "${brand}"` : ''
   const now = getSanityDate(new Date())
@@ -556,7 +557,7 @@ export async function fetchByRailContentIds(ids, contentType = undefined, brand 
   }
 
   // Sort results to match the order of the input IDs
-  const sortedResults = results.sort(sortFuction)
+  const sortedResults = results?.sort(sortFuction) ?? null
 
   return sortedResults
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -524,10 +524,11 @@ export async function fetchByRailContentIds(ids, contentType = undefined, brand 
   const idsString = ids.join(',')
   const brandFilter = brand ? ` && brand == "${brand}"` : ''
   const lessonCountFilter = await new FilterBuilder(`_id in ^.child[]._ref`, {pullFutureContent: true}).buildFilter()
+  const fields = await getFieldsForContentTypeWithFilteredChildren(contentType, true)
   const query = `*[
     railcontent_id in [${idsString}]${brandFilter}
   ]{
-    ${getFieldsForContentType(contentType)}
+    ${fields}
     'lesson_count': coalesce(count(*[${lessonCountFilter}]), 0),
     live_event_start_time,
     live_event_end_time,

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -917,10 +917,6 @@ async function extractPinnedItemsAndSortAllItems(userPinnedItem, contentsMap, el
     contentsMap,
     eligiblePlaylistItems,
   )
-  // // TODO there's a nice way to do this unpacking and I don't know it
-  // let temp = removeShowsOfSameType(pinnedItem, contentsMap)
-  // pinnedItem = temp.pinnedItem
-  // contentsMap = temp.contentsMap
 
   const guidedCourseID = pinnedGuidedCourse?.content_id
   let combined = [];

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1084,7 +1084,7 @@ async function processContentItem(content) {
       const timeRemaining = getTimeRemainingUntilLocal(nextLessonPublishedOn, {withTotalSeconds: true})
       content.time_remaining_seconds = timeRemaining.totalSeconds
       ctaText = 'Next lesson in ' + timeRemaining.formatted
-    } else if (content.progressStatus === 'not-started') {
+    } else if (!content.progressStatus || content.progressStatus === 'not-started' ) {
       ctaText = "Start Course"
     }
   }

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1317,7 +1317,7 @@ async function popPinnedItemFromContentsOrPlaylistMap(pinned, contentsMap, playl
   if (progressType === 'playlist') {
     const pinnedPlaylist = playlistItems.find(p => p.playlist.id === id)
     if (pinnedPlaylist) {
-      playlistItems = playlistItems.filter(p => p.playlist.id === id)
+      playlistItems = playlistItems.filter(p => p.playlist.id !== id)
       item = pinnedPlaylist
     } else {
       const playlist = await fetchPlaylist(id)

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -914,6 +914,7 @@ async function extractPinnedItemsAndSortAllItems(userPinnedItem, contentsMap, el
     const guidedCourseContent = contentsMap.get(guidedCourseID) ?? await addContextToContent(fetchByRailContentId, guidedCourseID, 'guided-course',
       {
         addNextLesson: true,
+        addNavigateTo: true,
         addProgressStatus: true,
         addProgressPercentage: true,
         addProgressTimestamp: true,
@@ -1022,12 +1023,14 @@ export async function getProgressRows({ brand = null, limit = 8 } = {}) {
   const [ playlistsContents, contents ] = await Promise.all([
     addContextToContent(fetchByRailContentIds, playlistEngagedOnContents, 'progress-tracker', {
       addNextLesson: true,
+      addNavigateTo: true,
       addProgressStatus: true,
       addProgressPercentage: true,
       addProgressTimestamp: true,
     }),
     addContextToContent(fetchByRailContentIds, nonPlaylistContentIds, 'progress-tracker', brand, {
       addNextLesson: true,
+      addNavigateTo: true,
       addProgressStatus: true,
       addProgressPercentage: true,
       addProgressTimestamp: true,
@@ -1204,7 +1207,6 @@ async function processPlaylistItem(item) {
       text:   'Continue',
       action: {
         brand:  playlist.brand,
-        id:     playlist.id,
         item_id: playlist.nextLesson.id,
         content_id: playlist.nextLesson.content_id,
         type:   'playlists',
@@ -1373,6 +1375,7 @@ async function popPinnedItemFromContentsOrPlaylistMap(pinned, contentsMap, playl
       item = await addContextToContent(fetchByRailContentId,`${pinnedId}`, 'progress-tracker',
         {
           addNextLesson: true,
+          addNavigateTo: true,
           addProgressStatus: true,
           addProgressPercentage: true,
           addProgressTimestamp: true

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -995,11 +995,13 @@ function generateContentsMap(contents, playlistsContents) {
 
   // TODO this doesn't work for guided courses as the GC card takes precedence over the playlist card
   // https://musora.atlassian.net/browse/BEH-812
-  for (const item of playlistsContents) {
-    const contentId = item.id
-    contentsMap.delete(contentId)
-    const parentIds = item.parent_content_data || [];
-    parentIds.forEach(id => contentsMap.delete(id) );
+  if (playlistsContents) {
+    for (const item of playlistsContents) {
+      const contentId = item.id
+      contentsMap.delete(contentId)
+      const parentIds = item.parent_content_data || [];
+      parentIds.forEach(id => contentsMap.delete(id));
+    }
   }
   return contentsMap;
 }
@@ -1309,6 +1311,7 @@ async function popPinnedItemFromContentsOrPlaylistMap(pinned, contentsMap, playl
     if (contentsMap.has(pinnedId)) {
       item = contentsMap.get(pinnedId)
       contentsMap.delete(pinnedId)
+
     } else {
       // we use fetchByRailContentIds so that we don't have the _type restriction in the query
       let data = await fetchByRailContentIds([id], 'progress-tracker')

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1064,7 +1064,7 @@ export async function getProgressRows({ brand = null, limit = 8 } = {}) {
         : processContentItem(item)
     )
   );
-  console.log('HomePageProgressRows results', results)
+  console.log('HomePageProgressRows results: remove before merge', results)
   return {
     type: TabResponseType.PROGRESS_ROWS,
     displayBrowseAll: combined.length > limit,

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -93,7 +93,7 @@ describe('Sanity Queries', function() {
   test('fetchSanity-WithPostProcess', async () => {
     const id = 380094
     const query = `*[railcontent_id == ${id}]{
-        ${await getFieldsForContentType('song')}
+        ${getFieldsForContentType('song')}
           }`
     const newSlug = 'keysmash1'
     const newField = 1

--- a/test/sanityQueryService.test.js
+++ b/test/sanityQueryService.test.js
@@ -93,7 +93,7 @@ describe('Sanity Queries', function() {
   test('fetchSanity-WithPostProcess', async () => {
     const id = 380094
     const query = `*[railcontent_id == ${id}]{
-        ${getFieldsForContentType('song')}
+        ${await getFieldsForContentType('song')}
           }`
     const newSlug = 'keysmash1'
     const newField = 1


### PR DESCRIPTION
JIRA
[T3PS-573](https://musora.atlassian.net/browse/T3PS-573) - songtutorials missing next lesson (homepage) (now navigateTo)  
- [T3PS-713](https://musora.atlassian.net/browse/T3PS-713) - playlist next_lesson (need 3 pieces of information)
 https://musora.atlassian.net/browse/T3PS-623 - Continue course goes to first lesson
https://musora.atlassian.net/browse/T3PS-647 - song tutorial missing next lesson (collection)
- https://musora.atlassian.net/browse/BEH-827 - hide drafted/unpublished children
- https://musora.atlassian.net/browse/T3PS-765 - pack navigation broken (as of august 1st 10:30, partially broken still, edge cases need to be hashed out)
- [recommended home page](https://musora.atlassian.net/browse/T3PS-635) -> missing context information. No ticket. Didier talked directly to me
- hide drafted/deleted children, this is done through `getFieldsForContentTypeWithFilteredChildren` which dynamically adds the status + published_on filters. This may break some material with GuidedCoures but I'll deal with that later.
-- this is needed to calculate the `navigateTo` fields. We'll need to do updates else where. 
- playlists now pull the `navigateTo` field by default, there is a performance hit here for the "add to playlist" page, but otherwise is necessary for all situations we pull playlists. Can be refactored later. Cleared with Didier. I could refactor this to be generic as well, but I don't think we'll need other context data. This maybe could/should have been done in the BE, but we're here now.

## Design
- Based on FE/MA/sync call earlier today I added a `navigateTo` to contextAggregator, which will replace the `nextLesson` field. 
- refactor flow for `getProgressRows`
-- move progress logic to the `contentAggregator` (this changed the data structures a lot, so there was a bunch of refactoring that ended up being needed)
-- return raw object (content or playlist) in the homepage progress row return package. FE/MA are encouraged to take the majority of the data from that.
- added the ability to get and filter children when fetching content from sanity (specifically for fetchByRailContentId(s)).
- fix 404 error on recommended endpoint for bad token
- add context to recommended rows on home page

All existing behaviour should still work (fingers crossed), but FE/MA will need to move to the `navigateTo` field instead of `nextLesson` for the bugs above to work.
new `navigateTo` structure:

Content
```
navigateTo {
    brand: content.brand,
    thumbnail: content.thumbnail ?? '',
    id: content.id,
    type: content.type,
    child: {
          brand: content.brand,
          thumbnail: content.thumbnail ?? '',
          id: content.id,
          type: content.type,
          child: null,
    },   
}
```

Playlist
```
navigateTo { 
    content_id: 397036
    id: 6656250
    playlist_id: 688647
    position: 4  
}

```

## Outstanding work:
- I'm pretty sure `generateContentsMap` has some issues in it. I needed to rebuilt the method because we weren't using `progressData` anymore and I think I missed some things. Works as expected though.
- navigateTo will need to be updated to include parent as well as child, so FE/MA can walk up or down as necessary.
- fetchByRailcontentId has both `children` and `lessons` fields now, which will be slightly divergent, this could be cleaned up.



## Testing
I used july8test2@musora.com (id: 843604) as my test user because they already have a lot of data. You can manually set the limit value in `getProgressRows` to something like 15 for testing to see more results to get more variety of data

Faff around with the homepage progress rows. It shouldn't crash.

All cards should (this is a non-definitive list of functionality, but this is basically what I verified for this):
- have a CTA text (the logic for this is non-trivial, I didn't test all cases)
- show a valid header for all content types listed below
- show a valid "% completed", or "X of Y lessons complete" tag 
- if it's a child object, should instead show teh parent object (shows pack instead of pack-bundle-lesson). Should not show both parent and children
- if the lesson was watched as part of a playlist, the playlist card should be shown instead 
- for GCs: show a locked CTA, if the content's published on is in the future

Content Types to test:

- [Play-along ](http://localhost:5173/drumeo/songs/play-along/216913)
- [Workout](http://localhost:5173/drumeo/lessons/workout/412875) 
- [Show](http://localhost:5173/drumeo/lessons/rhythmic-adventures-of-captain-carson/233956) 
-- pin & unpin the show. It should only show up once. Pin the Show, complete the existing lesson. Refresh the home page, verify it only shows up once and the new lesson is the next episode (I don't know how to verify that part, I just assumed it worked)
-- having progress in multiple episodes of the same show should not show multiple rows

- [Guided Course](http://localhost:5173/drumeo/lessons/course/416453): There are 4 test cases here: Next Lesson 
-- Locked, Not started, In progress, Completed. My brain is soup and I'm not gonig to write out tests for each
`update guided_course_user_enrollments set is_pinned = 0 where id = 14;
update guided_course_user_enrollments set is_pinned = 1 where id = 10;`
--you can use this to test partially finished. Currently id = 14 is enrolled but not started. 
-- guided courses are mostly drafted, so I used the development GC for testing. One has (had, someone changed it back :D) content that's locked in December 2025 so we can see the lock state. You'll have to do it yourself.

- [Course](http://localhost:5173/drumeo/lessons/course/388199/388641)
-- pin/unpin. Navigation works to netx lesson
- [Pack Bundle Lesson](http://localhost:5173/drumeo/lessons/pack/411083/411087)
-- pin/unpin. Navigation to next lesson is currently broken
- the code for this isn't written on FE, so testing means examining the return package, `navigateTo` should have child.child defined, as well as `cta.action.child.child` though that's expected to be depreciated shortly


## Playlist 
- pin playlist (should only show up once, and in front)
- unpin playlist (should still show up, but not in front)
- return package sholud have a `navigateTo` that containts the playlis_item_id, 
- navigate to next lesson doesn't work. This was part of the work necessary so the structure exists.


## CTA text
Preferable you'd have each of the available types in progress and then completed to check the CTA text :D
I don't have a document that shows what the text is supposed to say, so I used the existing format and refactored the logic.


## Recommended
- set the frontend .env token for `VITE_RECOMMENDATION_SYSTEM_TOKEN` to garbage
- home page should still load
- lessons for your page should still load (error in console that we can't access HG)
- lessons individuals page should still load (error in console that we can't access HG)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced content and playlist items with navigation targets, allowing users to easily continue where they left off.
  * Progress rows and recommended content now include richer context, such as progress status, progress timestamps, and next lesson details.
  * Added filtered and recursive child field queries for improved content type data retrieval.

* **Improvements**
  * More accurate handling of pinned items and guided courses in user activity.
  * Improved fallback behavior for recommendations, ensuring default results are shown if ranking fails.
  * More modular and maintainable user progress and content enrichment logic for a smoother experience.
  * Enhanced input sanitization, null safety, strict equality checks, and query limits in content fetching.
  * Unified progress data retrieval and enriched navigation context in content services.
  * Simplified and unified enrichment of recommended and tab content with navigation context.

* **Bug Fixes**
  * Fixed issues with input sanitization and null safety in content fetching.
  * Corrected strictness in equality checks and improved playlist sorting reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[T3PS-573]: https://musora.atlassian.net/browse/T3PS-573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[T3PS-713]: https://musora.atlassian.net/browse/T3PS-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ