### PR TITLE
fix(T3PS-798): 0 progress shows start course cta text

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -313,7 +313,6 @@ import {
 
 import {
 	login,
-	loginWithProvider,
 	logout
 } from './services/user/sessions.js';
 
@@ -530,7 +529,6 @@ declare module 'musora-content-services' {
 		lockThread,
 		logUserPractice,
 		login,
-		loginWithProvider,
 		logout,
 		markAllNotificationsAsRead,
 		markContentAsInterested,

--- a/src/index.js
+++ b/src/index.js
@@ -313,7 +313,6 @@ import {
 
 import {
 	login,
-	loginWithProvider,
 	logout
 } from './services/user/sessions.js';
 
@@ -529,7 +528,6 @@ export {
 	lockThread,
 	logUserPractice,
 	login,
-	loginWithProvider,
 	logout,
 	markAllNotificationsAsRead,
 	markContentAsInterested,

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -1118,7 +1118,7 @@ async function processContentItem(content) {
       })
       content.time_remaining_seconds = timeRemaining.totalSeconds
       ctaText = 'Next lesson in ' + timeRemaining.formatted
-    } else if (!content.progressStatus || content.progressStatus === 'not-started') {
+    } else if (!content.progressStatus || content.progressStatus === 'not-started' || content.progressPercentage === 0) {
       ctaText = 'Start Course'
     }
   }


### PR DESCRIPTION
## Jira

- [T3PS-798](https://musora.atlassian.net/browse/T3PS-798)

## Changes

- button displays "Start Course" if 0 progress percent

## Testing

- link mcs
- enroll in a GC (make sure you have no progress on it)
- homepage -> see button say "Start Course"

[T3PS-798]: https://musora.atlassian.net/browse/T3PS-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - “Start Course” button now appears when progress is explicitly 0%, ensuring accurate CTA for new or reset content.

- Chores
  - Removed provider-based login from the public API, simplifying the authentication options exposed to clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->