### PR TITLE
fix: remove timestamp filtering of practice records in offline mode

### DIFF
--- a/src/services/offline/activities.ts
+++ b/src/services/offline/activities.ts
@@ -20,7 +20,7 @@ interface Activity {
  * @returns `{ currentPage, totalPages, data }` where `data` is a page of `Activity` records
  */
 export async function getRecentActivityOffline(
-  offlineTimestamp: number,
+  _offlineTimestamp: number,
   {
     page = 1,
     limit = 5,
@@ -34,7 +34,7 @@ export async function getRecentActivityOffline(
   // because setting up watermelon user activities table is extremely complicated.
   // Note: this implementation does not persist "activities" beyond when the corresponding record is deleted. That's ok right now.
 
-  const clauses = getClauses(offlineTimestamp, tabName)
+  const clauses = getClauses(tabName)
 
   const query = await db.contentProgress.queryAll(...clauses)
   const progress = query.data
@@ -54,9 +54,8 @@ export async function getRecentActivityOffline(
   }
 }
 
-function getClauses(offlineTimestamp: number, tabName: string|null) {
+function getClauses(tabName: string|null) {
   let clauses: Q.Clause[] = [
-    Q.where('updated_at', Q.gte(offlineTimestamp)),
     Q.sortBy('created_at', 'desc'),
   ]
 

--- a/src/services/offline/practices.ts
+++ b/src/services/offline/practices.ts
@@ -15,7 +15,6 @@ export async function getPracticeSessionsOffline(
 ) {
 
   const query = await db.practices.queryAll(
-    Q.where('updated_at', Q.gte(offlineTimestamp)),
     Q.where('date', day),
     Q.sortBy('created_at', 'asc'))
   const practices = query.data


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

[BEHSTP-232](https://musora.atlassian.net/browse/BEHSTP-232)

## Description/Design

Returns all practice records from watermelon in offline methods. Responsibility for correct display of said records (when no metadata like title, thumbnail, etc. available) falls to MA.


[BEHSTP-232]: https://musora.atlassian.net/browse/BEHSTP-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ