### PR TITLE
feat: fix navigateTo for packs without progress, restrict pack access to allowed packs

### DIFF
--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -114,10 +114,10 @@ export async function getNavigateTo(data) {
       const contentState = await getProgressState(content.id)
       if (contentState !== STATE_STARTED) {
         const firstChild = content.children[0]
-        let lastInteractedChildNavToData =
-          (await getNavigateTo([firstChild])[firstChild.id]) ?? null
+        let lastInteractedChildNavToData = await getNavigateTo([firstChild])
+        lastInteractedChildNavToData = lastInteractedChildNavToData[firstChild.id] ?? null
         navigateToData[content.id] = buildNavigateTo(
-          content.children[0],
+          firstChild,
           lastInteractedChildNavToData
         )
       } else {

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1450,7 +1450,8 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
  *   .catch(error => console.error(error));
  */
 export async function fetchPackData(id) {
-  const query = `*[railcontent_id == ${id}]{
+  const builder = await new FilterBuilder(`railcontent_id == ${id}`).buildFilter()
+  const query = `*[${builder}]{
     ${await getFieldsForContentTypeWithFilteredChildren('pack')}
   } [0...1]`
   return fetchSanity(query, false)

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -2187,7 +2187,7 @@ export async function fetchTabData(
   const lessonCountFilter = await new FilterBuilder(`_id in ^.child[]._ref`).buildFilter()
   entityFieldsString =
     ` ${fieldsString}
-    'children': child[${childrenFilter}]->{ ${childrenFields} },
+    'children': child[${childrenFilter}]->{ ${childrenFields} 'children': child[${childrenFilter}]->{ ${childrenFields} }, },
     'isLive': live_event_start_time <= "${now}" && live_event_end_time >= "${now}",
     'lesson_count': coalesce(count(*[${lessonCountFilter}]), 0),
     'length_in_seconds': coalesce(


### PR DESCRIPTION
Changeset
- JS grammar fix for null eval
- add grandchildren to tab-data fields so navigateTo correctly caluculated for packs on lessons page
- fix permissions + status filter for `getPackData`

Testing
Note all packs in Drumeo are status==deleted  
 - devendpoint
 - `addContextToContent(fetchPackData, 416528, {addNavigateTo: true}).then(r => console.log('pack',r))`
 - should have a navigateTo with `navigateTo.child.id = 416530` and `type=pack-bundle-lesson`
 - you can also see this pack in the [lesson](http://localhost:5173/pianote/lessons/collections) collection page. Though it appears that navigate to is not properly implemented. I checked it exists correctly by adding a console log on line 127 of content.js `console.log('tabResults', results)` and checking the pack.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Tabs now support nested child items, enabling deeper content browsing within tab views.

* Bug Fixes
  * Fixed navigation reliability when opening content that hasn’t been started, ensuring correct routing to the appropriate first child.

* Refactor
  * Improved query construction for content packs using a standardized filter builder to enhance consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->