### PR TITLE
chore(TP-1190): Add coverage to workflow, removie files from coverage…

### DIFF
--- a/.github/workflows/automated-testing.yml
+++ b/.github/workflows/automated-testing.yml
@@ -17,4 +17,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run unit tests
-        run: npm test
+        run: npm test -- --coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# codecov.yml
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,16 +22,38 @@ export default {
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: true,
 
-  // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: undefined,
+  // Exclude pure transport/adapter layers with no business logic.
+  // Files with business logic stay in even at low coverage — gaps should be visible.
+  collectCoverageFrom: [
+    'src/**/*.{js,ts}',
+    '!src/services/sanity.js',
+    '!src/services/railcontent.js',
+    '!src/services/recommendations.js',
+    '!src/index.js',
+    '!src/index.d.ts',
+    '!src/services/user/account.ts',
+    '!src/services/user/sessions.js',
+    '!src/services/user/profile.js',
+    '!src/services/user/management.js',
+    '!src/services/user/interests.js',
+    '!src/services/user/payments.ts',
+    '!src/services/user/chat.js',
+  ],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
 
-  // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  // Global threshold — set just below current baseline.
+  // Intent is to ratchet up over time as coverage improves.
+  // Do not lower these numbers — raise them as tests are added.
+  coverageThreshold: {
+    global: {
+      statements: 40,
+      branches: 25,
+      functions: 40,
+      lines: 40,
+    },
+  },
 
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: "babel",

--- a/test/unit/progressRows.test.js
+++ b/test/unit/progressRows.test.js
@@ -6,6 +6,10 @@ import { initializeTestService } from '../initializeTests.js';
 import mockData_progress_content from '../mockData/mockData_progress_content.json';
 import mockData_sanity_progress_content from "../mockData/mockData_sanity_progress_content.json";
 
+jest.mock('../../src/services/progress-row/rows/method-card.js', () => ({
+  getMethodCard: jest.fn().mockResolvedValue(null),
+}))
+
 jest.mock('../../src/services/sync/repository-proxy.ts', () => {
   const mockFns = {
     contentProgress: {


### PR DESCRIPTION
[TP-1190](https://musora.atlassian.net/browse/TP-1190)

Exclude pure transport layers from coverage collection, set global threshold
at current baseline (40%), and add --coverage flag to CI workflow so PRs
fail if coverage drops.

Run coverage report in testing workflow.

[TP-1190]: https://musora.atlassian.net/browse/TP-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ