### PR TITLE
chore: resolve LokiJSAdapter ESM interop error in Node 20

### DIFF
--- a/src/services/sync/adapters/lokijs.ts
+++ b/src/services/sync/adapters/lokijs.ts
@@ -1,6 +1,8 @@
 import { SyncTelemetry } from '../telemetry'
 
-import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs'
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+const LokiJSAdapter = require('@nozbe/watermelondb/adapters/lokijs').default
 
 import { deleteDatabase, lokiFatalError } from '@nozbe/watermelondb/adapters/lokijs/worker/lokiExtensions'
 


### PR DESCRIPTION
fix: resolve LokiJSAdapter ESM/CJS interop failure in Node 20
`import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs'` resolves
to the exports object rather than the class constructor in Node 20 ESM context.
Use createRequire to force CJS resolution and unwrap .default explicitly.