### PR TITLE
fix(MU-921): add context to content empty arrays

### DIFF
--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -77,8 +77,11 @@ export async function addContextToContent(dataPromise, ...dataArgs)
   const dataParam = lastArg === options ? dataArgs.slice(0, -1) : dataArgs
 
   let data = await dataPromise(...dataParam)
-  if(!data) return false
   const isDataAnArray = Array.isArray(data)
+  if(isDataAnArray && data.length === 0) return data
+  if(!data) return false
+  const items = extractItemsFromData(data, dataField, isDataAnArray, dataField_includeParent)
+  const ids = items.map(item => item?.id).filter(Boolean)
 
   const items = extractItemsFromData(data, dataField, isDataAnArray, dataField_includeParent) ?? []
   const ids = items.map(item => item?.id).filter(Boolean)

--- a/src/services/contentAggregator.js
+++ b/src/services/contentAggregator.js
@@ -80,8 +80,6 @@ export async function addContextToContent(dataPromise, ...dataArgs)
   const isDataAnArray = Array.isArray(data)
   if(isDataAnArray && data.length === 0) return data
   if(!data) return false
-  const items = extractItemsFromData(data, dataField, isDataAnArray, dataField_includeParent)
-  const ids = items.map(item => item?.id).filter(Boolean)
 
   const items = extractItemsFromData(data, dataField, isDataAnArray, dataField_includeParent) ?? []
   const ids = items.map(item => item?.id).filter(Boolean)

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -11,7 +11,7 @@ import {
   fetchRecentUserActivities,
 } from './railcontent'
 import { DataContext, UserActivityVersionKey } from './dataContext.js'
-import { fetchByRailContentIds, fetchShows } from './sanity'
+import { fetchByRailContentId, fetchByRailContentIds, fetchShows } from './sanity'
 import { fetchPlaylist, fetchUserPlaylists } from './content-org/playlists'
 import { pinnedGuidedCourses } from './content-org/guided-courses'
 import {


### PR DESCRIPTION
Approved PR is [here](https://github.com/railroadmedia/musora-content-services/pull/407)


[MU2-921](https://musora.atlassian.net/browse/MU2-921)

Update the addContextToContent method to return an empty array ([]) instead of false when the result of the internal dataPromise call is an empty array

[MU2-921]: https://musora.atlassian.net/browse/MU2-921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty content data to ensure accurate processing.

* **Chores**
  * Updated internal imports to include additional dependencies for user activity services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->