### PR TITLE
fix: add missing vimeo_live_event_id field to downloads field list

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -149,6 +149,7 @@ export function getLiveFields(minimum = false) {
     "live_event_start_time",
     "live_event_end_time",
     "live_event_stream_id",
+    "vimeo_live_event_id",
     "'live_event_is_global': live_global_event == true",
     "'videoId': coalesce(live_event_stream_id, video.external_id)",
   ]


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- issues with livestreams

## Description/Design

- adds missing field that livestream pages need

## Testing

- test a livestream
