### PR TITLE
fix: add published on to navigate_to

### DIFF
--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -166,6 +166,7 @@ function buildNavigateTo(content, child = null) {
     thumbnail: content.thumbnail ?? '',
     id: content.id ?? null,
     type: content.type ?? '',
+    published_on: content.published_on ?? null,
     child: child,
   }
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -2184,11 +2184,12 @@ export async function fetchTabData(
   let filter = ''
 
   filter = `brand == "${brand}" ${includedFieldsFilter}`
-  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
+  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true, pullFutureContent: true }).buildFilter()
+  const childrenFields = await getChildFieldsForContentType('tab-data')
   const lessonCountFilter = await new FilterBuilder(`_id in ^.child[]._ref`).buildFilter()
   entityFieldsString =
     ` ${fieldsString}
-    'children': child[${childrenFilter}]->{'id': railcontent_id, 'type': _type, brand, 'thumbnail': thumbnail.asset->url, published_on},
+    'children': child[${childrenFilter}]->{ ${childrenFields} },
     'isLive': live_event_start_time <= "${now}" && live_event_end_time >= "${now}",
     'lesson_count': coalesce(count(*[${lessonCountFilter}]), 0),
     'length_in_seconds': coalesce(

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -2188,7 +2188,7 @@ export async function fetchTabData(
   const lessonCountFilter = await new FilterBuilder(`_id in ^.child[]._ref`).buildFilter()
   entityFieldsString =
     ` ${fieldsString}
-    'children': child[${childrenFilter}]->{'id': railcontent_id, 'type': _type, brand, 'thumbnail': thumbnail.asset->url},
+    'children': child[${childrenFilter}]->{'id': railcontent_id, 'type': _type, brand, 'thumbnail': thumbnail.asset->url, published_on},
     'isLive': live_event_start_time <= "${now}" && live_event_end_time >= "${now}",
     'lesson_count': coalesce(count(*[${lessonCountFilter}]), 0),
     'length_in_seconds': coalesce(


### PR DESCRIPTION
Based on a conversation I had with meenu regarding guided courses
MA-US-IDX-3: Course Not Started & First Lesson Unavailable
As a learner eager to start a course
 I want tapping the card to show a toast with the release date when the first lesson is locked
 So that I know exactly when I can begin
Acceptance Criteria
GIVEN the course has not yet been started by me
 AND the first lesson is not yet released (locked)
 WHEN I tap the course card
 THEN a toast appears reading “Released on May 15 at 11:00 a.m.” in my local timezone

MA/FEW needs the published_on date for children. So I added it to navigateTo, and the tab-data field. 

Testing:
http://localhost:5173/pianote/lessons/collections
I checked the lessonsTabStore value had the correct child fields . PReviously it was just thumbnail and such.
<img width="1778" height="963" alt="image" src="https://github.com/user-attachments/assets/555efc11-7e40-4cc8-9b12-45c88a9cd81c" />


Can see the update to navigateTo here on homepage. (For some reason it doesn't show in the store, but it does exist)
<img width="1778" height="963" alt="image" src="https://github.com/user-attachments/assets/a9197f49-71b3-4f87-b595-3bb3454048f2" />


This already exists for other queries that include children, but `tab-data` was hardcoding the children fields.