### PR TITLE
fix(T3PS-630): show song-tutorial children in recent songs instead of parent

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -224,7 +224,7 @@ export const filterTypes = {
 
 export const recentTypes = {
   lessons: [...individualLessonsTypes, 'course-part', 'pack-bundle-lesson', 'guided-course-part', 'quick-tips'],
-  songs: ['song-tutorial-children', ...transcriptionsLessonTypes, ...playAlongLessonTypes, 'jam-track'],
+  songs: [...SONG_TYPES],
   home: [...individualLessonsTypes, ...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes,
   'guided-course', 'learning-path', 'live', 'course', 'pack']
 }


### PR DESCRIPTION
Makes song tutorial _children_ show up in Songs > For You > Recent instead of parent.

[T3PS-630](https://musora.atlassian.net/browse/T3PS-630)

[Project requirements doc](https://docs.google.com/document/d/1cuUgAmOsrlw1uyBoFqRhn6t8Cy6A_4pymsXGUFtL5XE/edit?tab=t.0#bookmark=id.a9k6za66j8mv) suggests "_Lesson playback videos (not courses)_" should be shown in the Recent section

### Testing

Visit `/drumeo/songs/see-all/recent`, and notice that "Song Tutorial Lesson" items are shown instead of "Song Tutorial" items.

[T3PS-630]: https://musora.atlassian.net/browse/T3PS-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the list of recent song types to streamline and standardize the variety of recent song content displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->