### PR TITLE
feat(BEH-845): restore content progress endpoint

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,7 +44,8 @@ import {
 } from './services/content.js';
 
 import {
-	addContextToContent
+	addContextToContent,
+	getNavigateToForPlaylists
 } from './services/contentAggregator.js';
 
 import {
@@ -61,6 +62,7 @@ import {
 	getAllStarted,
 	getAllStartedOrCompleted,
 	getLastInteractedOf,
+	getNavigateTo,
 	getNextLesson,
 	getProgressDateByIds,
 	getProgressPercentage,
@@ -143,6 +145,7 @@ import {
 	postContentComplete,
 	postContentLiked,
 	postContentReset,
+	postContentRestore,
 	postContentUnliked,
 	postPlaylistContentEngaged,
 	postRecordWatchSession,
@@ -425,6 +428,8 @@ declare module 'musora-content-services' {
 		getLastInteractedOf,
 		getLessonContentRows,
 		getMonday,
+		getNavigateTo,
+		getNavigateToForPlaylists,
 		getNewAndUpcoming,
 		getNextLesson,
 		getPracticeNotes,
@@ -479,6 +484,7 @@ declare module 'musora-content-services' {
 		postContentComplete,
 		postContentLiked,
 		postContentReset,
+		postContentRestore,
 		postContentUnliked,
 		postPlaylistContentEngaged,
 		postRecordWatchSession,

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,8 @@ import {
 } from './services/content.js';
 
 import {
-	addContextToContent
+	addContextToContent,
+	getNavigateToForPlaylists
 } from './services/contentAggregator.js';
 
 import {
@@ -61,6 +62,7 @@ import {
 	getAllStarted,
 	getAllStartedOrCompleted,
 	getLastInteractedOf,
+	getNavigateTo,
 	getNextLesson,
 	getProgressDateByIds,
 	getProgressPercentage,
@@ -143,6 +145,7 @@ import {
 	postContentComplete,
 	postContentLiked,
 	postContentReset,
+	postContentRestore,
 	postContentUnliked,
 	postPlaylistContentEngaged,
 	postRecordWatchSession,
@@ -424,6 +427,8 @@ export {
 	getLastInteractedOf,
 	getLessonContentRows,
 	getMonday,
+	getNavigateTo,
+	getNavigateToForPlaylists,
 	getNewAndUpcoming,
 	getNextLesson,
 	getPracticeNotes,
@@ -478,6 +483,7 @@ export {
 	postContentComplete,
 	postContentLiked,
 	postContentReset,
+	postContentRestore,
 	postContentUnliked,
 	postPlaylistContentEngaged,
 	postRecordWatchSession,

--- a/src/services/railcontent.js
+++ b/src/services/railcontent.js
@@ -378,13 +378,33 @@ export async function fetchUserBadges(brand = null) {
   return await fetchHandler(url, 'get')
 }
 
+/**
+ * complete a content's progress for a given user
+ * @param contentId
+ * @returns {Promise<any|string|null>}
+ */
 export async function postContentComplete(contentId) {
   let url = `/api/content/v1/user/progress/complete/${contentId}`
   return postDataHandler(url)
 }
 
+/**
+ * resets the user's progress on a content
+ * @param contentId
+ * @returns {Promise<any|string|null>}
+ */
 export async function postContentReset(contentId) {
   let url = `/api/content/v1/user/progress/reset/${contentId}`
+  return postDataHandler(url)
+}
+
+/**
+ * restores the user's progress on a content
+ * @param contentId
+ * @returns {Promise<any|string|null>}
+ */
+export async function postContentRestore(contentId) {
+  let url = `/api/content/v1/user/progress/restore/${contentId}`
   return postDataHandler(url)
 }
 


### PR DESCRIPTION
## Jira
- [(related: BEH-845)](https://musora.atlassian.net/browse/BEH-845)
- [mpb PR](https://github.com/railroadmedia/musora-platform-backend/pull/245)
- Chris: "Peter brought this up, but I feel like we should include Undo in reset progress actions to remain consistent with most user actions that affect them have the option to undo if it was a result of misclick / they changed their mind.
Unless there’s a major complication with it, we should add it to reset progress if it’s not already there on App"

## Changes
- adds restore content progress endpoint to mcs

## testing
- pull MPB changes, link mcs
- use `postContentComplete(233956)` to get progress. it will show inthe content progress row.
- use `postContentRestore(233956)` to delete the content progress. the recent progress card should disappear.
- use `postContentRestore(233956)` and verify the card comes back
- this tested flat content
- repeat for `397035` to test child content of a course
- repeat for `397032` to test parent of a course
  - edge case: complete full course. uncomplete a lesson. reset then restore progress on course. lesson progress and course completion % should be as before reset (with that one lesson still uncompleted)