### PR TITLE
fix(BR-659): fix resources for null parents

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -116,7 +116,7 @@ export const descriptionField = 'description[0].children[0].text'
 // this pulls both any defined resources for the document as well as any resources in the parent document
 export const resourcesField = `[
           ... resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )},
-          ... coalesce(parent_content_reference[defined(count(@->resource) > 0]->resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )}, []),
+          ... coalesce(parent_content_reference[count(@->resource) > 0]->resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )}, []),
           ]`
 
 export const contentAwardField = "*[references(^._id) && _type == 'content-award'][0]"

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -116,7 +116,7 @@ export const descriptionField = 'description[0].children[0].text'
 // this pulls both any defined resources for the document as well as any resources in the parent document
 export const resourcesField = `[
           ... resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )},
-          ... coalesce(parent_content_reference[]->resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )}, []),
+          ... coalesce(parent_content_reference[defined(@->resource) && count(@->resource) > 0]->resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )}, []),
           ]`
 
 export const contentAwardField = "*[references(^._id) && _type == 'content-award'][0]"

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -116,7 +116,7 @@ export const descriptionField = 'description[0].children[0].text'
 // this pulls both any defined resources for the document as well as any resources in the parent document
 export const resourcesField = `[
           ... resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )},
-          ... coalesce(parent_content_reference[defined(@->resource) && count(@->resource) > 0]->resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )}, []),
+          ... coalesce(parent_content_reference[defined(count(@->resource) > 0]->resource[]{resource_name, _key, "resource_url": coalesce('${CloudFrontURl}'+string::split(resource_aws.asset->fileURL, '${AWSUrl}')[1], resource_url )}, []),
           ]`
 
 export const contentAwardField = "*[references(^._id) && _type == 'content-award'][0]"


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)
[JIRA](https://musora.atlassian.net/browse/BR-659)

## Description/Design

We filter on parents with defined resources now.


## Testing

Content to test
example course-lesson with resources in parent: 190706
example problem (previously showing null): 338244
example course lesson with resources in grandparent: 251510

Tested on live code:  `mcs call fetchLessonContent --args=[338244]`


[Old Query in vision](https://4032r8py.api.sanity.io/v2026-05-01/data/query/production_v2?query=*%5Brailcontent_id+in+%5B338244%2C+251510%2C+190706%5D+%26%26+status+in+%5B%27draft%27%2C%27scheduled%27%2C%27published%27%2C%27archived%27%2C%27unlisted%27%5D+%26%26+%21defined%28deprecated_railcontent_id%29%5D%7B%0A++++railcontent_id%2C%0A++_id%2C%0A++_type%2C%0A++++%22resources%22%3A+%5B%0A++++++++++...+resource%5B%5D%7Bresource_name%2C+_key%2C+%22resource_url%22%3A+coalesce%28%27https%3A%2F%2Fd3fzm1tzeyr5n3.cloudfront.net%27%2Bstring%3A%3Asplit%28resource_aws.asset-%3EfileURL%2C+%27https%3A%2F%2Fs3.us-east-1.amazonaws.com%2Fmusora-web-platform%27%29%5B1%5D%2C+resource_url+%29%7D%2C%0A++++++++++...+coalesce%28parent_content_reference%5B%5D-%3Eresource%5B%5D%7Bresource_name%2C+_key%2C+%22resource_url%22%3A+coalesce%28%27https%3A%2F%2Fd3fzm1tzeyr5n3.cloudfront.net%27%2Bstring%3A%3Asplit%28resource_aws.asset-%3EfileURL%2C+%27https%3A%2F%2Fs3.us-east-1.amazonaws.com%2Fmusora-web-platform%27%29%5B1%5D%2C+resource_url+%29%7D%2C+%5B%5D%29%2C+%0A++++++++++%5D%0A++++%7D+%7C+order%28published_on+desc%29%5B0...3%5D&perspective=published) Notice 338244 has a null.
[New Query in vision](https://4032r8py.api.sanity.io/v2026-05-01/data/query/production_v2?query=*%5Brailcontent_id+in+%5B338244%2C+251510%2C+190706%5D+%26%26+status+in+%5B%27draft%27%2C%27scheduled%27%2C%27published%27%2C%27archived%27%2C%27unlisted%27%5D+%26%26+%21defined%28deprecated_railcontent_id%29%5D%7B%0A++++railcontent_id%2C%0A++_id%2C%0A++_type%2C%0A++++%22resources%22%3A+%5B%0A++++++++++...+resource%5B%5D%7Bresource_name%2C+_key%2C+%22resource_url%22%3A+coalesce%28%27https%3A%2F%2Fd3fzm1tzeyr5n3.cloudfront.net%27%2Bstring%3A%3Asplit%28resource_aws.asset-%3EfileURL%2C+%27https%3A%2F%2Fs3.us-east-1.amazonaws.com%2Fmusora-web-platform%27%29%5B1%5D%2C+resource_url+%29%7D%2C%0A++++++++++...+coalesce%28parent_content_reference%5Bcount%28%40-%3Eresource%29+%3E+0%5D-%3Eresource%5B%5D%7Bresource_name%2C+_key%2C+%22resource_url%22%3A+coalesce%28%27https%3A%2F%2Fd3fzm1tzeyr5n3.cloudfront.net%27%2Bstring%3A%3Asplit%28resource_aws.asset-%3EfileURL%2C+%27https%3A%2F%2Fs3.us-east-1.amazonaws.com%2Fmusora-web-platform%27%29%5B1%5D%2C+resource_url+%29%7D%2C+%5B%5D%29%2C+%0A++++++++++%5D%0A++++%7D+%7C+order%28published_on+desc%29%5B0...3%5D&perspective=published)

Vision link of three

## Additional Notes

- _Provide any additional context or notes that might be helpful for the reviewer._
