### PR TITLE
fix: bypass permissions in a-la-carte hierarchy query to improve CDN cache hit rate

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1400,7 +1400,7 @@ async function fetchLearningPathHierarchyData(railcontentId, collection) {
 
 async function fetchALaCarteHierarchyData(railcontentId) {
   let topLevelId = await fetchTopLevelParentId(railcontentId)
-  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true }).buildFilter()
+  const childrenFilter = await new FilterBuilder(``, { isChildrenFilter: true, bypassPermissions: true }).buildFilter()
   const query = `*[railcontent_id == ${topLevelId}]{
       railcontent_id,
       'metadata': { brand, 'type': _type, 'parent_id':  coalesce(parent_content_data[0].id, 0) },


### PR DESCRIPTION
## Summary

- Adds `bypassPermissions: true` to the `childrenFilter` `FilterBuilder` in `fetchALaCarteHierarchyData`
- Removes `array::intersects(@->permission_v2, [...userPermissionIds...])` from the 4-level nested children GROQ query
- All users with the same top-level content ID will now share a single CDN cache entry instead of one per unique permission set

## Background

Analysis of 6M Sanity API requests (Apr 2–9) showed the same content IDs appearing multiple times in the top-50 GROQ queries with different permission arrays — e.g. `railcontent_id 409875` appeared as two separate top-50 entries (ranks #15 and #19) and `railcontent_id 402201` appeared as ranks #17 and #21. Users who have purchased individual content items (permission IDs like `100XXXXXX`) were generating entirely unique query hashes, fragmenting the CDN cache.

## Why it's safe

`fetchALaCarteHierarchyData` builds a parent/child ID map for content hierarchy navigation. It already calls `fetchSanity` with `processNeedAccess: false`, so the GROQ permission filter was providing no access control — only cache fragmentation.

## Test plan

- [ ] Verify a-la-carte content hierarchy navigation still works correctly for users with and without purchases
- [ ] Confirm users without access to gated content cannot access the content itself (gating happens at the content display layer, not in this hierarchy query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)