### PR TITLE
fix(T3PS-120): allow falsey values for description and category

### DIFF
--- a/src/services/content-org/playlists-types.js
+++ b/src/services/content-org/playlists-types.js
@@ -9,6 +9,16 @@
  */
 
 /**
+ * @typedef UpdatePlaylistDTO
+ * @property {string} name - The name of the new playlist. (required, max 255 characters)
+ * @property {string} description - A description of the playlist. (optional, max 1000 characters)
+ * @property {string} category - The category of the playlist. (optional, max 255 characters)
+ * @property {boolean} is_private - Whether the playlist is private. (optional, defaults to false)
+ * @property {Array<number>} deleted_items - List of playlist items to be deleted. (optional)
+ * @property {Array<number>} item_order - List of all remaining playlist item ids (not content_ids) provided in the new order. (optional)
+ */
+
+/**
  * @typedef DuplicatePlaylistDTO
  * @property {string} name - The name of the new playlist. (required, max 255 characters)
  * @property {string} description - A description of the playlist. (optional, max 1000 characters)

--- a/src/services/content-org/playlists.js
+++ b/src/services/content-org/playlists.js
@@ -224,12 +224,13 @@ export async function togglePlaylistPrivate(playlistId, is_private)
  * Updates a playlists values
  *
  * @param {string|number} playlistId
- * @param {Object} updateData - An object containing fields to update on the playlist:
+ * @param {PlaylistDTO} updateData  - An object containing fields to update on the playlist:
  *  - `name` (string): The name of the new playlist (required, max 255 characters).
  *  - `description` (string): A description of the playlist (optional, max 1000 characters).
- *  - `category` (string): The category of the playlist.
- * + *  - `deleted_items` (array): List of playlist item IDs to delete.
- * + *  - `item_order` (array): Updated order of playlist items (ids, not railcontent_ids).
+ *  - `category` (string): The category of the playlist (optional).
+ *  - `is_private` (boolean): Whether the playlist is private (optional, defaults to false).
+ *  - `deleted_items` (array): List of playlist item IDs to delete (optional).
+ *  - `item_order` (array): Updated order of playlist items (ids, not railcontent_ids) (optional).
  *
  * @returns {Promise<object>} - A promise that resolves to the created playlist data and lessons if successful, or an error response if validation fails.
  *
@@ -242,16 +243,14 @@ export async function togglePlaylistPrivate(playlistId, is_private)
  *   .then(response => console.log(response.playlist); console.log(response.lessons))
  *   .catch(error => console.error('Error updating playlist:', error));
  */
-export async function updatePlaylist(playlistId, {
-  name = null, description = null,  is_private = null, brand = null, category = null, deleted_items = null, item_order = null
-})
+export async function updatePlaylist(playlistId, updateData)
 {
-  const data = {
+  const { name, description, category, is_private, item_order, deleted_items } = updateData;
+  let data = {
     ...name && { name },
-    ...description && { description },
-    ...is_private !== null && { private: is_private},
-    ...brand && { brand },
-    ...category && { category},
+    ...'description' in updateData && { description },
+    ...'is_private' in updateData && { private: is_private || false },
+    ...'category' in updateData && { category },
     ...deleted_items && { deleted_items },
     ...item_order && { item_order },
   }

--- a/src/services/content-org/playlists.js
+++ b/src/services/content-org/playlists.js
@@ -224,7 +224,7 @@ export async function togglePlaylistPrivate(playlistId, is_private)
  * Updates a playlists values
  *
  * @param {string|number} playlistId
- * @param {PlaylistDTO} updateData  - An object containing fields to update on the playlist:
+ * @param {UpdatePlaylistDTO} updateData  - An object containing fields to update on the playlist:
  *  - `name` (string): The name of the new playlist (required, max 255 characters).
  *  - `description` (string): A description of the playlist (optional, max 1000 characters).
  *  - `category` (string): The category of the playlist (optional).


### PR DESCRIPTION
- only exclude sending description and category if they were not included with the request
- define type UpdatePlaylistDTO
- exclude is_private if undefined, if is_private is sent as null, default to false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist update behavior to ensure all provided fields, including falsy values (such as empty strings or false), are correctly sent when updating a playlist.
  * Enhanced handling of optional playlist fields during updates for more precise control.

* **Documentation**
  * Updated in-code documentation to clarify optional fields and their expected types when updating playlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->