### PR TITLE
fix: MU2-912 - fix pagination for Incomplete and Completed tabs

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -2173,10 +2173,12 @@ export async function fetchTabData(
     case 'incomplete':
       progressIds = await getAllStarted();
       sortOrder = null;
+      withoutPagination = true;
       break;
     case 'completed':
       progressIds = await getAllCompleted();
       sortOrder = null;
+      withoutPagination = true;
       break;
   }
 


### PR DESCRIPTION
[MU2-912](https://musora.atlassian.net/browse/MU2-912?atlOrigin=eyJpIjoiMjZmMzQxNTZlMjNkNDcyZDhjYjdiMjdhNDFmM2U5OGMiLCJwIjoiaiJ9)

**Description**:
Fix pagination for the Recent - Incomplete, and Completed tabs.
For contents that are in progress, we cannot rely on Sanity's pagination. Instead, we need to use JavaScript-based pagination to ensure that items are properly sorted by their progress state.

[MU2-912]: https://musora.atlassian.net/browse/MU2-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data fetching for tabs filtered by "incomplete" or "completed" progress, ensuring more accurate results in these views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->