### PR TITLE
refactor: refactor part of sanity.js

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,6 +38,13 @@ import {
 } from './services/content/instructor.ts';
 
 import {
+	fetchNewReleases,
+	fetchNewUpcomingAndLive,
+	fetchScheduledReleases,
+	fetchUpcomingEvents
+} from './services/content/scheduled.ts';
+
+import {
 	enrollUserInGuidedCourse,
 	fetchEnrollmentPageMetadata,
 	guidedCourses,
@@ -285,8 +292,6 @@ import {
 	fetchMethodV2IntroVideo,
 	fetchMethodV2Structure,
 	fetchMethodV2StructureFromId,
-	fetchNewReleases,
-	fetchNewUpcomingAndLive,
 	fetchOtherSongVersions,
 	fetchOwnedContent,
 	fetchPackData,
@@ -297,7 +302,6 @@ import {
 	fetchRelatedRecommendedContent,
 	fetchRelatedSongs,
 	fetchReturning,
-	fetchScheduledReleases,
 	fetchShows,
 	fetchShowsData,
 	fetchSiblingContent,
@@ -305,7 +309,6 @@ import {
 	fetchSongById,
 	fetchTabData,
 	fetchTopLevelParentId,
-	fetchUpcomingEvents,
 	getSongTypesFor,
 	jumpToContinueContent
 } from './services/sanity.js';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -82,6 +82,7 @@ import {
 } from './services/content-org/playlists.js';
 
 import {
+	filterCoursesInCourseCollections,
 	getContentRows,
 	getLegacyMethods,
 	getLessonContentRows,
@@ -262,7 +263,6 @@ import {
 } from './services/reporting/reporting.ts';
 
 import {
-	buildEntityAndTotalQuery,
 	fetchAll,
 	fetchAllFilterOptions,
 	fetchBrandsByContentIds,
@@ -286,6 +286,7 @@ import {
 	fetchMethodV2Structure,
 	fetchMethodV2StructureFromId,
 	fetchNewReleases,
+	fetchNewUpcomingAndLive,
 	fetchOtherSongVersions,
 	fetchOwnedContent,
 	fetchPackData,
@@ -296,8 +297,6 @@ import {
 	fetchRelatedRecommendedContent,
 	fetchRelatedSongs,
 	fetchReturning,
-	fetchSanity,
-	fetchScheduledAndNewReleases,
 	fetchScheduledReleases,
 	fetchShows,
 	fetchShowsData,
@@ -307,9 +306,7 @@ import {
 	fetchTabData,
 	fetchTopLevelParentId,
 	fetchUpcomingEvents,
-	getSanityDate,
 	getSongTypesFor,
-	getSortOrder,
 	jumpToContinueContent
 } from './services/sanity.js';
 
@@ -451,7 +448,6 @@ declare module 'musora-content-services' {
 		assignModeratorToComment,
 		blockUser,
 		blockedUsers,
-		buildEntityAndTotalQuery,
 		buildImageSRC,
 		calculateLongestStreaks,
 		clearAllCachedData,
@@ -539,6 +535,7 @@ declare module 'musora-content-services' {
 		fetchMethodV2Structure,
 		fetchMethodV2StructureFromId,
 		fetchNewReleases,
+		fetchNewUpcomingAndLive,
 		fetchNotificationSettings,
 		fetchNotifications,
 		fetchOtherSongVersions,
@@ -558,8 +555,6 @@ declare module 'musora-content-services' {
 		fetchRelatedRecommendedContent,
 		fetchRelatedSongs,
 		fetchReturning,
-		fetchSanity,
-		fetchScheduledAndNewReleases,
 		fetchScheduledReleases,
 		fetchShows,
 		fetchShowsData,
@@ -581,6 +576,7 @@ declare module 'musora-content-services' {
 		fetchUserPracticeMeta,
 		fetchUserPracticeNotes,
 		fetchUserPractices,
+		filterCoursesInCourseCollections,
 		findIncompleteLesson,
 		flushWatchSession,
 		followThread,
@@ -630,10 +626,8 @@ declare module 'musora-content-services' {
 		getReportIssueOptions,
 		getResumeTimeSecondsByIds,
 		getResumeTimeSecondsByIdsAndCollections,
-		getSanityDate,
 		getScheduleContentRows,
 		getSongTypesFor,
-		getSortOrder,
 		getStartedOrCompletedProgressOnly,
 		getStreaksAndMessage,
 		getTabResults,

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,13 @@ import {
 } from './services/content/instructor.ts';
 
 import {
+	fetchNewReleases,
+	fetchNewUpcomingAndLive,
+	fetchScheduledReleases,
+	fetchUpcomingEvents
+} from './services/content/scheduled.ts';
+
+import {
 	enrollUserInGuidedCourse,
 	fetchEnrollmentPageMetadata,
 	guidedCourses,
@@ -289,8 +296,6 @@ import {
 	fetchMethodV2IntroVideo,
 	fetchMethodV2Structure,
 	fetchMethodV2StructureFromId,
-	fetchNewReleases,
-	fetchNewUpcomingAndLive,
 	fetchOtherSongVersions,
 	fetchOwnedContent,
 	fetchPackData,
@@ -301,7 +306,6 @@ import {
 	fetchRelatedRecommendedContent,
 	fetchRelatedSongs,
 	fetchReturning,
-	fetchScheduledReleases,
 	fetchShows,
 	fetchShowsData,
 	fetchSiblingContent,
@@ -309,7 +313,6 @@ import {
 	fetchSongById,
 	fetchTabData,
 	fetchTopLevelParentId,
-	fetchUpcomingEvents,
 	getSongTypesFor,
 	jumpToContinueContent
 } from './services/sanity.js';

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,7 @@ import {
 } from './services/content-org/playlists.js';
 
 import {
+	filterCoursesInCourseCollections,
 	getContentRows,
 	getLegacyMethods,
 	getLessonContentRows,
@@ -266,7 +267,6 @@ import {
 } from './services/reporting/reporting.ts';
 
 import {
-	buildEntityAndTotalQuery,
 	fetchAll,
 	fetchAllFilterOptions,
 	fetchBrandsByContentIds,
@@ -290,6 +290,7 @@ import {
 	fetchMethodV2Structure,
 	fetchMethodV2StructureFromId,
 	fetchNewReleases,
+	fetchNewUpcomingAndLive,
 	fetchOtherSongVersions,
 	fetchOwnedContent,
 	fetchPackData,
@@ -300,8 +301,6 @@ import {
 	fetchRelatedRecommendedContent,
 	fetchRelatedSongs,
 	fetchReturning,
-	fetchSanity,
-	fetchScheduledAndNewReleases,
 	fetchScheduledReleases,
 	fetchShows,
 	fetchShowsData,
@@ -311,9 +310,7 @@ import {
 	fetchTabData,
 	fetchTopLevelParentId,
 	fetchUpcomingEvents,
-	getSanityDate,
 	getSongTypesFor,
-	getSortOrder,
 	jumpToContinueContent
 } from './services/sanity.js';
 
@@ -450,7 +447,6 @@ export {
 	assignModeratorToComment,
 	blockUser,
 	blockedUsers,
-	buildEntityAndTotalQuery,
 	buildImageSRC,
 	calculateLongestStreaks,
 	clearAllCachedData,
@@ -538,6 +534,7 @@ export {
 	fetchMethodV2Structure,
 	fetchMethodV2StructureFromId,
 	fetchNewReleases,
+	fetchNewUpcomingAndLive,
 	fetchNotificationSettings,
 	fetchNotifications,
 	fetchOtherSongVersions,
@@ -557,8 +554,6 @@ export {
 	fetchRelatedRecommendedContent,
 	fetchRelatedSongs,
 	fetchReturning,
-	fetchSanity,
-	fetchScheduledAndNewReleases,
 	fetchScheduledReleases,
 	fetchShows,
 	fetchShowsData,
@@ -580,6 +575,7 @@ export {
 	fetchUserPracticeMeta,
 	fetchUserPracticeNotes,
 	fetchUserPractices,
+	filterCoursesInCourseCollections,
 	findIncompleteLesson,
 	flushWatchSession,
 	followThread,
@@ -629,10 +625,8 @@ export {
 	getReportIssueOptions,
 	getResumeTimeSecondsByIds,
 	getResumeTimeSecondsByIdsAndCollections,
-	getSanityDate,
 	getScheduleContentRows,
 	getSongTypesFor,
-	getSortOrder,
 	getStartedOrCompletedProgressOnly,
 	getStreaksAndMessage,
 	getTabResults,

--- a/src/lib/sanity/fetch.ts
+++ b/src/lib/sanity/fetch.ts
@@ -1,0 +1,159 @@
+import {  SONG_TYPES_WITH_CHILDREN } from '../../contentTypeConfig.js'
+import { globalConfig } from '../../services/config.js'
+import { getPermissionsAdapter } from '../../services/permissions'
+
+interface SanityConfig {
+  token: string;
+  projectId: string;
+  dataset: string;
+  version: string;
+}
+
+interface Config {
+  sanityConfig: SanityConfig;
+}
+
+export async function fetchSanity(
+  query: any,
+  isList: any,
+  { customPostProcess = null, processNeedAccess = true, processPageType = true }: any = {}
+) {
+  // Check the config object before proceeding
+  if (!checkSanityConfig(globalConfig)) {
+    return null
+  }
+  const perspective = globalConfig.sanityConfig.perspective ?? 'published'
+  const api = globalConfig.sanityConfig.useCachedAPI ? 'apicdn' : 'api'
+  const baseUrl = `https://${globalConfig.sanityConfig.projectId}.${api}.sanity.io/v${globalConfig.sanityConfig.version}/data/query/${globalConfig.sanityConfig.dataset}?perspective=${perspective}`
+  const headers = {
+    'Content-Type': 'application/json',
+  }
+  try {
+    const encodedQuery = encodeURIComponent(query)
+    const fullGetUrl = `${baseUrl}&query=${encodedQuery}`
+    const useGet = fullGetUrl.length < 8000
+
+    let url, method, options
+    if (useGet) {
+      url = fullGetUrl
+      method = 'GET'
+      options = {
+        method,
+        headers,
+      }
+    } else {
+      url = baseUrl
+      method = 'POST'
+      options = {
+        method,
+        headers,
+        body: JSON.stringify({ query }),
+      }
+    }
+    const adapter = getPermissionsAdapter()
+    let promisesResult = await Promise.all([
+      fetch(url, options),
+      processNeedAccess ? adapter.fetchUserPermissions() : null,
+    ])
+    const response = promisesResult[0]
+    const userPermissions = promisesResult[1]
+    if (!response.ok) {
+      throw new Error(`Sanity API error: ${response.status} - ${response.statusText}`)
+    }
+    const result = await response.json()
+    if (result.result) {
+      let results = isList ? result.result : result.result[0]
+      if (!results) {
+        throw new Error('No results found')
+      }
+      results = processNeedAccess ? await needsAccessDecorator(results, userPermissions) : results
+      results = processPageType ? pageTypeDecorator(results) : results
+      return customPostProcess ? customPostProcess(results) : results
+    } else {
+      throw new Error('No results found')
+    }
+  } catch (error) {
+    console.error('fetchSanity: Fetch error:', { error, query })
+    return null
+  }
+}
+
+function contentResultsDecorator(results: any, fieldName: any, callback: any) {
+  if (Array.isArray(results)) {
+    results.forEach((result) => {
+      // Check if this is a content row structure
+      if (result.content && Array.isArray(result.content)) {
+        // Content rows structure: array of rows, each with a content array
+        result.content.forEach((contentItem: any) => {
+          if (contentItem) {
+            contentItem[fieldName] = callback(contentItem)
+          }
+        })
+      } else {
+        result[fieldName] = callback(result)
+      }
+    })
+  } else if (results.entity && Array.isArray(results.entity)) {
+    // Group By
+    results.entity.forEach((result: any) => {
+      if (result.lessons) {
+        result.lessons.forEach((lesson: any) => {
+          lesson[fieldName] = callback(lesson) // Updated to check lesson access
+        })
+      } else {
+        result[fieldName] = callback(result)
+      }
+    })
+  } else if (results.related_lessons && Array.isArray(results.related_lessons)) {
+    results.related_lessons.forEach((result: any) => {
+      result[fieldName] = callback(result)
+    })
+  } else if (results.data && Array.isArray(results.data)) {
+    results.data.forEach((result: any) => {
+      result[fieldName] = callback(result)
+    })
+  } else {
+    results[fieldName] = callback(results)
+    if (results.children && Array.isArray(results.children)) {
+      results.children.forEach((result: any) => {
+        result[fieldName] = callback(result)
+      })
+    }
+  }
+
+  return results
+}
+
+function pageTypeDecorator(results: any) {
+  return contentResultsDecorator(results, 'page_type', function (content: any) {
+    return SONG_TYPES_WITH_CHILDREN.includes(content['type']) ? 'song' : 'lesson'
+  })
+}
+
+function needsAccessDecorator(results: any, userPermissions: any) {
+  if (globalConfig.sanityConfig.useDummyRailContentMethods) return results
+  const adapter = getPermissionsAdapter()
+  return contentResultsDecorator(results, 'need_access', function (content: any) {
+    return adapter.doesUserNeedAccess(content, userPermissions)
+  })
+}
+
+function checkSanityConfig(config: Config): boolean {
+  if (!config.sanityConfig.token) {
+    console.warn('fetchSanity: The "token" property is missing in the config object.');
+    return false;
+  }
+  if (!config.sanityConfig.projectId) {
+    console.warn('fetchSanity: The "projectId" property is missing in the config object.');
+    return false;
+  }
+  if (!config.sanityConfig.dataset) {
+    console.warn('fetchSanity: The "dataset" property is missing in the config object.');
+    return false;
+  }
+  if (!config.sanityConfig.version) {
+    console.warn('fetchSanity: The "version" property is missing in the config object.');
+    return false;
+  }
+  return true;
+}

--- a/src/lib/sanity/fetch.ts
+++ b/src/lib/sanity/fetch.ts
@@ -1,4 +1,4 @@
-import {  SONG_TYPES_WITH_CHILDREN } from '../../contentTypeConfig.js'
+import { SONG_TYPES_WITH_CHILDREN } from '../../contentTypeConfig.js'
 import { globalConfig } from '../../services/config.js'
 import { getPermissionsAdapter } from '../../services/permissions'
 

--- a/src/lib/sanity/filter.ts
+++ b/src/lib/sanity/filter.ts
@@ -100,6 +100,15 @@ export class Filters {
   }
 
   /**
+   * @param {string[]} types - Array of type values
+   * @returns {string} Filter expression
+   * @example Filters.typeIn(['song', 'workout']) // "_type in ['song','workout']"
+   */
+  static typeIn(types: string[]): string {
+    return `_type in ${arrayToStringRepresentation(types)}`
+  }
+
+  /**
    * @param {string} slug - The slug to filter by
    * @returns {string} Filter expression
    * @example Filters.slug('guitar-basics') // "slug.current == 'guitar-basics'"

--- a/src/lib/sanity/helper.ts
+++ b/src/lib/sanity/helper.ts
@@ -1,0 +1,230 @@
+import { Brands } from '../brands'
+import { coachLessonsTypes, showsTypes } from '../../contentTypeConfig.js'
+import { FilterBuilder } from '../../filterBuilder'
+
+interface FilterParams {
+  pullFutureContent?: boolean;
+}
+
+interface QueryOptions {
+  sortOrder?: string;
+  start?: number;
+  end?: number;
+  isSingle?: boolean;
+}
+
+interface EntityAndTotalQueryOptions extends QueryOptions {
+  withoutPagination?: boolean;
+}
+
+type FilterOption =
+  | 'difficulty'
+  | 'type'
+  | 'genre'
+  | 'essential'
+  | 'focus'
+  | 'theory'
+  | 'topic'
+  | 'lifestyle'
+  | 'creativity'
+  | 'instrumentless'
+  | 'gear'
+  | 'bpm';
+
+export function arrayJoinWithQuotes(array: string[], delimiter: string = ','): string {
+  const wrapped = array.map((value) => `'${value}'`);
+  return wrapped.join(delimiter);
+}
+
+export function getSanityDate(date: Date, roundToHourForCaching: boolean = true): string {
+  if (roundToHourForCaching) {
+    // We need to set the published on filter date to be a round time so that it doesn't bypass the query cache
+    // with every request by changing the filter date every second. I've set it to one minute past the current hour
+    // because publishing usually publishes content on the hour exactly which means it should still skip the cache
+    // when the new content is available.
+    // Round to the start of the current hour
+    const roundedDate = new Date(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours()
+    );
+
+    return roundedDate.toISOString();
+  }
+
+  return date.toISOString();
+}
+
+export function getDateOnly(date: Date = new Date()): string {
+  return date.toISOString().split('T')[0];
+}
+
+export const merge = <T>(
+  a: T[],
+  b: T[],
+  predicate: (a: T, b: T) => boolean = (a, b) => a === b
+): T[] => {
+  const c = [...a]; // copy to avoid side effects
+  // add all items from B to copy C if they're not already present
+  b.forEach((bItem) => (c.some((cItem) => predicate(bItem, cItem)) ? null : c.push(bItem)));
+  return c;
+};
+
+export function buildRawQuery(
+  filter: string = '',
+  fields: string = '...',
+  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false }: QueryOptions = {}
+): string {
+  const sortString = sortOrder ? `order(${sortOrder})` : '';
+  const countString = isSingle ? '[0...1]' : `[${start}...${end}]`;
+  const query = `*[${filter}]{
+        ${fields}
+    } | ${sortString}${countString}`;
+  return query;
+}
+
+export async function buildQuery(
+  baseFilter: string = '',
+  filterParams: FilterParams = { pullFutureContent: false },
+  fields: string = '...',
+  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false }: QueryOptions = {}
+): Promise<string> {
+  const filter = await new FilterBuilder(baseFilter, filterParams).buildFilter();
+  return buildRawQuery(filter, fields, { sortOrder, start, end, isSingle });
+}
+
+export function buildEntityAndTotalQuery(
+  filter: string = '',
+  fields: string = '...',
+  {
+    sortOrder = 'published_on desc',
+    start = 0,
+    end = 10,
+    isSingle = false,
+    withoutPagination = false,
+  }: EntityAndTotalQueryOptions = {}
+): string {
+  const sortString = sortOrder ? ` | order(${sortOrder})` : '';
+  const countString = isSingle ? '[0...1]' : withoutPagination ? `` : `[${start}...${end}]`;
+  const query = `{
+      "entity": *[${filter}]  ${sortString}${countString}
+      {
+        ${fields}
+      },
+      "total": 0
+    }`;
+  return query;
+}
+
+export function getFilterOptions(
+  option: FilterOption|string,
+  commonFilter: string,
+  contentType: string,
+  brand: string
+): string {
+  let filterGroq = '';
+  const types = Array.from(new Set([...coachLessonsTypes, ...showsTypes[brand]]));
+
+  switch (option) {
+    case 'difficulty':
+      filterGroq = `
+                "difficulty": [
+        {"type": "All", "count": count(*[${commonFilter} && difficulty_string == "All"])},
+        {"type": "Introductory", "count": count(*[${commonFilter} && (difficulty_string == "Novice" || difficulty_string == "Introductory")])},
+        {"type": "Beginner", "count": count(*[${commonFilter} && difficulty_string == "Beginner"])},
+        {"type": "Intermediate", "count": count(*[${commonFilter} && difficulty_string == "Intermediate" ])},
+        {"type": "Advanced", "count": count(*[${commonFilter} && difficulty_string == "Advanced" ])},
+        {"type": "Expert", "count": count(*[${commonFilter} && difficulty_string == "Expert" ])}
+        ][count > 0],`;
+      break;
+    case 'type':
+      const typesString = types
+        .map((t) => {
+          return `{"type": "${t}"}`;
+        })
+        .join(', ');
+      filterGroq = `"type": [${typesString}]{type, 'count': count(*[_type == ^.type && ${commonFilter}])}[count > 0],`;
+      break;
+    case 'genre':
+    case 'essential':
+    case 'focus':
+    case 'theory':
+    case 'topic':
+    case 'lifestyle':
+    case 'creativity':
+      filterGroq = `
+            "${option}": *[_type == '${option}' ${contentType ? ` && '${contentType}' in filter_types` : ''} ] {
+            "type": name,
+                "count": count(*[${commonFilter} && references(^._id)])
+        }[count > 0],`;
+      break;
+    case 'instrumentless':
+      filterGroq = `
+            "${option}":  [
+                  {"type": "Full Song Only", "count": count(*[${commonFilter} && instrumentless == false ])},
+                  {"type": "Instrument Removed", "count": count(*[${commonFilter} && instrumentless == true ])}
+              ][count > 0],`;
+      break;
+    case 'gear':
+      filterGroq = `
+            "${option}":  [
+                  {"type": "Practice Pad", "count": count(*[${commonFilter} && gear match 'Practice Pad' ])},
+                  {"type": "Drum-Set", "count": count(*[${commonFilter} && gear match 'Drum-Set'])}
+              ][count > 0],`;
+      break;
+    case 'bpm':
+      filterGroq = `
+            "${option}":  [
+                  {"type": "50-90", "count": count(*[${commonFilter} && bpm > 50 && bpm < 91])},
+                  {"type": "91-120", "count": count(*[${commonFilter} && bpm > 90 && bpm < 121])},
+                  {"type": "121-150", "count": count(*[${commonFilter} && bpm > 120 && bpm < 151])},
+                  {"type": "151-180", "count": count(*[${commonFilter} && bpm > 150 && bpm < 181])},
+                  {"type": "180+", "count": count(*[${commonFilter} && bpm > 180])},
+              ][count > 0],`;
+      break;
+    default:
+      filterGroq = '';
+      break;
+  }
+
+  return filterGroq;
+}
+
+export function getSortOrder(
+  sort: string = '-published_on',
+  brand: Brands,
+  groupBy?: string
+): string {
+  const sanitizedSort = sort?.trim() || '-published_on';
+  let isDesc = sanitizedSort.startsWith('-');
+  const sortField = isDesc ? sanitizedSort.substring(1) : sanitizedSort;
+
+  let sortOrder = '';
+
+  switch (sortField) {
+    case 'slug':
+      sortOrder = groupBy ? 'name' : '!defined(title), lower(title)';
+      break;
+
+    case 'popularity':
+      if (groupBy === 'artist' || groupBy === 'genre') {
+        sortOrder = isDesc ? `coalesce(popularity.${brand}, -1)` : 'popularity';
+      } else {
+        sortOrder = isDesc ? 'coalesce(popularity, -1)' : 'popularity';
+      }
+      break;
+
+    case 'recommended':
+      sortOrder = 'published_on';
+      isDesc = true;
+      break;
+
+    default:
+      sortOrder = sortField;
+      break;
+  }
+
+  sortOrder += isDesc ? ' desc' : ' asc';
+  return sortOrder;
+}

--- a/src/lib/sanity/helper.ts
+++ b/src/lib/sanity/helper.ts
@@ -193,7 +193,7 @@ export function getFilterOptions(
 
 export function getSortOrder(
   sort: string = '-published_on',
-  brand: Brands,
+  brand: Brands|string,
   groupBy?: string
 ): string {
   const sanitizedSort = sort?.trim() || '-published_on';

--- a/src/lib/sanity/query.ts
+++ b/src/lib/sanity/query.ts
@@ -1,6 +1,7 @@
 import { Monoid } from '../ads/monoid'
 
 export interface BuildQueryOptions {
+  page?: number
   sort?: string
   offset?: number
   limit?: number

--- a/src/services/awards/internal/award-definitions.js
+++ b/src/services/awards/internal/award-definitions.js
@@ -101,7 +101,7 @@ class AwardDefinitionsService {
     this.isFetching = true
 
     try {
-      const { fetchSanity } = await import('../../sanity')
+      const { fetchSanity } = await import('../../../lib/sanity/fetch')
       const { FilterBuilder } = await import('../../../filterBuilder')
 
       const childFilter = await new FilterBuilder('@->exclude_from_awards_calculation != true', {

--- a/src/services/content.js
+++ b/src/services/content.js
@@ -7,16 +7,21 @@ import {
   fetchMetadata,
   fetchRecent,
   fetchTabData,
+  fetchContentRows,
+  fetchOwnedContent,
+  fetchCourseCollectionData,
+  fetchReturning,
+  fetchLeaving,
+} from './sanity.js'
+import {
   fetchNewReleases,
   fetchUpcomingEvents,
   fetchScheduledReleases,
-  fetchReturning,
-  fetchLeaving, fetchScheduledAndNewReleases, fetchContentRows, fetchOwnedContent, fetchCourseCollectionData
-} from './sanity.js'
+  fetchNewUpcomingAndLive,
+} from './content/scheduled'
 import {TabResponseType, Tabs, capitalizeFirstLetter} from '../contentMetaData.js'
 import {recommendations, rankCategories, rankItems} from "./recommendations";
 import {addContextToContent} from "./contentAggregator.js";
-import {globalConfig} from "./config";
 import {getUserData} from "./user/management";
 import {
   lessonTypesMapping,
@@ -345,7 +350,7 @@ export async function getNewAndUpcoming(brand, {
   limit = 10,
 } = {}) {
 
-  const data = await fetchScheduledAndNewReleases(brand, {page: page, limit: limit});
+  const data = await fetchNewUpcomingAndLive(brand, {page: page, limit: limit});
   if (!data) {
     return null;
   }

--- a/src/services/content/artist.ts
+++ b/src/services/content/artist.ts
@@ -5,7 +5,8 @@ import { getFieldsForContentTypeWithFilteredChildren } from '../../contentTypeCo
 import { Brands } from '../../lib/brands'
 import { Filters as f } from '../../lib/sanity/filter'
 import { BuildQueryOptions, query } from '../../lib/sanity/query'
-import { fetchSanity, getSortOrder } from '../sanity.js'
+import { getSortOrder } from '../../lib/sanity/helper'
+import { fetchSanity } from '../../lib/sanity/fetch'
 import { Lesson } from './content'
 
 export interface Artist {
@@ -24,6 +25,7 @@ export interface Artists {
  * Fetch all artists with lessons available for a specific brand.
  *
  * @param {Brands|string} brand - The brand for which to fetch artists.
+ * @param {Object} options - Options for sorting, pagination, and filtering.
  * @returns {Promise<Artist[]|null>} - A promise that resolves to an array of artist objects or null if not found.
  *
  * @example
@@ -32,7 +34,7 @@ export interface Artists {
  *   .catch(error => console.error(error));
  */
 export async function fetchArtists(
-  brand: Brands | string,
+  brand: Brands,
   options: BuildQueryOptions
 ): Promise<Artists> {
   const type = f.type('artist')
@@ -109,10 +111,10 @@ export interface ArtistLessons {
  * @param {Object} params - Parameters for sorting, searching, pagination and filtering.
  * @param {string} [params.sort="-published_on"] - The field to sort the lessons by.
  * @param {string} [params.searchTerm=""] - The search term to filter the lessons.
- * @param {number} [params.page=1] - The page number for pagination.
+ * @param {number} [params.offset=1] - The offset number for pagination.
  * @param {number} [params.limit=10] - The number of items per page.
  * @param {Array<string>} [params.includedFields=[]] - Additional filters to apply to the query in the format of a key,value array. eg. ['difficulty,Intermediate', 'genre,rock'].
- * @param {Array<number>} [params.progressId=[]] - The ids of the lessons that are in progress or completed
+ * @param {Array<number>} [params.progressIds=[]] - The ids of the lessons that are in progress or completed
  * @returns {Promise<ArtistLessons>} - The lessons for the artist
  *
  * @example
@@ -122,7 +124,7 @@ export interface ArtistLessons {
  */
 export async function fetchArtistLessons(
   slug: string,
-  brand: Brands | string,
+  brand: Brands,
   contentType?: string,
   {
     sort = '-published_on',

--- a/src/services/content/artist.ts
+++ b/src/services/content/artist.ts
@@ -34,7 +34,7 @@ export interface Artists {
  *   .catch(error => console.error(error));
  */
 export async function fetchArtists(
-  brand: Brands,
+  brand: Brands|string,
   options: BuildQueryOptions
 ): Promise<Artists> {
   const type = f.type('artist')
@@ -124,7 +124,7 @@ export interface ArtistLessons {
  */
 export async function fetchArtistLessons(
   slug: string,
-  brand: Brands,
+  brand: Brands|string,
   contentType?: string,
   {
     sort = '-published_on',

--- a/src/services/content/genre.ts
+++ b/src/services/content/genre.ts
@@ -33,7 +33,7 @@ export interface Genres {
  *   .catch(error => console.error(error));
  */
 export async function fetchGenres(
-  brand: Brands,
+  brand: Brands|string,
   options: BuildQueryOptions
 ): Promise<Genres> {
   const type = f.type('genre')
@@ -122,7 +122,7 @@ export interface GenreLessons {
  */
 export async function fetchGenreLessons(
   slug: string,
-  brand: Brands,
+  brand: Brands|string,
   contentType?: string,
   {
     sort = '-published_on',

--- a/src/services/content/genre.ts
+++ b/src/services/content/genre.ts
@@ -5,7 +5,8 @@ import { getFieldsForContentTypeWithFilteredChildren } from '../../contentTypeCo
 import { Brands } from '../../lib/brands'
 import { Filters as f } from '../../lib/sanity/filter'
 import { BuildQueryOptions, query } from '../../lib/sanity/query'
-import { fetchSanity, getSortOrder } from '../sanity.js'
+import { getSortOrder } from '../../lib/sanity/helper'
+import { fetchSanity } from '../../lib/sanity/fetch'
 import { Lesson } from './content'
 
 export interface Genre {
@@ -32,7 +33,7 @@ export interface Genres {
  *   .catch(error => console.error(error));
  */
 export async function fetchGenres(
-  brand: Brands | string,
+  brand: Brands,
   options: BuildQueryOptions
 ): Promise<Genres> {
   const type = f.type('genre')
@@ -121,7 +122,7 @@ export interface GenreLessons {
  */
 export async function fetchGenreLessons(
   slug: string,
-  brand: Brands | string,
+  brand: Brands,
   contentType?: string,
   {
     sort = '-published_on',

--- a/src/services/content/instructor.ts
+++ b/src/services/content/instructor.ts
@@ -5,7 +5,8 @@ import { getFieldsForContentTypeWithFilteredChildren } from '../../contentTypeCo
 import { Brands } from '../../lib/brands'
 import { Filters as f } from '../../lib/sanity/filter'
 import { BuildQueryOptions, query } from '../../lib/sanity/query'
-import { fetchSanity, getSortOrder } from '../sanity.js'
+import { getSortOrder } from '../../lib/sanity/helper'
+import { fetchSanity } from '../../lib/sanity/fetch'
 import { Lesson } from './content'
 
 export interface Instructor {
@@ -25,6 +26,7 @@ export interface Instructors {
  * Fetch all instructor with lessons available for a specific brand.
  *
  * @param {Brands|string} brand - The brand for which to fetch instructors.
+ * @param {BuildQueryOptions} options - Parameters for pagination and sorting.
  * @returns {Promise<Instructors>} - A promise that resolves to an array of instructor objects.
  *
  * @example
@@ -33,7 +35,7 @@ export interface Instructors {
  *   .catch(error => console.error(error));
  */
 export async function fetchInstructors(
-  brand: Brands | string,
+  brand: Brands,
   options: BuildQueryOptions
 ): Promise<Instructors> {
   const type = f.type('instructor')
@@ -107,12 +109,12 @@ export interface InstructorLessons {
  * Fetch the data needed for the instructor screen.
  * @param {string} slug - The slug of the instructor
  * @param {Brands|string} brand - The brand for which to fetch instructor lessons
- * @param {string|null} [contentType] - The content type to filter lessons by (e.g., 'lesson', 'course').
- * @param {FetchInstructorLessonsOptions} options - Parameters for pagination, filtering and sorting.
- * @param {string} [options.sortOrder="-published_on"] - The field to sort the lessons by.
+ * @param {InstructorLessonsOptions} options - Parameters for pagination, filtering and sorting.
+ * @param {string} [options.sort="-published_on"] - The field to sort the lessons by.
  * @param {string} [options.searchTerm=""] - The search term to filter content by title.
- * @param {number} [options.page=1] - The page number for pagination.
+ * @param {number} [options.offset=1] - The offset for pagination.
  * @param {number} [options.limit=10] - The number of items per page.
+ * @param {string} [options.contentType=null] - The content type to filter lessons by (e.g., 'lesson', 'course').
  * @param {Array<string>} [options.includedFields=[]] - Additional filters to apply to the query in the format of a key,value array. eg. ['difficulty,Intermediate', 'genre,rock'].
  *
  * @returns {Promise<InstructorLessons>} - The lessons for the instructor or null if not found.
@@ -123,7 +125,7 @@ export interface InstructorLessons {
  */
 export async function fetchInstructorLessons(
   slug: string,
-  brand: Brands | string,
+  brand: Brands,
   {
     sort = '-published_on',
     searchTerm = '',

--- a/src/services/content/instructor.ts
+++ b/src/services/content/instructor.ts
@@ -35,7 +35,7 @@ export interface Instructors {
  *   .catch(error => console.error(error));
  */
 export async function fetchInstructors(
-  brand: Brands,
+  brand: Brands|string,
   options: BuildQueryOptions
 ): Promise<Instructors> {
   const type = f.type('instructor')
@@ -125,7 +125,7 @@ export interface InstructorLessons {
  */
 export async function fetchInstructorLessons(
   slug: string,
-  brand: Brands,
+  brand: Brands|string,
   {
     sort = '-published_on',
     searchTerm = '',

--- a/src/services/content/scheduled.ts
+++ b/src/services/content/scheduled.ts
@@ -76,7 +76,7 @@ function getNewAndScheduledContentFilter(brand: string, now: string, status: "ne
       ]
       break
     case "scheduled":
-      types = upcomingTypes
+      types = merge(upcomingTypes, newTypes)
       statuses = ['published', 'scheduled']
       clauses = [
         f.publishedAfter(now),
@@ -162,7 +162,7 @@ export async function fetchNewReleases(
   {
     page = 1,
     limit = 20,
-    sort = 'published_on'
+    sort = '-published_on'
   }: BuildQueryOptions = {}
 ): Promise<NewRelease[]> {
   const start = (page - 1) * limit

--- a/src/services/content/scheduled.ts
+++ b/src/services/content/scheduled.ts
@@ -119,7 +119,7 @@ function getLiveEventFilter(brand: string, now: string) {
 }
 
 export async function fetchNewUpcomingAndLive(
-  brand: Brands,
+  brand: Brands|string,
   {
     page = 1,
     limit = 20,
@@ -155,7 +155,7 @@ export async function fetchNewUpcomingAndLive(
 }
 
 export async function fetchNewReleases(
-  brand: Brands,
+  brand: Brands|string,
   {
     page = 1,
     limit = 20,
@@ -180,7 +180,7 @@ export async function fetchNewReleases(
 }
 
 export async function fetchScheduledReleases(
-  brand: Brands,
+  brand: Brands|string,
   {
     page = 1,
     limit = 10
@@ -204,7 +204,7 @@ export async function fetchScheduledReleases(
 }
 
 export async function fetchUpcomingEvents(
-  brand: Brands,
+  brand: Brands|string,
   {
     page = 1,
     limit = 10

--- a/src/services/content/scheduled.ts
+++ b/src/services/content/scheduled.ts
@@ -81,7 +81,7 @@ function getNewAndScheduledContentFilter(brand: string, now: string, status: "ne
         f.publishedAfter(now),
         f.combineOr(
           f.notDefined('live_event_end_time'),
-          `live_event_end_time < ${now}`,
+          `live_event_end_time < "${now}"`,
         )
       ]
       break
@@ -105,7 +105,7 @@ function getLiveEventFilter(brand: string, now: string) {
     f.defined('live_event_start_time'),
     f.combineOr(
       f.notDefined('live_event_end_time'),
-      `live_event_end_time >= ${now}`,
+      `live_event_end_time >= "${now}"`,
     ),
     f.combineOr(
       f.brand(brand),

--- a/src/services/content/scheduled.ts
+++ b/src/services/content/scheduled.ts
@@ -1,0 +1,236 @@
+/**
+ * @module Scheduled
+ */
+import {
+  artistOrInstructorName,
+  getNewReleasesTypes,
+  getUpcomingEventsTypes, instructorField,
+} from '../../contentTypeConfig.js'
+import { Brands } from '../../lib/brands'
+import { Filters as f } from '../../lib/sanity/filter'
+import { BuildQueryOptions, query } from '../../lib/sanity/query'
+import { fetchSanity } from '../../lib/sanity/fetch'
+import {
+  getDateOnly,
+  getSanityDate,
+  getSortOrder,
+  merge,
+} from '../../lib/sanity/helper'
+import { Instructor } from './instructor'
+
+export interface NewRelease {
+  id: number,
+  title: string,
+  image: string,
+  thumbnail: string,
+  artist_name: string,
+  instructor: Instructor[],
+  artists: string[],
+  difficulty: number,
+  difficulty_string: string,
+  length_in_seconds: number,
+  published_on: string,
+  show_in_new_feed: boolean,
+  type: string,
+  permission_id: number[],
+}
+
+export interface NewAndUpcomingRelease extends NewRelease {
+  isLive: boolean,
+  live_event_start_time: string,
+  live_event_end_time: string,
+}
+
+const baseFields = [
+  `"id": railcontent_id`,
+  `title`,
+  `"type": _type`,
+  `"image": thumbnail.asset->url`,
+  `"thumbnail": thumbnail.asset->url`,
+  `${artistOrInstructorName()}`,
+  `"instructor": ${instructorField}`,
+  `"artists": instructor[]->name`,
+  `difficulty`,
+  `difficulty_string`,
+  `length_in_seconds`,
+  `published_on`,
+  `"permission_id": permission_v2`,
+  `show_in_new_feed`,
+]
+
+function getNewAndScheduledContentFilter(brand: string, now: string, status: "new"|"scheduled"|"all") {
+  const upcomingTypes = getUpcomingEventsTypes(brand)
+  const newTypes = getNewReleasesTypes(brand)
+
+  let clauses: string[] = []
+  let types: string[]
+  let statuses: string[]
+
+  switch (status) {
+    case "new":
+      types = newTypes
+      statuses = ['published']
+      clauses = [
+        f.publishedBefore(now),
+      ]
+      break
+    case "scheduled":
+      types = upcomingTypes
+      statuses = ['published', 'scheduled']
+      clauses = [
+        f.publishedAfter(now),
+        f.combineOr(
+          f.notDefined('live_event_end_time'),
+          `live_event_end_time < ${now}`,
+        )
+      ]
+      break
+    case "all":
+    default:
+      types = merge(upcomingTypes, newTypes)
+      statuses = ['published', 'scheduled']
+  }
+
+  return f.combine(
+    f.typeIn(types),
+    f.brand(brand),
+    f.statusIn(statuses),
+    "show_in_new_feed == true",
+    ...clauses
+  )
+}
+
+function getLiveEventFilter(brand: string, now: string) {
+  return f.combine(
+    f.defined('live_event_start_time'),
+    f.combineOr(
+      f.notDefined('live_event_end_time'),
+      `live_event_end_time >= ${now}`,
+    ),
+    f.combineOr(
+      f.brand(brand),
+      f.combine(
+        f.brand('musora'),
+        "live_global_event == true",
+      )
+    ),
+    f.statusIn(['scheduled'])
+  )
+}
+
+export async function fetchNewUpcomingAndLive(
+  brand: Brands,
+  {
+    page = 1,
+    limit = 20,
+    sort = 'published_on'
+  }: BuildQueryOptions = {}
+): Promise<NewAndUpcomingRelease[]> {
+  const now = getSanityDate(new Date())
+
+  const start = (page - 1) * limit
+  const end = start + limit
+  const sortOrder = getSortOrder(sort, brand)
+
+  // can be used for fetchScheduledReleases()
+  const newAndUpcomingFilter = getNewAndScheduledContentFilter(brand, now, "all")
+
+  // can be reused for fetchUpcomingEvents()
+  const liveEventFilter = getLiveEventFilter(brand, now)
+
+  const fields = [
+    ...baseFields,
+    `"isLive": live_event_start_time <= '${now}' && (!defined(live_event_end_time) || live_event_end_time >= '${now}')`,
+  ]
+
+  const q = query()
+    .and(newAndUpcomingFilter)
+    .or(liveEventFilter)
+    .slice(start, end)
+    .order(sortOrder)
+    .select(...fields)
+    .build()
+
+  return fetchSanity(q, true)
+}
+
+export async function fetchNewReleases(
+  brand: Brands,
+  {
+    page = 1,
+    limit = 20,
+    sort = 'published_on'
+  }: BuildQueryOptions = {}
+): Promise<NewRelease[]> {
+  const start = (page - 1) * limit
+  const end = start + limit
+  const sortOrder = getSortOrder(sort, brand)
+  const now = getDateOnly()
+
+  const filter = getNewAndScheduledContentFilter(brand, now, "new")
+
+  const q = query()
+    .and(filter)
+    .slice(start, end)
+    .order(sortOrder)
+    .select(...baseFields)
+    .build()
+
+  return fetchSanity(q, true)
+}
+
+export async function fetchScheduledReleases(
+  brand: Brands,
+  {
+    page = 1,
+    limit = 10
+  }: BuildQueryOptions = {}
+): Promise<NewRelease[]> {
+  const now = getSanityDate(new Date())
+  const start = (page - 1) * limit
+  const end = start + limit
+  const sortOrder = getSortOrder("published_on", brand)
+
+  const filter = getNewAndScheduledContentFilter(brand, now, "scheduled")
+
+  const q = query()
+    .and(filter)
+    .slice(start, end)
+    .order(sortOrder)
+    .select(...baseFields)
+    .build()
+
+  return fetchSanity(q, true)
+}
+
+export async function fetchUpcomingEvents(
+  brand: Brands,
+  {
+    page = 1,
+    limit = 10
+  }: BuildQueryOptions = {}
+): Promise<NewAndUpcomingRelease[]> {
+  const now = getSanityDate(new Date())
+
+  const start = (page - 1) * limit
+  const end = start + limit
+  const sortOrder = getSortOrder("published_on", brand)
+
+  const filter = getLiveEventFilter(brand, now)
+
+  const fields = [
+    ...baseFields,
+    `live_event_start_time`,
+    `live_event_end_time`,
+    `"isLive": live_event_start_time <= '${now}' && live_event_end_time >= '${now}'`,
+  ]
+
+  const q = query()
+    .and(filter)
+    .slice(start, end)
+    .order(sortOrder)
+    .select(...fields)
+    .build()
+
+  return fetchSanity(q, true)
+}

--- a/src/services/content/scheduled.ts
+++ b/src/services/content/scheduled.ts
@@ -72,6 +72,7 @@ function getNewAndScheduledContentFilter(brand: string, now: string, status: "ne
       statuses = ['published']
       clauses = [
         f.publishedBefore(now),
+        "show_in_new_feed == true",
       ]
       break
     case "scheduled":
@@ -89,13 +90,15 @@ function getNewAndScheduledContentFilter(brand: string, now: string, status: "ne
     default:
       types = merge(upcomingTypes, newTypes)
       statuses = ['published', 'scheduled']
+      clauses = [
+        "show_in_new_feed == true",
+      ]
   }
 
   return f.combine(
     f.typeIn(types),
     f.brand(brand),
     f.statusIn(statuses),
-    "show_in_new_feed == true",
     ...clauses
   )
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -2,10 +2,8 @@
  * @module Sanity-Services
  */
 import {
-  artistOrInstructorName,
   assignmentsField,
   chapterField,
-  coachLessonsTypes,
   contentTypeConfig,
   DEFAULT_FIELDS,
   descriptionField,
@@ -14,8 +12,6 @@ import {
   getFieldsForContentType,
   getFieldsForContentTypeWithFilteredChildren,
   getIntroVideoFields,
-  getNewReleasesTypes,
-  getUpcomingEventsTypes,
   instructorField,
   lessonTypesMapping,
   individualLessonsTypes,
@@ -30,21 +26,29 @@ import {
   resourcesField,
   showsTypes,
   SONG_TYPES,
-  SONG_TYPES_WITH_CHILDREN,
   liveFields,
   addAwardTemplateToContent,
-  contentAwardField,
+  contentAwardField, getUpcomingEventsTypes, getNewReleasesTypes, artistOrInstructorName,
 } from '../contentTypeConfig.js'
 import { fetchSimilarItems } from './recommendations.js'
 import { getSongType, processMetadata, ALWAYS_VISIBLE_TABS, CONTENT_STATUSES } from '../contentMetaData.js'
 import { GET } from '../infrastructure/http/HttpClient.ts'
 
-import { globalConfig } from './config.js'
-
 import { arrayToStringRepresentation, FilterBuilder } from '../filterBuilder.js'
 import { getPermissionsAdapter } from './permissions/index.ts'
 import { getAllCompleted, getAllStarted, getAllStartedOrCompleted } from './contentProgress.js'
 import { fetchRecentActivitiesActiveTabs } from './userActivity.js'
+import {
+  arrayJoinWithQuotes,
+  getSanityDate,
+  getDateOnly,
+  buildRawQuery,
+  buildQuery,
+  buildEntityAndTotalQuery,
+  getFilterOptions,
+  getSortOrder, merge,
+} from '../lib/sanity/helper'
+import { fetchSanity } from '../lib/sanity/fetch'
 
 /**
  * Exported functions that are excluded from index generation.
@@ -767,40 +771,6 @@ async function getProgressFilter(progress, progressIds) {
   }
 }
 
-export function getSortOrder(sort = '-published_on', brand, groupBy) {
-  const sanitizedSort = sort?.trim() || '-published_on'
-  let isDesc = sanitizedSort.startsWith('-')
-  const sortField = isDesc ? sanitizedSort.substring(1) : sanitizedSort
-
-  let sortOrder = ''
-
-  switch (sortField) {
-    case 'slug':
-      sortOrder = groupBy ? 'name' : '!defined(title), lower(title)'
-      break
-
-    case 'popularity':
-      if (groupBy == 'artist' || groupBy == 'genre') {
-        sortOrder = isDesc ? `coalesce(popularity.${brand}, -1)` : 'popularity'
-      } else {
-        sortOrder = isDesc ? 'coalesce(popularity, -1)' : 'popularity'
-      }
-      break
-
-    case 'recommended':
-      sortOrder = 'published_on'
-      isDesc = true
-      break
-
-    default:
-      sortOrder = sortField
-      break
-  }
-
-  sortOrder += isDesc ? ' desc' : ' asc'
-  return sortOrder
-}
-
 /**
  * Fetches all available filter options based on brand, filters, and various optional criteria.
  *
@@ -1417,155 +1387,6 @@ export async function fetchCommentModContentData(ids) {
 }
 
 /**
- *
- * @param {string} query - The GROQ query to execute against the Sanity API.
- * @param {boolean} isList - Whether to return an array or a single result.
- * @param {Object} options - Additional options for fetching data.
- * @param {Function} [options.customPostProcess=null] - custom post process callback
- * @param {boolean} [options.processNeedAccess=true] - execute the needs_access callback
- * @param {boolean} [options.processPageType=true] - execute the page_type callback
- * @returns {Promise<*|null>} - A promise that resolves to the fetched data or null if an error occurs or no results are found.
- *
- * @example
- * const query = `*[_type == "song"]{title, artist->name}`;
- * fetchSanity(query, true)
- *   .then(data => console.log(data))
- *   .catch(error => console.error(error));
- */
-
-export async function fetchSanity(
-  query,
-  isList,
-  { customPostProcess = null, processNeedAccess = true, processPageType = true } = {}
-) {
-  // Check the config object before proceeding
-  if (!checkSanityConfig(globalConfig)) {
-    return null
-  }
-  const perspective = globalConfig.sanityConfig.perspective ?? 'published'
-  const api = globalConfig.sanityConfig.useCachedAPI ? 'apicdn' : 'api'
-  const baseUrl = `https://${globalConfig.sanityConfig.projectId}.${api}.sanity.io/v${globalConfig.sanityConfig.version}/data/query/${globalConfig.sanityConfig.dataset}?perspective=${perspective}`
-  const headers = {
-    'Content-Type': 'application/json',
-  }
-  try {
-    const encodedQuery = encodeURIComponent(query)
-    const fullGetUrl = `${baseUrl}&query=${encodedQuery}`
-    const useGet = fullGetUrl.length < 8000
-
-    let url, method, options
-    if (useGet) {
-      url = fullGetUrl
-      method = 'GET'
-      options = {
-        method,
-        headers,
-      }
-    } else {
-      url = baseUrl
-      method = 'POST'
-      options = {
-        method,
-        headers,
-        body: JSON.stringify({ query }),
-      }
-    }
-    const adapter = getPermissionsAdapter()
-    let promisesResult = await Promise.all([
-      fetch(url, options),
-      processNeedAccess ? adapter.fetchUserPermissions() : null,
-    ])
-    const response = promisesResult[0]
-    const userPermissions = promisesResult[1]
-    if (!response.ok) {
-      throw new Error(`Sanity API error: ${response.status} - ${response.statusText}`)
-    }
-    const result = await response.json()
-    if (result.result) {
-      let results = isList ? result.result : result.result[0]
-      if (!results) {
-        throw new Error('No results found')
-      }
-      results = processNeedAccess ? await needsAccessDecorator(results, userPermissions) : results
-      results = processPageType ? pageTypeDecorator(results) : results
-      return customPostProcess ? customPostProcess(results) : results
-    } else {
-      throw new Error('No results found')
-    }
-  } catch (error) {
-    console.error('fetchSanity: Fetch error:', { error, query })
-    return null
-  }
-}
-
-function contentResultsDecorator(results, fieldName, callback) {
-  if (Array.isArray(results)) {
-    results.forEach((result) => {
-      // Check if this is a content row structure
-      if (result.content && Array.isArray(result.content)) {
-        // Content rows structure: array of rows, each with a content array
-        result.content.forEach((contentItem) => {
-          if (contentItem) {
-            contentItem[fieldName] = callback(contentItem)
-          }
-        })
-      } else {
-        result[fieldName] = callback(result)
-      }
-    })
-  } else if (results.entity && Array.isArray(results.entity)) {
-    // Group By
-    results.entity.forEach((result) => {
-      if (result.lessons) {
-        result.lessons.forEach((lesson) => {
-          lesson[fieldName] = callback(lesson) // Updated to check lesson access
-        })
-      } else {
-        result[fieldName] = callback(result)
-      }
-    })
-  } else if (results.related_lessons && Array.isArray(results.related_lessons)) {
-    results.related_lessons.forEach((result) => {
-      result[fieldName] = callback(result)
-    })
-  } else if (results.data && Array.isArray(results.data)) {
-    results.data.forEach((result) => {
-      result[fieldName] = callback(result)
-    })
-  } else {
-    results[fieldName] = callback(results)
-    if (results.children && Array.isArray(results.children)) {
-      results.children.forEach((result) => {
-        result[fieldName] = callback(result)
-      })
-    }
-  }
-
-  return results
-}
-
-function pageTypeDecorator(results) {
-  return contentResultsDecorator(results, 'page_type', function (content) {
-    return SONG_TYPES_WITH_CHILDREN.includes(content['type']) ? 'song' : 'lesson'
-  })
-}
-
-function needsAccessDecorator(results, userPermissions) {
-  if (globalConfig.sanityConfig.useDummyRailContentMethods) return results
-  const adapter = getPermissionsAdapter()
-  return contentResultsDecorator(results, 'need_access', function (content) {
-    return adapter.doesUserNeedAccess(content, userPermissions)
-  })
-}
-
-function doesUserNeedAccessToContent(result, userPermissions) {
-  // Legacy function - now delegates to adapter
-  // Kept for backwards compatibility if used elsewhere
-  const adapter = getPermissionsAdapter()
-  return adapter.doesUserNeedAccess(result, userPermissions)
-}
-
-/**
  * Fetch shows data for a brand.
  *
  * @param brand - The brand for which to fetch shows.
@@ -1651,203 +1472,6 @@ export async function fetchChatAndLiveEnvent(brand, forcedId = null) {
   const chatData = await GET(url)
 
   return { ...chatData, ...liveEvent[0] }
-}
-
-//Helper Functions
-function arrayJoinWithQuotes(array, delimiter = ',') {
-  const wrapped = array.map((value) => `'${value}'`)
-  return wrapped.join(delimiter)
-}
-
-export function getSanityDate(date, roundToHourForCaching = true) {
-  if (roundToHourForCaching) {
-    // We need to set the published on filter date to be a round time so that it doesn't bypass the query cache
-    // with every request by changing the filter date every second. I've set it to one minute past the current hour
-    // because publishing usually publishes content on the hour exactly which means it should still skip the cache
-    // when the new content is available.
-    // Round to the start of the current hour
-    const roundedDate = new Date(
-      date.getFullYear(),
-      date.getMonth(),
-      date.getDate(),
-      date.getHours()
-    )
-
-    return roundedDate.toISOString()
-  }
-
-  return date.toISOString()
-}
-
-function getDateOnly(date = new Date()) {
-  return date.toISOString().split('T')[0]
-}
-
-const merge = (a, b, predicate = (a, b) => a === b) => {
-  const c = [...a] // copy to avoid side effects
-  // add all items from B to copy C if they're not already present
-  b.forEach((bItem) => (c.some((cItem) => predicate(bItem, cItem)) ? null : c.push(bItem)))
-  return c
-}
-
-function checkSanityConfig(config) {
-  if (!config.sanityConfig.token) {
-    console.warn('fetchSanity: The "token" property is missing in the config object.')
-    return false
-  }
-  if (!config.sanityConfig.projectId) {
-    console.warn('fetchSanity: The "projectId" property is missing in the config object.')
-    return false
-  }
-  if (!config.sanityConfig.dataset) {
-    console.warn('fetchSanity: The "dataset" property is missing in the config object.')
-    return false
-  }
-  if (!config.sanityConfig.version) {
-    console.warn('fetchSanity: The "version" property is missing in the config object.')
-    return false
-  }
-  return true
-}
-
-function buildRawQuery(
-  filter = '',
-  fields = '...',
-  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false }
-) {
-  const sortString = sortOrder ? `order(${sortOrder})` : ''
-  const countString = isSingle ? '[0...1]' : `[${start}...${end}]`
-  const query = `*[${filter}]{
-        ${fields}
-    } | ${sortString}${countString}`
-  return query
-}
-
-async function buildQuery(
-  baseFilter = '',
-  filterParams = { pullFutureContent: false },
-  fields = '...',
-  { sortOrder = 'published_on desc', start = 0, end = 10, isSingle = false }
-) {
-  const filter = await new FilterBuilder(baseFilter, filterParams).buildFilter()
-  return buildRawQuery(filter, fields, { sortOrder, start, end, isSingle })
-}
-
-export function buildEntityAndTotalQuery(
-  filter = '',
-  fields = '...',
-  {
-    sortOrder = 'published_on desc',
-    start = 0,
-    end = 10,
-    isSingle = false,
-    withoutPagination = false,
-  }
-) {
-  const sortString = sortOrder ? ` | order(${sortOrder})` : ''
-  const countString = isSingle ? '[0...1]' : withoutPagination ? `` : `[${start}...${end}]`
-  const query = `{
-      "entity": *[${filter}]  ${sortString}${countString}
-      {
-        ${fields}
-      },
-      "total": 0
-    }`
-  return query
-}
-
-function getFilterOptions(option, commonFilter, contentType, brand) {
-  let filterGroq = ''
-  const types = Array.from(new Set([...coachLessonsTypes, ...showsTypes[brand]]))
-
-  switch (option) {
-    case 'difficulty':
-      filterGroq = `
-                "difficulty": [
-        {"type": "All", "count": count(*[${commonFilter} && difficulty_string == "All"])},
-        {"type": "Introductory", "count": count(*[${commonFilter} && (difficulty_string == "Novice" || difficulty_string == "Introductory")])},
-        {"type": "Beginner", "count": count(*[${commonFilter} && difficulty_string == "Beginner"])},
-        {"type": "Intermediate", "count": count(*[${commonFilter} && difficulty_string == "Intermediate" ])},
-        {"type": "Advanced", "count": count(*[${commonFilter} && difficulty_string == "Advanced" ])},
-        {"type": "Expert", "count": count(*[${commonFilter} && difficulty_string == "Expert" ])}
-        ][count > 0],`
-      break
-    case 'type':
-      const typesString = types
-        .map((t) => {
-          return `{"type": "${t}"}`
-        })
-        .join(', ')
-      filterGroq = `"type": [${typesString}]{type, 'count': count(*[_type == ^.type && ${commonFilter}])}[count > 0],`
-      break
-    case 'genre':
-    case 'essential':
-    case 'focus':
-    case 'theory':
-    case 'topic':
-    case 'lifestyle':
-    case 'creativity':
-      filterGroq = `
-            "${option}": *[_type == '${option}' ${contentType ? ` && '${contentType}' in filter_types` : ''} ] {
-            "type": name,
-                "count": count(*[${commonFilter} && references(^._id)])
-        }[count > 0],`
-      break
-    case 'instrumentless':
-      filterGroq = `
-            "${option}":  [
-                  {"type": "Full Song Only", "count": count(*[${commonFilter} && instrumentless == false ])},
-                  {"type": "Instrument Removed", "count": count(*[${commonFilter} && instrumentless == true ])}
-              ][count > 0],`
-      break
-    case 'gear':
-      filterGroq = `
-            "${option}":  [
-                  {"type": "Practice Pad", "count": count(*[${commonFilter} && gear match 'Practice Pad' ])},
-                  {"type": "Drum-Set", "count": count(*[${commonFilter} && gear match 'Drum-Set'])}
-              ][count > 0],`
-      break
-    case 'bpm':
-      filterGroq = `
-            "${option}":  [
-                  {"type": "50-90", "count": count(*[${commonFilter} && bpm > 50 && bpm < 91])},
-                  {"type": "91-120", "count": count(*[${commonFilter} && bpm > 90 && bpm < 121])},
-                  {"type": "121-150", "count": count(*[${commonFilter} && bpm > 120 && bpm < 151])},
-                  {"type": "151-180", "count": count(*[${commonFilter} && bpm > 150 && bpm < 181])},
-                  {"type": "180+", "count": count(*[${commonFilter} && bpm > 180])},
-              ][count > 0],`
-      break
-    default:
-      filterGroq = ''
-      break
-  }
-
-  return filterGroq
-}
-
-function cleanUpGroq(query) {
-  // Split the query into clauses based on the logical operators
-  const clauses = query.split(/(\s*&&|\s*\|\|)/).map((clause) => clause.trim())
-
-  // Filter out empty clauses
-  const filteredClauses = clauses.filter((clause) => clause.length > 0)
-
-  // Check if there are valid conditions in the clauses
-  const hasConditions = filteredClauses.some((clause) => !clause.match(/^\s*&&\s*|\s*\|\|\s*$/))
-
-  if (!hasConditions) {
-    // If no valid conditions, return an empty string or the original query
-    return ''
-  }
-
-  // Remove occurrences of '&& ()'
-  const cleanedQuery = filteredClauses
-    .join(' ')
-    .replace(/&&\s*\(\)/g, '')
-    .replace(/(\s*&&|\s*\|\|)(?=\s*[\s()]*$|(?=\s*&&|\s*\|\|))/g, '')
-    .trim()
-
-  return cleanedQuery
 }
 
 // V2 methods
@@ -1975,7 +1599,7 @@ export async function fetchRecent(
   return results.entity
 }
 
-export async function fetchScheduledAndNewReleases(
+export async function fetchNewUpcomingAndLive(
   brand,
   { page = 1, limit = 20, sort = '-published_on' } = {}
 ) {

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1991,7 +1991,8 @@ export async function fetchScheduledAndNewReleases(
   const sortOrder = getSortOrder(sort, brand)
 
   const query = `
-    *[_type in [${typesString}] && brand == '${brand}' && ((status in ['published','scheduled'] )||(show_in_new_feed == true)) ]
+    *[(_type in [${typesString}] && brand == '${brand}' && ((status in ['published','scheduled'] )||(show_in_new_feed == true)))
+      || (defined(live_event_start_time) && (!defined(live_event_end_time) || live_event_end_time >= '${now}' ) && (brand == '${brand}' || brand == 'musora' && live_global_event) && status in ['scheduled'])]
     [${start}...${end}]
    | order(published_on asc) {
       "id": railcontent_id,


### PR DESCRIPTION
## ticket
- sanity.js is huge and needs to be broken up and refactored
  - like with the AGI functions :chef_kiss:
- found a common group of functions: scheduled
  - in charge of fetching newly released and scheduled-to-be-released content and events
  - functions used on homepage "New and Upcoming" content row, and the content rows on the scheduled page
- also found many helper functions in sanity.js, which are also perfect to go into their own file -> helper.ts
- also also decided that with the move to split up sanity.js, we should also separate out `fetchSanity` and corresponding functions, leaving sanity.js with only fetch functions, and is now just another fetch function file like the AGI files

## Design
- `scheduled.ts` follows the design of the Artist,Genre,Instructor (AGI) ts files, which used to also live in sanity.js
  - common fields moved to a const :ok_hand: 
  - common filters moved to a filter generator fn (could argue it's complexity isn't much better than hard-coded queries in each fetch fn)
- common sanity.js helper functions moved to `helper.ts` (sanity.js now imports those fn's from this file)
- moved `fetchSanity` and related internal fn's to `fetch.ts`, and updated all imports (minus tests, because those need their own refactor)

## Platform feature changes
- homepage "New and Upcoming" row now:
  - returns currently-airing live events
  - filters new and upcoming (not live) contents by `show_in_new_feed == true`

## Testing
- use staging dataset

quick:
- go to homepage -> New and Upcoming content row
- see "PlayBass Launch Q&A With Chris Wong" (only one that matches the new logic)
- go to https://devapp.musora.com:5174/drumeo/schedule
- take a screenshot of the contents
- revert mcs changes, and see that the cards are all the same

thorough: