### PR TITLE
fix(recsys): support navigateTo and permissions filtering for recomme…

### DIFF
--- a/src/services/content.js
+++ b/src/services/content.js
@@ -80,6 +80,7 @@ export async function getTabResults(brand, pageName, tabName, {
     results = await addContextToContent(getLessonContentRows, brand, pageName, {
       dataField: 'items',
       addNextLesson: true,
+      addNavigateTo: true,
       addProgressPercentage: true,
       addProgressStatus: true
     })
@@ -90,6 +91,7 @@ export async function getTabResults(brand, pageName, tabName, {
       sort === 'recommended' ? rankItems(brand, temp.entity.map(e => e.railcontent_id)) : [],
       addContextToContent(() => temp.entity, {
         addNextLesson: true,
+        addNavigateTo: true,
         addProgressPercentage: true,
         addProgressStatus: true
       })
@@ -400,14 +402,11 @@ export async function getRecommendedForYou(brand, rowId = null, {
   // Apply pagination before calling fetchByRailContentIds
   const startIndex = (page - 1) * limit;
   const paginatedData = data.slice(startIndex, startIndex + limit);
-
-  const contents = await fetchByRailContentIds(paginatedData);
-  const result = {
-    id: 'recommended',
-    title: 'Recommended For You',
-    items: contents
-  };
-
+  const contents = await addContextToContent(fetchByRailContentIds, paginatedData, 'tab-data', brand, true,
+    {
+      addNextLesson: true,
+      addNavigateTo: true,
+    })
   if (rowId) {
     return {
       type: TabResponseType.CATALOG,

--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -77,7 +77,7 @@ export async function addContextToContent(dataPromise, ...dataArgs)
   if(!data) return false
   const isDataAnArray = Array.isArray(data)
   const items = extractItemsFromData(data, dataField, isDataAnArray, dataField_includeParent)
-  const ids = items.map(item => item?.id).filter(Boolean)
+  const ids = items?.map(item => item?.id).filter(Boolean) ?? []
 
   if(ids.length === 0) return false
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -515,15 +515,18 @@ export async function fetchByRailContentId(id, contentType) {
  *   .then(contents => console.log(contents))
  *   .catch(error => console.error(error));
  */
-export async function fetchByRailContentIds(ids, contentType = undefined, brand = undefined) {
+export async function fetchByRailContentIds(ids, contentType = undefined, brand = undefined, includePermissionsAndStatusFilter = false) {
   if (!ids?.length) {
     return []
   }
   const idsString = ids.join(',')
   const brandFilter = brand ? ` && brand == "${brand}"` : ''
-  const now = getSanityDate(new Date())
+  const lessonCountFilter = await new FilterBuilder(`_id in ^.child[]._ref`, {pullFutureContent: true}).buildFilter()
+  const fields = await getFieldsForContentTypeWithFilteredChildren(contentType, true)
+  const baseFilter = `railcontent_id in [${idsString}]${brandFilter}`
+  const finalFilter = includePermissionsAndStatusFilter ? await new FilterBuilder(baseFilter).buildFilter() : baseFilter
   const query = `*[
-    railcontent_id in [${idsString}]${brandFilter}
+    ${finalFilter}
   ]{
     ${getFieldsForContentType(contentType)}
     live_event_start_time,
@@ -1203,7 +1206,7 @@ export async function fetchLessonContent(railContentId) {
 export async function fetchRelatedRecommendedContent(railContentId, brand, count = 10) {
   const recommendedItems = await fetchSimilarItems(railContentId, brand, count)
   if (recommendedItems && recommendedItems.length > 0) {
-    return fetchByRailContentIds(recommendedItems)
+    return fetchByRailContentIds(recommendedItems, 'tab-data', brand, true)
   }
 
   return await fetchRelatedLessons(railContentId, brand).then((result) =>

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1180,11 +1180,11 @@ async function processContentItem(item) {
       thumbnail:       data.thumbnail,
       title:           data.title,
       isLive:          isLive,
-      badge:           data.badge ?? null,
-      isLocked:        data.is_locked ?? false,
-      subtitle:        !data.child_count || data.lesson_count === 1
-        ? (contentType === 'lesson' && isLive === false) ? `${item.percent}% Complete`: `${data.difficulty_string} • ${data.artist_name}`
-        : `${data.completed_children} of ${data.lesson_count ?? data.child_count} Lessons Complete`
+      badge:           content.badge ?? null,
+      isLocked:        content.is_locked ?? false,
+      subtitle:        collectionLessonTypes.includes(content.type) || content.lesson_count > 1
+        ? `${content.completed_children} of ${content.lesson_count ?? content.child_count} Lessons Complete`
+        : (contentType === 'lesson' && isLive === false) ? `${content.progressPercentage}% Complete`: `${content.difficulty_string} • ${content.artist_name}`
     },
     cta:               {
       text:   ctaText,


### PR DESCRIPTION
## Jira
- nope. Slack conversations with Eli and Peter lead to this
- unpublished data was accessible through recommended system. See [heer](https://app.musora.com/drumeo/songs/play-along/316736)
- courses in the recommended for you, didn't contain valid `navigateTo` data (they won't, because now we have hardcoded the recommendations and there are no courses in there) 
- "undefined of X lessons complete" shown on home page progress row for [this](http://localhost:5173/drumeo/songs/transcription/411128) content

## Changes:
- removes unpublished data from the "recommended for you " and fetchRelatedRecommendedContent queries.
- some additional null checking on contentAgregator as a result
- patch for `navigateTo` field on recommended MCS methods (add pseudo content-type 'tab-data')
- patch for home page progress row subtitle for some transcriptions. This only shows up for transcriptions that have a child_count =1 (most have `null`), which I wasn't sure why this is in sanity. I didn't dig further. But put it on my backlog. 

## Testing:
- [home page](http://localhost:5173/drumeo) - Recommended For you (and [recommended](http://localhost:5173/drumeo/recommended) page) . Page should load and if you check the recommended for you results they should include `navigateTo` field. I needed to add a console.log to content.getRecommendedForYou (  console.log('re for you', contents)) to see the fields. Non of the current default recommendations are collection types, so the value will be null for all of these. But if it exists, it should be calculated correctly elsewhere.
- Recommended Lessons on[ playback](http://localhost:5173/drumeo/lessons/course/397032/397033) page, now filters for unpublished data (this is hard to prove, but I compared [local](http://localhost:5173/drumeo/songs/play-along/316736) to [prod](https://app.musora.com/drumeo/songs/play-along/316736). on prod all those links go to a special 404 page.) On staging, there are only a few play-alongs so most of the recommended content for play alongs is invalid. I also tested other types ([workout](http://localhost:5173/drumeo/lessons/workout/401981)) to make sure i didn't over filter. 
- Subtext for song types on home page progress rows now shows artist + difficulty instead of "undefined of X Lessons Completed". Example
- [lesson type ](http://localhost:5173/drumeo/lessons/workout/402009) (show completion %)
- transcription  [content](http://localhost:5173/drumeo/songs/transcription/411128) (should show artist/difficulty)
- course (link above) should show X of Y completed
 