### PR TITLE
fix(BEHSTP-177): Merge the V1 practice time to the V2 Total Practice Time

### DIFF
--- a/src/services/user/profile.js
+++ b/src/services/user/profile.js
@@ -28,7 +28,7 @@ export async function otherStats(userId = globalConfig.sessionConfig.userId) {
       type: 'week',
       length: longestStreaks.longestWeeklyStreak,
     },
-    total_practice_time: longestStreaks.totalPracticeSeconds,
+    total_practice_time: longestStreaks.totalPracticeSeconds + (stats.v1_practice_time ?? 0),
   }
 }
 


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [BEHSTP-177](https://musora.atlassian.net/browse/BEHSTP-177)

## Description/Design

- Merge the V1 practice time to the V2 Total Practice Time

## Testing

- **brand_seconds_practiced** from **usora_users** table is added to the V2 Total Practice Time

## Additional Notes

- _Provide any additional context or notes that might be helpful for the reviewer._


[BEHSTP-177]: https://musora.atlassian.net/browse/BEHSTP-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ