### PR TITLE
feat(TP-1095): handle late-start active paths

### DIFF
--- a/src/services/content-org/learning-paths.ts
+++ b/src/services/content-org/learning-paths.ts
@@ -4,10 +4,12 @@
 
 import { GET, POST } from '../../infrastructure/http/HttpClient'
 import {
+  devFetchAllLearningPathsAndIntroVideoIdsForDelete,
   fetchByRailContentId,
   fetchByRailContentIds,
   fetchMethodV2Structure,
-  fetchParentChildRelationshipsFor
+  fetchParentChildRelationshipsFor,
+  hasAnyMethodV2IntroCompleted,
 } from '../sanity.js'
 import { addContextToLearningPaths } from '../contentAggregator.js'
 import {
@@ -18,12 +20,11 @@ import {
   getIdsWhereLastAccessedFromMethod,
   getProgressState,
 } from '../contentProgress.js'
-import { COLLECTION_ID_SELF, COLLECTION_TYPE, STATE } from '../sync/models/ContentProgress'
-import { SyncWriteDTO } from '../sync'
+import { COLLECTION_ID_SELF, COLLECTION_TYPE, CollectionParameter, STATE } from '../sync/models/ContentProgress'
+import { db, SyncWriteDTO } from '../sync'
 import { ContentProgress } from '../sync/models'
-import { CollectionParameter } from '../sync/models/ContentProgress'
 import dayjs from 'dayjs'
-import { LEARNING_PATH_LESSON } from "../../contentTypeConfig";
+import { LEARNING_PATH_LESSON } from '../../contentTypeConfig'
 
 const BASE_PATH: string = `/api/content-org`
 const LEARNING_PATHS_PATH = `${BASE_PATH}/v1/user/learning-paths`
@@ -196,7 +197,18 @@ async function dataPromiseGET(
  */
 export async function resetAllLearningPaths() {
   const url: string = `${LEARNING_PATHS_PATH}/reset`
-  return await POST(url, {})
+
+  return await Promise.all([
+    devFetchAllLearningPathsAndIntroVideoIdsForDelete().then(async (all) => {
+      await Promise.all([
+        db.contentProgress.eraseProgressMany(all.intros, null),
+        ...all.learning_paths.map((id) =>
+          db.contentProgress.eraseProgress(id, {id, type: COLLECTION_TYPE.LEARNING_PATH})
+        )
+      ])
+    }),
+    POST(url, {}),
+  ])
 }
 
 /**
@@ -457,20 +469,20 @@ interface completeMethodIntroVideo {
 }
 /**
  * Handles completion of method intro video and other related actions.
- * @param introVideoId - The method intro video content ID.
+ * @param introVideoId - The method intro video content ID. If not provided, does not `complete` intro video.
  * @param brand
  * @returns {Promise<Array>} response - The response object.
  * @returns {Promise<Object|null>} response.intro_video_response - The intro video completion response or null if already completed.
  * @returns {Promise<Object>} response.active_path_response - The set active learning path response.
  */
 export async function completeMethodIntroVideo(
-  introVideoId: number,
+  introVideoId: number|null,
   brand: string
 ): Promise<completeMethodIntroVideo> {
   let response = {} as completeMethodIntroVideo
 
   const [intro_video_response, methodStructure] = await Promise.all([
-    completeIfNotCompleted(introVideoId),
+    introVideoId ? completeIfNotCompleted(introVideoId) : Promise.resolve(null),
     fetchMethodV2Structure(brand)
   ])
   response.intro_video_response = intro_video_response
@@ -520,13 +532,25 @@ export async function completeLearningPathIntroVideo(
   let response = {} as completeLearningPathIntroVideo
   const collection: CollectionObject = { id: learningPathId, type: COLLECTION_TYPE.LEARNING_PATH }
 
+  const [anyIntroComplete, activePath] = await Promise.all([
+    hasAnyMethodV2IntroCompleted(),
+    getActivePath(brand)
+  ])
+
+  let lateMethodSetup = false
+  // check if the method intro was watched elsewhere; then we have to give user active path for this brand.
+  if (anyIntroComplete && !activePath) {
+    completeMethodIntroVideo(null, brand) // no need to await.
+    lateMethodSetup = true
+  }
+
   if (!lessonsToImport) {
     response.learning_path_reset_response = await resetIfPossible(learningPathId, collection)
   } else {
     response.lesson_import_response = await contentStatusCompletedMany(lessonsToImport, collection)
 
     const activePath = await getActivePath(brand)
-    if (activePath.active_learning_path_id === learningPathId) {
+    if (activePath.active_learning_path_id === learningPathId && !lateMethodSetup) { // don't update dailies if they were just set by completeMethodIntroVideoCompleteActions.
       response.update_dailies_response = await updateDailySession(brand, new Date(), true)
     }
   }

--- a/src/services/progress-row/rows/method-card.js
+++ b/src/services/progress-row/rows/method-card.js
@@ -8,24 +8,6 @@ import { getProgressState } from '../../contentProgress'
 import { COLLECTION_TYPE, STATE } from '../../sync/models/ContentProgress'
 
 export async function getMethodCard(brand) {
-  let introVideo
-  try {
-    introVideo = await fetchMethodV2IntroVideo(brand)
-  } catch (error) {
-    console.error('Error fetching method intro video:', error)
-    return null
-  }
-
-  if (!introVideo) return null
-
-  let introVideoProgressState
-  try {
-    introVideoProgressState = await getProgressState(introVideo?.id)
-  } catch (error) {
-    console.error('Error fetching progress state for method intro video:', error)
-    return null
-  }
-
   let activeLearningPath
   try {
     activeLearningPath = await getActivePath(brand)
@@ -34,7 +16,17 @@ export async function getMethodCard(brand) {
     return null
   }
 
-  if (introVideoProgressState !== STATE.COMPLETED || !activeLearningPath) {
+  // only check if has active path, because method intro video may have been completed elsewhere
+  if (!activeLearningPath) {
+    let introVideo
+    try {
+      introVideo = await fetchMethodV2IntroVideo(brand)
+      if (!introVideo) return null
+    } catch (error) {
+      console.error('Error fetching method intro video:', error)
+      return null
+    }
+
     const timestamp = Math.floor(Date.now())
     const instructorText =
       introVideo.instructor?.length > 1

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -56,7 +56,7 @@ import { COLLECTION_TYPE } from './sync/models/ContentProgress'
  *
  * @type {string[]}
  */
-const excludeFromGeneratedIndex = ['fetchRelatedByLicense']
+const excludeFromGeneratedIndex = ['fetchRelatedByLicense', 'devFetchAllLearningPathsAndIntroVideoIdsForDelete']
 
 /**
  * Mapping from tab names to their underlying Sanity content types.
@@ -2200,6 +2200,14 @@ export async function fetchMethodV2Structure(brand) {
     }
   }`
   return await fetchSanity(query, false)
+}
+
+export async function devFetchAllLearningPathsAndIntroVideoIdsForDelete() {
+  const query = `{
+    'intros': *[_type in ['method-intro', 'learning-path-intro']].railcontent_id,
+    'learning_paths': *[_type == 'learning-path-v2'].railcontent_id
+  }`
+  return await fetchSanity(query, true)
 }
 
 /**


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- https://musora.atlassian.net/browse/TP-1095
- blocks [FE](https://musora.atlassian.net/browse/BEHSTP-196) & [MA](https://musora.atlassian.net/browse/BEHSTP-197)

## problem

- when a method intro video has already been watched in another brand, we skip showing this brand's method intro video. But the M intro video is what starts the first LP as active for the user.


## Description/Design

- handles this new logic.
  - if any method intro video has been watched, then if you are entering any LP for a brand that doesnt have an active path yet, start the first LP as active.
  - handle this case on method homepage card, since this brand's intro video is technically not completed status

## Testing

- mcs call resetAllLearningPaths
- complete drumeo method intro
- see drumeo method card with daily session
- go to singeo -> no method intro video
- comlplete LP1 intro video
- see singeo method card with daily session -> of first LP
- go to playbass -> no method intro video
- comlplete LP3 intro video
- see playbass method card with daily session -> of first LP