### PR TITLE
fix: Revert "add resolver condition to ensure seen records always get marked sync"

### DIFF
--- a/src/services/sync/resolver.ts
+++ b/src/services/sync/resolver.ts
@@ -7,7 +7,6 @@ export type SyncResolution = {
   tuplesForUpdate: [BaseModel, SyncEntry][]
   tuplesForRestore: [BaseModel, SyncEntry][]
   idsForDestroy: RecordId[]
-  recordsForSynced: BaseModel[]
 }
 
 export type SyncResolverComparator<T extends BaseModel = BaseModel> = (serverEntry: SyncEntryNonDeleted<T>, localModel: T) => 'SERVER' | 'LOCAL'
@@ -25,8 +24,7 @@ export default class SyncResolver {
       entriesForCreate: [],
       tuplesForUpdate: [],
       tuplesForRestore: [],
-      idsForDestroy: [],
-      recordsForSynced: []
+      idsForDestroy: []
     }
   }
 
@@ -60,9 +58,6 @@ export default class SyncResolver {
     } else if (this.comparator(server as SyncEntryNonDeleted<BaseModel>, local) !== 'LOCAL') {
       // local is older, so update it with server's
       this.resolution.tuplesForUpdate.push([local, server])
-    } else {
-      // server is older - can happen with clock skew - just mark as synced
-      this.resolution.recordsForSynced.push(local)
     }
   }
 
@@ -74,9 +69,6 @@ export default class SyncResolver {
     } else if (this.comparator(server as SyncEntryNonDeleted<BaseModel>, local) !== 'LOCAL') {
       // local is older, so update it with server's
       this.resolution.tuplesForUpdate.push([local, server])
-    } else {
-      // server is older - can happen with clock skew - just mark as synced
-      this.resolution.recordsForSynced.push(local)
     }
   }
 

--- a/src/services/sync/store/index.ts
+++ b/src/services/sync/store/index.ts
@@ -958,15 +958,9 @@ export default class SyncStore<TModel extends BaseModel = BaseModel> {
         r._raw._changed = ''
       })
     })
-    const syncedBuilds = result.recordsForSynced.map((record) => {
-      return record.prepareUpdate((r) => {
-        r._raw._status = 'synced'
-        r._raw._changed = ''
-      })
-    })
 
     return [
-      [...destroyedBuilds, ...createdBuilds, ...updatedBuilds, ...restoreDestroyBuilds, ...syncedBuilds],
+      [...destroyedBuilds, ...createdBuilds, ...updatedBuilds, ...restoreDestroyBuilds],
       [...restoreCreateBuilds],
     ]
   }

--- a/test/unit/sync/resolver.test.ts
+++ b/test/unit/sync/resolver.test.ts
@@ -65,11 +65,10 @@ describe('againstNone', () => {
     const resolver = new SyncResolver()
     resolver.againstNone(makeEntry('rec-1', { deletedAt: T }))
 
-    const { entriesForCreate, tuplesForUpdate, idsForDestroy, recordsForSynced } = resolver.result
+    const { entriesForCreate, tuplesForUpdate, idsForDestroy } = resolver.result
     expect(entriesForCreate).toHaveLength(0)
     expect(tuplesForUpdate).toHaveLength(0)
     expect(idsForDestroy).toHaveLength(0)
-    expect(recordsForSynced).toHaveLength(0)
   })
 })
 
@@ -101,10 +100,9 @@ describe('againstSynced', () => {
     const resolver = new SyncResolver()
     resolver.againstSynced(makeLocal('rec-1', T + 1), makeEntry('rec-1', { updatedAt: T }))
 
-    const { tuplesForUpdate, idsForDestroy, recordsForSynced } = resolver.result
+    const { tuplesForUpdate, idsForDestroy } = resolver.result
     expect(tuplesForUpdate).toHaveLength(0)
     expect(idsForDestroy).toHaveLength(0)
-    expect(recordsForSynced).toHaveLength(0)
   })
 })
 
@@ -129,14 +127,14 @@ describe('againstCreated', () => {
     expect(resolver.result.tuplesForUpdate[0][1]).toBe(server)
   })
 
-  test('server older (clock skew) → recordsForSynced', () => {
+  test('server older (clock skew) → no action (record stays dirty)', () => {
     const resolver = new SyncResolver()
     const local = makeLocal('rec-1', T + 1)
 
     resolver.againstCreated(local, makeEntry('rec-1', { updatedAt: T }))
 
-    expect(resolver.result.recordsForSynced).toContain(local)
     expect(resolver.result.tuplesForUpdate).toHaveLength(0)
+    expect(resolver.result.idsForDestroy).toHaveLength(0)
   })
 })
 
@@ -160,14 +158,14 @@ describe('againstUpdated', () => {
     expect(resolver.result.tuplesForUpdate).toHaveLength(1)
   })
 
-  test('server older (clock skew) → recordsForSynced', () => {
+  test('server older (clock skew) → no action (record stays dirty)', () => {
     const resolver = new SyncResolver()
     const local = makeLocal('rec-1', T + 1)
 
     resolver.againstUpdated(local, makeEntry('rec-1', { updatedAt: T }))
 
-    expect(resolver.result.recordsForSynced).toContain(local)
     expect(resolver.result.tuplesForUpdate).toHaveLength(0)
+    expect(resolver.result.idsForDestroy).toHaveLength(0)
   })
 })
 
@@ -214,7 +212,6 @@ describe('custom comparator', () => {
     resolver.againstSynced(local, server)
 
     expect(resolver.result.tuplesForUpdate).toHaveLength(0)
-    expect(resolver.result.recordsForSynced).toHaveLength(0)
     expect(resolver.result.idsForDestroy).toHaveLength(0)
   })
 


### PR DESCRIPTION
### Background: sync resolver conflict rule

When client A pulls a record from the server, the resolver compares timestamps:

- `server.updated_at >= local.updated_at` → apply server changes (server is newer)
- `server.updated_at < local.updated_at` → *(this is what #741 changed)*

### The original bug (#741)

At the time of #741, the server returned its **own clock-based `updated_at`** (generated via `NOW(3)` on insert), and the production DB column lacked millisecond precision. This created two real failure cases:

**Case 1 — single client, clock skew:**
Client clock is 10s ahead of server. Client writes at local T=100 (real time T=90). Push succeeds. Server saves with `updated_at=90` (server clock, second precision). Client pulls, gets back `updated_at=90`. Resolver: `server(90) < local(100)` → old behavior: ignore server record, record stays dirty. Next sync: same result. Record **permanently stuck dirty**, causing the "Hang On!" logout modal to never clear.

**Case 2 — multi-client:**
Client B writes at T=95, pushes. Server has `updated_at=95`. Client A writes same record at T=100, not yet pushed. Client A pulls, gets `updated_at=95`. Resolver: `server(95) < local(100)` → old behavior: stays dirty. This was acceptable — A has a newer write, it will push and LWW resolves on server. But case 1 was a real user-facing bug.

#741 fixed case 1 by marking the record `synced` + `_changed=''` when `server < local`, preventing the infinite dirty loop.

### Why #741 is now wrong

PR #806 changed the server to store client-provided timestamps in a dedicated `client_updated_at` column and return that in pull responses instead of the server's own clock. This eliminated case 1 entirely: client pushes `updated_at=100`, server stores `client_updated_at=100`, pull returns `100`. Resolver sees `server(100) == local(100)` — no mismatch, no stuck record.

But #741's fix remained active. Now `server(95) < local(100)` only occurs in the case 2 scenario: client A has a **dirty, unpushed write** at T=100, and server holds another client's older write at T=95. The fix marks A's record as synced and clears `_changed`. A's write **never reaches the server** — silently dropped.

This is wrong for our architecture. Pulls can happen at any time, independently of push. The correct behavior when `server < local` is to leave the dirty record alone: client A has a newer version, it will push, and server LWW handles the conflict. That is exactly what the pre-#741 behavior did.

The revert restores it.