### PR TITLE
feat(BEH-983): refactoring queries to allow for brand redirects

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1196,8 +1196,8 @@ export async function fetchRelatedRecommendedContent(railContentId, brand, count
  * @param count
  * @returns {Promise<Array<Object>>}
  */
-export async function fetchOtherSongVersions(railcontentId, brand, count = 3) {
-  return fetchRelatedByLicense(railcontentId, brand, true, count)
+export async function fetchOtherSongVersions(railcontentId, count = 3) {
+  return fetchRelatedByLicense(railcontentId, true, count)
 }
 
 /**
@@ -1209,8 +1209,8 @@ export async function fetchOtherSongVersions(railcontentId, brand, count = 3) {
  * @param {integer:3} count
  * @returns {Promise<Array<Object>>}
  */
-export async function fetchLessonsFeaturingThisContent(railcontentId, brand, count = 3) {
-  return fetchRelatedByLicense(railcontentId, brand, false, count)
+export async function fetchLessonsFeaturingThisContent(railcontentId,  count = 3) {
+  return fetchRelatedByLicense(railcontentId, false, count)
 }
 
 /**
@@ -1222,9 +1222,9 @@ export async function fetchLessonsFeaturingThisContent(railcontentId, brand, cou
  * @param {integer:3} count
  * @returns {Promise<Array<Object>>}
  */
-async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, count) {
+async function fetchRelatedByLicense(railcontentId, onlyUseSongTypes, count) {
   const typeCheck = `@->_type in [${arrayJoinWithQuotes(SONG_TYPES)}]`
-  let typeCheckString = `@->brand == '${brand}' && `
+  let typeCheckString = `@->brand == ^.brand && `
   typeCheckString += onlyUseSongTypes ? `${typeCheck}` : `!(${typeCheck})`
   const contentFromLicenseFilter = `_type == 'license' && references(^._id)].content[${typeCheckString} && @->railcontent_id != ${railcontentId}`
   let filterSongTypesWithSameLicense = await new FilterBuilder(contentFromLicenseFilter, {
@@ -1247,12 +1247,11 @@ async function fetchRelatedByLicense(railcontentId, brand, onlyUseSongTypes, cou
 }
 
 /**
- * Fetch sibling lessons to a specific lesson
+ * Fetches sibling lessons to a specific lesson
  * @param {string} railContentId - The RailContent ID of the current lesson.
- * @param {string} brand - The current brand.
  * @returns {Promise<Array<Object>|null>} - The fetched related lessons data or null if not found.
  */
-export async function fetchSiblingContent(railContentId, brand= null)
+export async function fetchSiblingContent(railContentId)
 {
   const filterGetParent = await new FilterBuilder(`references(^._id) && _type == ^.parent_type`, {
     pullFutureContent: true

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1263,10 +1263,9 @@ export async function fetchSiblingContent(railContentId)
 
   const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
 
-  const brandString = brand ? ` && brand == "${brand}"` : ''
   const queryFields = `_id, "id":railcontent_id, published_on, "instructor": instructor[0]->name, title, "thumbnail":thumbnail.asset->url, length_in_seconds, status, "type": _type, difficulty, difficulty_string, artist->, "permission_id": permission[]->railcontent_id, "genre": genre[]->name, "parent_id": parent_content_data[0].id`
 
-  const query = `*[railcontent_id == ${railContentId}${brandString}]{
+  const query = `*[railcontent_id == ${railContentId}]{
    _type, parent_type, 'parent_id': parent_content_data[0].id, railcontent_id,
    'for-calculations': *[${filterGetParent}][0]{
     'siblings-list': child[]->railcontent_id,


### PR DESCRIPTION
## Jira
- [BEH-983](https://musora.atlassian.net/browse/TP-983)
- [mpb PR](https://github.com/railroadmedia/musora-platform-backend/pull/271)

## Design

- we need to refactor sanity queries so that they either dont use brand as a parameter, and instead use the content's brand from within the groq query, or have content.brand passed in from FE/MA after receiving it from a different fetch function
- refactors many sanity query functions to use groq methods to pull content's brand, instead of it needing to be passed in
- removes brand parameter from functions that query sanity for lesson content
  - this is needed for comparing brands on FE/MA

## Testing

- test all these endpoints in the mcs devendpoint at https://devapp.musora.com:5174/devendpoint
  - `397033` is a course-part, `411128` is a song transcription
  - 
- fetchRelatedRecommendedContent - `{"railcontentId": "397033", "brand": "drumeo"}`
  - needs brand for huggingface, and FE passes in `content.brand`
- fetchSiblingContent - `{"railcontentId": "397033"}`
- fetchLessonsFeaturingThisContent - `{"railcontentId": "411128"}`
- fetchOtherSongVersions - `{"railcontentId": "411128"}`
- fetchLessonContent - `{"railcontentId": "397033"}`
- fetchPackData - `{"railcontentId": "397033"}`


[BEH-983]: https://musora.atlassian.net/browse/BEH-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Related and sibling content now auto-detect brand context for more accurate suggestions.
- Refactor
  - Simplified fetching logic for related lessons and alternate song versions, removing explicit brand handling.
- Documentation
  - Updated description clarifying sibling content behavior.

Note: These changes streamline recommendations by deriving brand context from content rather than requiring manual selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->