### PR TITLE
fix: getNavigateTo for cycle blocked if child not found

### DIFF
--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -147,8 +147,8 @@ export async function getNavigateTo(data) {
           if (childrenStates[lastInteractedChildId] === STATE_COMPLETED) {
             // TODO: packs have an extra situation where we need to jump to the next course if all lessons in the last engaged course are completed
           }
-          let lastInteractedChildNavToData = await getNavigateTo(firstChildren)
-          if (lastInteractedChildNavToData) {
+          if (firstChildren){
+            let lastInteractedChildNavToData = await getNavigateTo(firstChildren)
             lastInteractedChildNavToData = lastInteractedChildNavToData[lastInteractedChildId]
             navigateToData[content.id] = buildNavigateTo(
               children.get(lastInteractedChildId),

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -114,12 +114,14 @@ export async function getNavigateTo(data) {
       const contentState = await getProgressState(content.id)
       if (contentState !== STATE_STARTED) {
         const firstChild = content.children[0]
-        let lastInteractedChildNavToData =
-          (await getNavigateTo([firstChild])[firstChild.id]) ?? null
-        navigateToData[content.id] = buildNavigateTo(
-          content.children[0],
-          lastInteractedChildNavToData
-        )
+        if (firstChild) {
+          let lastInteractedChildNavToData =
+            (await getNavigateTo([firstChild])[firstChild.id]) ?? null
+          navigateToData[content.id] = buildNavigateTo(
+            content.children[0],
+            lastInteractedChildNavToData
+          )
+        }
       } else {
         const childrenStates = await getProgressStateByIds(childrenIds)
         const lastInteracted = await getLastInteractedOf(childrenIds)
@@ -130,7 +132,9 @@ export async function getNavigateTo(data) {
             navigateToData[content.id] = buildNavigateTo(children.get(lastInteracted))
           } else {
             let incompleteChild = findIncompleteLesson(childrenStates, lastInteracted, content.type)
-            navigateToData[content.id] = buildNavigateTo(children.get(incompleteChild))
+            if (incompleteChild) {
+              navigateToData[content.id] = buildNavigateTo(children.get(incompleteChild))
+            }
           }
         } else if (content.type === 'guided-course' || content.type === 'song-tutorial') {
           let incompleteChild = findIncompleteLesson(childrenStates, lastInteracted, content.type)
@@ -144,11 +148,13 @@ export async function getNavigateTo(data) {
             // TODO: packs have an extra situation where we need to jump to the next course if all lessons in the last engaged course are completed
           }
           let lastInteractedChildNavToData = await getNavigateTo(firstChildren)
-          lastInteractedChildNavToData = lastInteractedChildNavToData[lastInteractedChildId]
-          navigateToData[content.id] = buildNavigateTo(
-            children.get(lastInteractedChildId),
-            lastInteractedChildNavToData
-          )
+          if (lastInteractedChildNavToData) {
+            lastInteractedChildNavToData = lastInteractedChildNavToData[lastInteractedChildId]
+            navigateToData[content.id] = buildNavigateTo(
+              children.get(lastInteractedChildId),
+              lastInteractedChildNavToData
+            )
+          }
         }
       }
     }

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -132,9 +132,7 @@ export async function getNavigateTo(data) {
             navigateToData[content.id] = buildNavigateTo(children.get(lastInteracted))
           } else {
             let incompleteChild = findIncompleteLesson(childrenStates, lastInteracted, content.type)
-            if (incompleteChild) {
-              navigateToData[content.id] = buildNavigateTo(children.get(incompleteChild))
-            }
+            navigateToData[content.id] = buildNavigateTo(children.get(incompleteChild))
           }
         } else if (content.type === 'guided-course' || content.type === 'song-tutorial') {
           let incompleteChild = findIncompleteLesson(childrenStates, lastInteracted, content.type)


### PR DESCRIPTION
**Jira Ticket**
https://musora.atlassian.net/browse/T3PS-351

**Description**
If buildNavigateTo returns null, this for `for (const content of data) ` gets blocked and none of the items will have navigateTo field added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents crashes and broken redirects when resuming content with missing or incomplete progress data.
  - Improves navigation stability for not-started items, course/pack bundles, and multi-level pack content by adding guards against absent navigation details.
  - Ensures “Continue” works consistently across guided courses and song tutorials, avoiding incorrect or null navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->