### PR TITLE
fix(BR-632): dont trickle progress to children when enrolling in GC

### DIFF
--- a/src/services/content-org/guided-courses.ts
+++ b/src/services/content-org/guided-courses.ts
@@ -14,7 +14,7 @@ export async function enrollUserInGuidedCourse(guidedCourse, { notifications_ena
   const response = await POST(url, { notifications_enabled })
   const state = await getProgressState(guidedCourse)
   if (!state) {
-    await contentStatusStarted(guidedCourse)
+    await contentStatusStarted(guidedCourse, null, { skipBubbleTrickle: true })
   }
   return response
 }

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -490,12 +490,13 @@ export async function contentStatusCompletedMany(contentIds, collection = null) 
   )
 }
 
-export async function contentStatusStarted(contentId, collection = null) {
+export async function contentStatusStarted(contentId, collection = null, {skipPush = false, skipBubbleTrickle = false} = {}) {
   collection = collection ?? {id: COLLECTION_ID_SELF, type: COLLECTION_TYPE.SELF}
   return setStartedOrCompletedStatus(
     normalizeContentId(contentId),
     normalizeCollection(collection),
-    false
+    false,
+    {skipPush, skipBubbleTrickle}
   )
 }
 export async function contentStatusReset(contentId, collection = null, {skipPush = false} = {}) {
@@ -510,9 +511,9 @@ async function saveContentProgress(contentId, collection, progress, currentSecon
 
   // filter out contentIds that are setting progress lower than existing
   const contentIdProgress = await getProgressDataByIds([contentId], collection)
-  const currentProgress = contentIdProgress[contentId].progress;
+  const currentProgress = contentIdProgress[contentId].progress
   if (progress <= currentProgress) {
-    progress = currentProgress;
+    progress = currentProgress
   }
 
   const hierarchy = await getHierarchy(contentId, collection)
@@ -578,7 +579,7 @@ async function saveContentProgress(contentId, collection, progress, currentSecon
   return response
 }
 
-async function setStartedOrCompletedStatus(contentId, collection, isCompleted, {skipPush = false} = {}) {
+async function setStartedOrCompletedStatus(contentId, collection, isCompleted, {skipPush = false, skipBubbleTrickle = false} = {}) {
   const isLP = collection?.type === COLLECTION_TYPE.LEARNING_PATH
 
   const hierarchy = await getHierarchy(contentId, collection)
@@ -594,24 +595,25 @@ async function setStartedOrCompletedStatus(contentId, collection, isCompleted, {
     {skipPush: true}
   )
 
-  let progresses = {
-    ...trickleProgress(hierarchy, contentId, collection, progress),
-    ...await bubbleProgress(hierarchy, contentId, collection)
-  }
+  let allProgresses = {}
+  allProgresses[contentId] = progress
 
-  // have to do this so we dont unnecessarily create a 0% record for each child on set to started/completed
-  await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, false)
+  if (!skipBubbleTrickle) {
+    let progresses = {
+      ...trickleProgress(hierarchy, contentId, collection, progress),
+      ...await bubbleProgress(hierarchy, contentId, collection)
+    }
+    Object.assign(allProgresses, progresses)
+
+    await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, false)
+  }
 
   if (isLP) {
-    let exportProgresses = progresses
-    exportProgresses[contentId] = progress
-    await duplicateProgressToALaCarte(exportProgresses, collection, {skipPush: true})
+    await duplicateProgressToALaCarte(allProgresses, collection, {skipPush: true})
   }
 
-  if (progress === 100) await onContentCompletedLearningPathActions(contentId, collection)
-
-  for (const [id, progress] of Object.entries(progresses)) {
-    if (progress === 100) {
+  for (const [id, prog] of Object.entries(allProgresses)) {
+    if (prog === 100) {
       await onContentCompletedLearningPathActions(Number(id), collection)
     }
   }
@@ -621,7 +623,7 @@ async function setStartedOrCompletedStatus(contentId, collection, isCompleted, {
   return response
 }
 
-async function setStartedOrCompletedStatusMany(contentIds, collection, isCompleted, {skipPush = false} = {}) {
+async function setStartedOrCompletedStatusMany(contentIds, collection, isCompleted, {skipPush = false, skipBubbleTrickle = false} = {}) {
   const isLP = collection?.type === COLLECTION_TYPE.LEARNING_PATH
   const progress = isCompleted ? 100 : 0
 
@@ -637,32 +639,28 @@ async function setStartedOrCompletedStatusMany(contentIds, collection, isComplet
     {skipPush: true}
   )
 
-  let progresses = {}
-  for (const contentId of contentIds) {
-    progresses = {
-      ...progresses,
-      ...trickleProgress(hierarchy, contentId, collection, progress),
-      ...(await bubbleProgress(hierarchy, contentId, collection)),
+  let allProgresses = Object.fromEntries(contentIds.map(id => [id, progress]))
+
+  if (!skipBubbleTrickle) {
+    let progresses = {}
+    for (const contentId of contentIds) {
+      progresses = {
+        ...progresses,
+        ...trickleProgress(hierarchy, contentId, collection, progress),
+        ...(await bubbleProgress(hierarchy, contentId, collection)),
+      }
     }
+    Object.assign(allProgresses, progresses)
+
+    await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, false)
   }
-  // have to do this so we dont unnecessarily create a 0% record for each child on set to started/completed
-  await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, false)
 
   if (isLP) {
-    let exportProgresses = progresses
-    for (const contentId of contentIds){
-      exportProgresses[contentId] = progress
-    }
-    await duplicateProgressToALaCarte(exportProgresses, collection, {skipPush: true})
+    await duplicateProgressToALaCarte(allProgresses, collection, {skipPush: true})
   }
 
-  if (progress === 100) {
-    for (const contentId of contentIds) {
-      await onContentCompletedLearningPathActions(contentId, collection)
-    }
-  }
-  for (const [id, progress] of Object.entries(progresses)) {
-    if (progress === 100) {
+  for (const [id, prog] of Object.entries(allProgresses)) {
+    if (prog === 100) {
       await onContentCompletedLearningPathActions(Number(id), collection)
     }
   }
@@ -672,7 +670,7 @@ async function setStartedOrCompletedStatusMany(contentIds, collection, isComplet
   return response
 }
 
-async function resetStatus(contentId, collection = null, {skipPush = false} = {}) {
+async function resetStatus(contentId, collection = null, {skipPush = false, skipBubbleTrickle = false} = {}) {
   const isLP = collection?.type === COLLECTION_TYPE.LEARNING_PATH
 
   const progress = 0
@@ -681,17 +679,21 @@ async function resetStatus(contentId, collection = null, {skipPush = false} = {}
   const hierarchy = await getHierarchy(contentId, collection)
   const metadata = hierarchy.metadata || {}
 
-  let progresses = {
-    ...trickleProgress(hierarchy, contentId, collection, progress),
-    ...await bubbleProgress(hierarchy, contentId, collection)
+  let allProgresses = {}
+  allProgresses[contentId] = progress
+
+  if (!skipBubbleTrickle) {
+    let progresses = {
+      ...trickleProgress(hierarchy, contentId, collection, progress),
+      ...await bubbleProgress(hierarchy, contentId, collection)
+    }
+    Object.assign(allProgresses, progresses)
+
+    await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, true)
   }
 
-  // have to use different endpoints for erase vs record
-  await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, true)
-
   if (isLP) {
-    progresses[contentId] = progress
-    await duplicateProgressToALaCarte(progresses, collection, {skipPush: true})
+    await duplicateProgressToALaCarte(allProgresses, collection, {skipPush: true})
   }
 
   if (!skipPush) db.contentProgress.requestPushUnsynced('reset-status')

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -490,6 +490,7 @@ export async function contentStatusCompletedMany(contentIds, collection = null) 
   )
 }
 
+// skipBubbleTrickle is only for starting enrolled GC's as a hack to get them into the progress row.
 export async function contentStatusStarted(contentId, collection = null, {skipPush = false, skipBubbleTrickle = false} = {}) {
   collection = collection ?? {id: COLLECTION_ID_SELF, type: COLLECTION_TYPE.SELF}
   return setStartedOrCompletedStatus(

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -623,7 +623,7 @@ async function setStartedOrCompletedStatus(contentId, collection, isCompleted, {
   return response
 }
 
-async function setStartedOrCompletedStatusMany(contentIds, collection, isCompleted, {skipPush = false, skipBubbleTrickle = false} = {}) {
+async function setStartedOrCompletedStatusMany(contentIds, collection, isCompleted, {skipPush = false} = {}) {
   const isLP = collection?.type === COLLECTION_TYPE.LEARNING_PATH
   const progress = isCompleted ? 100 : 0
 
@@ -641,19 +641,17 @@ async function setStartedOrCompletedStatusMany(contentIds, collection, isComplet
 
   let allProgresses = Object.fromEntries(contentIds.map(id => [id, progress]))
 
-  if (!skipBubbleTrickle) {
-    let progresses = {}
-    for (const contentId of contentIds) {
-      progresses = {
-        ...progresses,
-        ...trickleProgress(hierarchy, contentId, collection, progress),
-        ...(await bubbleProgress(hierarchy, contentId, collection)),
-      }
+  let progresses = {}
+  for (const contentId of contentIds) {
+    progresses = {
+      ...progresses,
+      ...trickleProgress(hierarchy, contentId, collection, progress),
+      ...(await bubbleProgress(hierarchy, contentId, collection)),
     }
-    Object.assign(allProgresses, progresses)
-
-    await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, false)
   }
+  Object.assign(allProgresses, progresses)
+
+  await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, false)
 
   if (isLP) {
     await duplicateProgressToALaCarte(allProgresses, collection, {skipPush: true})

--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -670,7 +670,7 @@ async function setStartedOrCompletedStatusMany(contentIds, collection, isComplet
   return response
 }
 
-async function resetStatus(contentId, collection = null, {skipPush = false, skipBubbleTrickle = false} = {}) {
+async function resetStatus(contentId, collection = null, {skipPush = false} = {}) {
   const isLP = collection?.type === COLLECTION_TYPE.LEARNING_PATH
 
   const progress = 0
@@ -682,15 +682,14 @@ async function resetStatus(contentId, collection = null, {skipPush = false, skip
   let allProgresses = {}
   allProgresses[contentId] = progress
 
-  if (!skipBubbleTrickle) {
-    let progresses = {
-      ...trickleProgress(hierarchy, contentId, collection, progress),
-      ...await bubbleProgress(hierarchy, contentId, collection)
-    }
-    Object.assign(allProgresses, progresses)
-
-    await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, true)
+  let progresses = {
+    ...trickleProgress(hierarchy, contentId, collection, progress),
+    ...await bubbleProgress(hierarchy, contentId, collection)
   }
+  Object.assign(allProgresses, progresses)
+
+  await bubbleAndTrickleProgressesSafely(progresses, collection, metadata, true)
+
 
   if (isLP) {
     await duplicateProgressToALaCarte(allProgresses, collection, {skipPush: true})


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- https://musora.atlassian.net/browse/BR-632

## Description/Design

- when enrolling in GC's we mark the GC as `started` status with 0% `progress`, but we also then trickle that state/progress to all children. this PR fixes that

## Testing

- sanity development
- check state of recent row on lessons page: https://devapp.musora.com:5174/drumeo/lessons
- enroll in GC: https://devapp.musora.com:5174/drumeo/lessons/enrollment/405781
- see no new lessons from GC in lessons page
