### PR TITLE
fix(BEH-624): Sanity CDN doesn't require bearer token authorization

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1810,7 +1810,6 @@ export async function fetchSanity(
   const api = globalConfig.sanityConfig.useCachedAPI ? 'apicdn' : 'api'
   const url = `https://${globalConfig.sanityConfig.projectId}.${api}.sanity.io/v${globalConfig.sanityConfig.version}/data/query/${globalConfig.sanityConfig.dataset}?perspective=${perspective}`
   const headers = {
-    Authorization: `Bearer ${globalConfig.sanityConfig.token}`,
     'Content-Type': 'application/json',
   }
 


### PR DESCRIPTION
In this fix branch I remove the Authorization header from sanity read only CDN, which is indifferent if an auth token is there or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of content loading from the CMS by adjusting request headers, reducing intermittent authorization-related errors for publicly accessible data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->