### PR TITLE
fix: MU2-914: prevent null access error in fetchUnreadCount

### DIFF
--- a/src/services/user/notifications.js
+++ b/src/services/user/notifications.js
@@ -162,7 +162,7 @@ export async function restoreNotification(notificationId) {
 export async function fetchUnreadCount({ brand = 'drumeo'} = {}) {
   const url = `${baseUrl}/v1/unread-count`
   const notifUnread =  await fetchHandler(url, 'get')
-  if (notifUnread.data > 0) {
+  if (notifUnread && notifUnread.data > 0) {
     return notifUnread// Return early if unread notifications exist
   }
   const liveEventPollingState = await fetchLiveEventPollingState()
@@ -170,7 +170,7 @@ export async function fetchUnreadCount({ brand = 'drumeo'} = {}) {
     const liveEvent = await fetchLiveEvent(brand)
     return { data: liveEvent ? 1 : 0}
   }
-  return notifUnread
+  return { data: 0}
 }
 
 /**


### PR DESCRIPTION
[MU2-914](https://musora.atlassian.net/browse/MU2-914?atlOrigin=eyJpIjoiZmJlY2NlOGNiZWNiNDU1Njk1NTc0NTQyZmI5ZTRiNzciLCJwIjoiaiJ9)

This update prevents runtime errors when `fetchHandler` returns null or an unexpected response in the `fetchUnreadCount` function.

### Changes
- Added a null check before accessing `notifUnread.data`.
- Ensured the function always returns a consistent `{ data: number }` object when there are no unread notifications.
- Removed potential `Cannot read property 'data' of null` errors.


