### PR TITLE
feat(BEH-601): fix parent list coming as null due to erroneous query

### DIFF
--- a/src/filterBuilder.js
+++ b/src/filterBuilder.js
@@ -21,6 +21,7 @@ export class FilterBuilder {
       isSingle = false,
       allowsPullSongsContent = true,
       isChildrenFilter = false,
+      isParentFilter = false,
     } = {}
   ) {
     this.availableContentStatuses = availableContentStatuses
@@ -36,6 +37,7 @@ export class FilterBuilder {
     // this.debug = process.env.DEBUG === 'true' || false;
     this.debug = false
     this.prefix = isChildrenFilter ? '@->' : ''
+    this.prefix = isParentFilter ? '^.' : ''
   }
 
   static withOnlyFilterAvailableStatuses(filter, availableContentStatuses, bypassPermissions) {

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1243,6 +1243,7 @@ export async function fetchSiblingContent(railContentId, brand)
 {
   const filterGetParent = await new FilterBuilder(`references(^._id) && _type == ^.parent_type`, {
     pullFutureContent: true,
+    isParentFilter: true,
   }).buildFilter()
   const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
 


### PR DESCRIPTION
The issue was stemming from the subquery not de-referencing the correct properties from the children going up to the document (in this case the pack-bundle):

<details>
<summary>full query</summary>
<pre><code>*[
  railcontent_id == 299934 && brand == "drumeo"
]{
  _type,
  parent_type,
  'parent_id': parent_content_data[0].id,
  railcontent_id,

  'for-calculations': *[
    references(^._id) &&
    _type == ^.parent_type &&
    (
      status in ['draft', 'published', 'archived', 'unlisted'] ||
      (
        status == 'scheduled' &&
        defined(published_on) &&
        published_on >= '2025-08-06T22:01:00.000Z'
      )
    )
  ][0]{
    'siblings-list': child[]->railcontent_id,
    'parents-list': *[
      references(^._id) &&
      _type == ^.parent_type &&
      (
        status in ['draft', 'published', 'archived', 'unlisted'] ||
        (
          status == 'scheduled' &&
          defined(published_on) &&
          published_on >= '2025-08-06T22:01:00.000Z'
        )
      )
    ][0].child[]->railcontent_id
  },

  "related_lessons": *[
    references(^._id) &&
    _type == ^.parent_type &&
    (
      status in ['draft', 'published', 'archived', 'unlisted'] ||
      (
        status == 'scheduled' &&
        defined(published_on) &&
        published_on >= '2025-08-06T22:01:00.000Z'
      )
    )
  ][0].child[
    (
      @->status in ['draft', 'published', 'archived', 'unlisted'] ||
      (
        @->status == 'scheduled' &&
        defined(@->published_on) &&
        @->published_on >= '2025-08-06T22:01:00.000Z'
      )
    )
  ]->{
    _id,
    "id": railcontent_id,
    published_on,
    "instructor": instructor[0]->name,
    title,
    "thumbnail": thumbnail.asset->url,
    length_in_seconds,
    status,
    "type": _type,
    difficulty,
    difficulty_string,
    artist->,
    "permission_id": permission[]->railcontent_id,
    "genre": genre[]->name,
    "parent_id": parent_content_data[0].id
  }
}</code></pre>
</details>

<details>
<summary>erroneous part of query</summary>

```
[0]{
    'siblings-list': child[]->railcontent_id,
    'parents-list': *[
      references(^._id) &&
      _type == ^.parent_type &&
      (
        status in ['draft', 'published', 'archived', 'unlisted'] ||
        (
          status == 'scheduled' &&
          defined(published_on) &&
          published_on >= '2025-08-06T22:01:00.000Z'
        )
      )
    ][0].child[]->railcontent_id
  },
```

</details>
<details>
<summary>fixed query</summary>

```
[0]{
    'siblings-list': child[]->railcontent_id,
    'parents-list': *[
      references(^._id) &&
      _type == ^.parent_type &&
      (
        ^.status in ['published'] ||
        (
          ^.status == 'scheduled' &&
          defined(^.published_on) &&
          ^.published_on >= '2025-08-06T20:01:00.000Z'
        )
      ) &&
      (
        !defined(permission) ||
        references(*[
          _type == 'permission' &&
          railcontent_id in [92]
        ]._id)
      )
    ][0].child[]->{railcontent_id, status}
  },
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved filtering capabilities to better distinguish between parent and child filters when viewing related content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->