### PR TITLE
fix(BEH-601): fix the over encompassing previous change

### DIFF
--- a/src/filterBuilder.js
+++ b/src/filterBuilder.js
@@ -36,8 +36,17 @@ export class FilterBuilder {
     this.filter = filter
     // this.debug = process.env.DEBUG === 'true' || false;
     this.debug = false
-    this.prefix = isChildrenFilter ? '@->' : ''
-    this.prefix = isParentFilter ? '^.' : ''
+    this.prefix = this.getPrefix(isParentFilter, isChildrenFilter)
+  }
+
+  getPrefix(isParentFilter, isChildrenFilter) {
+    if (isParentFilter) {
+      return '^.'
+    } else if (isChildrenFilter) {
+      return '@->'
+    } else {
+      return ''
+    }
   }
 
   static withOnlyFilterAvailableStatuses(filter, availableContentStatuses, bypassPermissions) {

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1242,9 +1242,13 @@ async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, cou
 export async function fetchSiblingContent(railContentId, brand)
 {
   const filterGetParent = await new FilterBuilder(`references(^._id) && _type == ^.parent_type`, {
+    pullFutureContent: true
+  }).buildFilter()
+  const filterForParentList = await new FilterBuilder(`references(^._id) && _type == ^.parent_type`, {
     pullFutureContent: true,
     isParentFilter: true,
   }).buildFilter()
+
   const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
 
   const queryFields = `_id, "id":railcontent_id, published_on, "instructor": instructor[0]->name, title, "thumbnail":thumbnail.asset->url, length_in_seconds, status, "type": _type, difficulty, difficulty_string, artist->, "permission_id": permission[]->railcontent_id, "genre": genre[]->name, "parent_id": parent_content_data[0].id`
@@ -1253,7 +1257,7 @@ export async function fetchSiblingContent(railContentId, brand)
    _type, parent_type, 'parent_id': parent_content_data[0].id, railcontent_id,
    'for-calculations': *[${filterGetParent}][0]{
     'siblings-list': child[]->railcontent_id,
-    'parents-list': *[${filterGetParent}][0].child[]->railcontent_id
+    'parents-list': *[${filterForParentList}][0].child[]->railcontent_id
     },
     "related_lessons" : *[${filterGetParent}][0].child[${childrenFilter}]->{${queryFields}}
   }`


### PR DESCRIPTION
## Jira
- no ticket

## Changes
- fix unintentional sanity query prefix overwrite, affecting all sanity queries that have child filter across brand site
- also fix fetchSiblingContent query incorrectly referencing enclosing document scope

## Testing
- link mcs
- go to a pack bundle lesson and verify you get a collection module that has sibling lessons in that pack-bundle, with correct data about index (like "Course X of Y, Lesson A of B")
- load homepage and content cards should load (previously the fetch queries returned null)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for assigning filter prefixes, ensuring more consistent and accurate filter behavior.
  * Updated how parent lists are filtered when fetching sibling content, potentially affecting the display of future or parent-related items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->