### PR TITLE
fix: Change recommendation config to use recommender.musora.com

### DIFF
--- a/src/services/config.js
+++ b/src/services/config.js
@@ -8,7 +8,6 @@ import './types.js'
 export let globalConfig = {
   sanityConfig: {},
   railcontentConfig: {},
-  recommendationsConfig: {},
   sessionConfig: {},
   localStorage: null,
   isMA: false,
@@ -50,10 +49,6 @@ const excludeFromGeneratedIndex = []
  *     userId: 'current-user-id',
  *     authToken 'your-auth-token',
  *   },
- *   recommendationsConfig: {
- *     token: 'your-user-api-token',
- *     baseUrl: 'https://MusoraProductDepartment-PWGenerator.hf.space',
- *   },
  *   baseUrl: 'https://web-staging-one.musora.com',
  *   localStorage: localStorage,
  *   isMA: false,
@@ -67,5 +62,4 @@ export function initializeService(config) {
   globalConfig.localStorage = config.localStorage
   globalConfig.isMA = config.isMA || false
   globalConfig.localTimezoneString = config.localTimezoneString || null
-  globalConfig.recommendationsConfig = config.recommendationsConfig
 }

--- a/src/services/recommendations.js
+++ b/src/services/recommendations.js
@@ -36,10 +36,7 @@ export async function fetchSimilarItems(content_id, brand, count = 10) {
   }
   const url = `/similar_items/`
   try {
-    const httpClient = new HttpClient(
-      globalConfig.recommendationsConfig.baseUrl,
-      globalConfig.recommendationsConfig.token
-    )
+    const httpClient = new HttpClient('https://recommender.musora.com')
     const response = await httpClient.post(url, data)
     // we requested count + 1 then filtered out the extra potential value, so we need slice to the correct size if necessary
     return response['similar_items'].filter((item) => item !== content_id).slice(0, count)
@@ -75,17 +72,14 @@ export async function rankCategories(brand, categories) {
   }
   const url = `/rank_each_list/`
   try {
-    const httpClient = new HttpClient(
-      globalConfig.recommendationsConfig.baseUrl,
-      globalConfig.recommendationsConfig.token
-    )
+    const httpClient = new HttpClient('https://recommender.musora.com')
     const response = await httpClient.post(url, data)
     let rankedCategories = []
 
     for (const rankedPlaylist of response['ranked_playlists']) {
       rankedCategories.push({
-        'slug': rankedPlaylist.playlist_id,
-        'items': rankedPlaylist.ranked_items
+        slug: rankedPlaylist.playlist_id,
+        items: rankedPlaylist.ranked_items,
       })
     }
     return rankedCategories
@@ -117,10 +111,7 @@ export async function rankItems(brand, content_ids) {
   }
   const url = `/rank_items/`
   try {
-    const httpClient = new HttpClient(
-      globalConfig.recommendationsConfig.baseUrl,
-      globalConfig.recommendationsConfig.token
-    )
+    const httpClient = new HttpClient('https://recommender.musora.com')
     const response = await httpClient.post(url, data)
     return response['ranked_content_ids']
   } catch (error) {

--- a/src/services/types.js
+++ b/src/services/types.js
@@ -30,19 +30,11 @@
  */
 
 /**
- * @typedef {object} RecommendationsConfig - Configuration for recommendation services.
- *
- * @property {string} token - The token for authenticating recommendation requests.
- * @property {string} baseUrl - The url for the recommendation server.
- */
-
-/**
  * @typedef {object} Config
  *
  * @property {SanityConfig} sanityConfig
  * @property {RailcontentConfig} railcontentConfig - DEPRECATED use sessionConfig and baseUrl instead.
  * @property {SessionConfig} sessionConfig
- * @property {RecommendationsConfig} recommendationsConfig
  * @property {string} baseUrl - The url for the environment.
  * @property {Object} localStorage - Cache to use for localStorage
  * @property {boolean} isMA - Variable that tells if the library is used by MA or FEW

--- a/test/initializeTests.js
+++ b/test/initializeTests.js
@@ -33,10 +33,6 @@ export async function initializeTestService(useLive = false, isAdmin = false) {
     baseUrl: process.env.RAILCONTENT_BASE_URL,
     localStorage: new LocalStorageMock(),
     isMA: true,
-    recommendationsConfig: {
-      token: process.env.HUGGINGFACE_TOKEN,
-      baseUrl: process.env.HUGGINGFACE_URL,
-    },
   }
   initializeService(config)
 


### PR DESCRIPTION
Added a Cloudflare worker as a proxy that injects the authorization.
This doesn't secure the endpoint any more than it was, but the key shouldn't get flagged.
I'll look into locking this down more post-alpha.

Testing:
Post man endpoints can be changed to point to recommender.musora.com, remove auth token and it still should work.

https://red-shadow-611407.postman.co/workspace/Team-Workspace~38bb093f-0978-4a83-8423-944a3c78fd51/request/31092567-5ea90bda-9eff-4e41-8310-7432aefe37d8?tab=auth

Or pull locally and test through frontend.  Here's a screenshot of my results.
<img width="1600" height="972" alt="image" src="https://github.com/user-attachments/assets/919177ce-1d8b-4ad7-aeed-00986c919215" />
