### PR TITLE
fix: progress rows throws error for empty progress

### DIFF
--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -995,6 +995,7 @@ function generateContentsMap(contents, playlistsContents) {
   const existingShows = new Set()
   const contentsMap = new Map()
   const childToParentMap = {}
+  if (!contents) return contentsMap
   contents.forEach((content) => {
     if (Array.isArray(content.parent_content_data) && content.parent_content_data.length > 0) {
       childToParentMap[content.id] =
@@ -1073,20 +1074,20 @@ export async function getProgressRows({ brand = null, limit = 8 } = {}) {
     nonPlaylistContentIds.push(userPinnedItem.id)
   }
   const [playlistsContents, contents] = await Promise.all([
-    addContextToContent(fetchByRailContentIds, playlistEngagedOnContents, 'progress-tracker', {
+    playlistEngagedOnContents ? addContextToContent(fetchByRailContentIds, playlistEngagedOnContents, 'progress-tracker', {
       addNextLesson: true,
       addNavigateTo: true,
       addProgressStatus: true,
       addProgressPercentage: true,
       addProgressTimestamp: true,
-    }),
-    addContextToContent(fetchByRailContentIds, nonPlaylistContentIds, 'progress-tracker', brand, {
+    }) : Promise.resolve([]),
+    nonPlaylistContentIds ? addContextToContent(fetchByRailContentIds, nonPlaylistContentIds, 'progress-tracker', brand, {
       addNextLesson: true,
       addNavigateTo: true,
       addProgressStatus: true,
       addProgressPercentage: true,
       addProgressTimestamp: true,
-    }),
+    }) : Promise.resolve([]),
   ])
   const contentsMap = generateContentsMap(contents, playlistsContents)
   let combined = await extractPinnedItemsAndSortAllItems(


### PR DESCRIPTION
Issue:
sanity can return null in the case of no results (not an empty array). 
I don't know if we should update sanity to return an empty array instead, but for the moment I just patched the getProgressRows

## Testing
Clear your existing data (set the use_id)
- delete from railcontent_user_content_progress where user_id = 631736;
- delete from guided_course_user_enrollments where user_id = 631736;
- clear local storage
- log back in and refresh home page. It should still load and progress rows should be empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Release 2.32.0: display name update; blocked users list available.

- Bug Fixes
  - Ensure parent artist is added if null (closes #380, #384).
  - Correct brand filtering in related lessons (T3PS-373).

- Documentation
  - Added comprehensive API docs (Awards, Content-Services V2, User modules, etc.) and updated docs index.
  - Introduced automatic V2 docs sync to main.

- CI/CD
  - Enforce Conventional Commit titles on PRs.
  - Enabled automated reviews and chat responses.

- Chores
  - New PR template.
  - Standardized editor settings; streamlined README setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->