### PR TITLE
feat: T3PS-458: Add Jam Tracks pill on Songs Overview page

### DIFF
--- a/src/contentMetaData.js
+++ b/src/contentMetaData.js
@@ -39,6 +39,7 @@ export class Tabs {
   static Tutorials = { name: 'Tutorials', short_name: 'Tutorials', value: 'type,tutorials', cardType: 'big' }
   static Transcriptions = { name: 'Transcriptions', short_name: 'Transcriptions', value: 'type,transcription', cardType: 'small' }
   static PlayAlongs = { name: 'Play-Alongs', short_name: 'Play-Alongs', value:'type,play along', cardType: 'small' }
+  static JamTracks = { name: 'Jam Tracks', short_name: 'Jam Tracks', value:'type,jam-track', cardType: 'small' }
   static RecentAll = { name: 'All', short_name: 'All' }
   static RecentIncomplete = { name: 'Incomplete', short_name: 'Incomplete' }
   static RecentCompleted = { name: 'Completed', short_name: 'Completed' }
@@ -220,6 +221,7 @@ const commonMetadata = {
       Tabs.Tutorials,
       Tabs.Transcriptions,
       Tabs.PlayAlongs,
+      Tabs.JamTracks,
       Tabs.ExploreAll
     ],
   },
@@ -359,6 +361,7 @@ const contentMetadata = {
         Tabs.Tutorials,
         Tabs.Transcriptions,
         Tabs.PlayAlongs,
+        Tabs.JamTracks,
         Tabs.ExploreAll
       ],
     },
@@ -400,6 +403,7 @@ const contentMetadata = {
         Tabs.Tutorials,
         Tabs.Transcriptions,
         Tabs.PlayAlongs,
+        Tabs.JamTracks,
         Tabs.ExploreAll
       ],
     },
@@ -451,6 +455,7 @@ const contentMetadata = {
         Tabs.Tutorials,
         Tabs.Transcriptions,
         Tabs.PlayAlongs,
+        Tabs.JamTracks,
         Tabs.ExploreAll
       ],
     },
@@ -491,6 +496,7 @@ const contentMetadata = {
         Tabs.Tutorials,
         Tabs.Transcriptions,
         Tabs.PlayAlongs,
+        Tabs.JamTracks,
         Tabs.ExploreAll
       ],
     },

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -174,6 +174,7 @@ export const studentArchivesLessonTypes = ['student-review', 'student-focus','st
 export const tutorialsLessonTypes = ['song-tutorial'];
 export const transcriptionsLessonTypes = ['song'];
 export const playAlongLessonTypes = ['play-along'];
+export const jamTrackLessonTypes = ['jam-track'];
 
 export const individualLessonsTypes = [
   ...singleLessonTypes,
@@ -207,7 +208,7 @@ export const lessonTypesMapping = {
   'tabs': transcriptionsLessonTypes,
   'sheet music': transcriptionsLessonTypes,
   'play-alongs': playAlongLessonTypes,
-  'jam tracks': ['jam-track'],
+  'jam tracks': jamTrackLessonTypes,
 };
 
 export const getNextLessonLessonParentTypes = ['course', 'guided-course', 'pack', 'pack-bundle', 'song-tutorial'];
@@ -222,7 +223,7 @@ export const progressTypesMapping = {
   'guided course': ['guided-course'],
   'pack': ['pack', 'semester-pack'],
   'method': ['learning-path'],
-  'jam track': ['jam-track'],
+  'jam track': jamTrackLessonTypes,
   'course video': ['course-part'],
 };
 
@@ -235,7 +236,7 @@ export const songs = {
 
 export const filterTypes = {
   lessons: [...individualLessonsTypes, ...collectionLessonTypes],
-  songs: [...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes, 'jam-track'],
+  songs: [...tutorialsLessonTypes, ...transcriptionsLessonTypes, ...playAlongLessonTypes, ...jamTrackLessonTypes],
 }
 
 export const recentTypes = {
@@ -801,6 +802,9 @@ export function filtersToGroq(filters, selectedFilters = [], pageName = '') {
               return ` (${conditions})`;
             } else if(value.toLowerCase() === Tabs.PlayAlongs.name.toLowerCase()){
               const conditions = playAlongLessonTypes.map(lessonType => `_type == '${lessonType}'`).join(' || ');
+              return ` (${conditions})`;
+            } else if(value.toLowerCase() === Tabs.JamTracks.name.toLowerCase()){
+              const conditions = jamTrackLessonTypes.map(lessonType => `_type == '${lessonType}'`).join(' || ');
               return ` (${conditions})`;
             } else if(value.toLowerCase() === Tabs.ExploreAll.name.toLowerCase()){
               var allLessons = filterTypes[pageName] || [];


### PR DESCRIPTION
[T3PS-458](https://musora.atlassian.net/browse/T3PS-458?atlOrigin=eyJpIjoiNDA1YTY1MTM3YzIyNGZkY2E3NThhNzgwZDUyZDA4MDUiLCJwIjoiaiJ9)

Add Jam Tracks pill on Songs Overview page



[T3PS-458]: https://musora.atlassian.net/browse/T3PS-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Jam Tracks tab across applicable content views and brand-specific song sections.
  * Supports filtering by Jam Tracks, with a consistent small-card presentation.
  * Integrated seamlessly into existing tab sets without altering established tab order.
  * Progress and lesson tracking now recognize Jam Tracks for a consistent experience across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->