### PR TITLE
fix(TMA-275): MCS - Sanity - Add a v2 url segment to to all sanity requests to force a cache refresh

### DIFF
--- a/.agent/decisions/2026-04-28-tma-275-mcs-sanity-add-a-v2-url-segmen.md
+++ b/.agent/decisions/2026-04-28-tma-275-mcs-sanity-add-a-v2-url-segmen.md
@@ -1,0 +1,26 @@
+---
+date: 2026-04-28
+pr: TBD
+branch: TMA-275-mcs-sanity-add-a-v2-url-segment-to-to-all-sanity-r
+status: open
+tags: [[jira]], [[bug-fix]]
+components: [[sanity]]
+---
+
+# Add /v2 URL segment to all Sanity requests to force cache refresh
+
+## Context
+Sanity responses were being served from a stale CDN cache. To force a cache refresh, a new URL segment `/v2` needed to be appended after the dataset name in all Sanity API requests. The Jira ticket provided the target URL format: `https://sanity.musora.com/{projectId}/apicdn/v{version}/{dataset}/v2?perspective=...`
+
+## Decision
+Modified the `baseUrl` construction in `src/services/sanity.js` (line 1570) to append `/v2` after the dataset segment. This is the single place where all Sanity API request URLs are built, so this one-line change affects all queries made through MCS.
+
+## Alternatives Considered
+- Adding a cache-busting query parameter instead of a path segment — rejected because the Jira description explicitly shows the `/v2` path segment as the desired approach.
+- Updating config to pass the segment dynamically — unnecessary complexity for a single constant value.
+
+## Process Notes
+The URL is constructed in a single location in `fetchFromSanity()` inside `src/services/sanity.js`. Both GET and POST requests use the same `baseUrl`, so the fix applies to all request methods automatically.
+
+## Consequences
+All Sanity API requests will now include `/v2` in the path, causing the CDN to treat them as new cache keys and serve fresh data.

--- a/.agent/decisions/2026-04-28-tma-275-mcs-sanity-add-a-v2-url-segmen.md
+++ b/.agent/decisions/2026-04-28-tma-275-mcs-sanity-add-a-v2-url-segmen.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-04-28
-pr: TBD
+pr: railroadmedia/musora-content-services#946
 branch: TMA-275-mcs-sanity-add-a-v2-url-segment-to-to-all-sanity-r
 status: open
 tags: [[jira]], [[bug-fix]]

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1567,7 +1567,7 @@ export async function fetchSanity(
   }
   const perspective = globalConfig.sanityConfig.perspective ?? 'published'
   const api = globalConfig.sanityConfig.useCachedAPI ? 'apicdn' : 'api'
-  const baseUrl = `https://sanity.musora.com/${globalConfig.sanityConfig.projectId}/${api}/v${globalConfig.sanityConfig.version}/${globalConfig.sanityConfig.dataset}?perspective=${perspective}`
+  const baseUrl = `https://sanity.musora.com/${globalConfig.sanityConfig.projectId}/${api}/v${globalConfig.sanityConfig.version}/${globalConfig.sanityConfig.dataset}/v2?perspective=${perspective}`
 
   try {
     const encodedQuery = encodeURIComponent(query)


### PR DESCRIPTION
## Jira Ticket
[TMA-275: MCS - Sanity - Add a v2 url segment to to all sanity requests to force a cache refresh](https://musora.atlassian.net/browse/TMA-275)

## Description
Appends `/v2` to the Sanity API URL path after the dataset segment in `src/services/sanity.js`. This forces a CDN cache refresh by changing the cache key for all Sanity requests.

Before: `.../v2021-06-07/{dataset}?perspective=...`
After: `.../v2021-06-07/{dataset}/v2?perspective=...`

## Notes
Please review and test manually before merging.

🤖 Generated by Musora Agent