### PR TITLE
fix(BEHSTP-160): hide future content in related lessons

### DIFF
--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1162,7 +1162,6 @@ export async function fetchRelatedLessons(railContentId) {
     `${defaultFilterFields} && difficulty == ^.difficulty`,
     params
   ).buildFilter()
-  console.log(filterSameArtist)
   const queryFields = getFieldsForContentType()
 
   const query = `*[railcontent_id == ${railContentId}]{
@@ -1172,7 +1171,6 @@ export async function fetchRelatedLessons(railContentId) {
       ...(*[${filterSameGenre}]{${queryFields}}|order(published_on desc, title asc)[0...10]),
       ...(*[${filterSameDifficulty}]{${queryFields}}|order(published_on desc, title asc)[0...10]),
       ])[0...10]}`
-  console.log(query);
   return await fetchSanity(query, false, { processNeedAccess: true })
 }
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1146,20 +1146,23 @@ export async function fetchSiblingContent(railContentId, brand = null) {
  */
 export async function fetchRelatedLessons(railContentId) {
   const defaultFilterFields = `_type==^._type && brand == ^.brand && railcontent_id != ${railContentId}`
-
+  const params = {
+    showMembershipRestrictedContent: true,
+    availableContentStatuses: ['published']
+  }
   const filterSameArtist = await new FilterBuilder(
     `${defaultFilterFields} && references(^.artist->_id)`,
-    { showMembershipRestrictedContent: true }
+    params
   ).buildFilter()
   const filterSameGenre = await new FilterBuilder(
     `${defaultFilterFields} && references(^.genre[]->_id)`,
-    { showMembershipRestrictedContent: true }
+    params
   ).buildFilter()
   const filterSameDifficulty = await new FilterBuilder(
     `${defaultFilterFields} && difficulty == ^.difficulty`,
-    { showMembershipRestrictedContent: true }
+    params
   ).buildFilter()
-
+  console.log(filterSameArtist)
   const queryFields = getFieldsForContentType()
 
   const query = `*[railcontent_id == ${railContentId}]{
@@ -1169,7 +1172,7 @@ export async function fetchRelatedLessons(railContentId) {
       ...(*[${filterSameGenre}]{${queryFields}}|order(published_on desc, title asc)[0...10]),
       ...(*[${filterSameDifficulty}]{${queryFields}}|order(published_on desc, title asc)[0...10]),
       ])[0...10]}`
-
+  console.log(query);
   return await fetchSanity(query, false, { processNeedAccess: true })
 }
 


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

[JIRA](https://musora.atlassian.net/browse/BEHSTP-160?focusedCommentId=29451)

## Description/Design

- I only show published content (in the past) no more extra content
- In order to show future content (scheduled) given the default status, we don't restrict publish_on. By explicitly setting `published` we include the published_on restriction.

## Testing

- ` mcs call fetchRelatedLessons [411128]` and I logged the query to verify the 
- I trust the query :D. Testing this requires setting up more stuff in sanity that I can to do.
