### PR TITLE
fix: T3PS-732 Filter sorting by name

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -749,7 +749,7 @@ export function getSortOrder(sort = '-published_on', brand, groupBy) {
   sort = isDesc ? sort.substring(1) : sort
   switch (sort) {
     case 'slug':
-      sortOrder = groupBy ? 'name' : 'title'
+      sortOrder = groupBy ? 'name' : '!defined(title), lower(title)'
       break
     case 'name':
       sortOrder = sort


### PR DESCRIPTION
[T3PS-732](https://musora.atlassian.net/browse/T3PS-732?atlOrigin=eyJpIjoiNmMwY2NhYjQ2NTU1NDI0NmJjYTM4NjRmZGMzNzJmNWUiLCJwIjoiaiJ9)

Fix GROQ query sorting: move null titles to end and apply case-insensitive order for filter sorting Name:A-Z and Name:Z-A