### PR TITLE
fix: revert recordWatchSesssion signature

### DIFF
--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -444,6 +444,7 @@ export async function recordWatchSession(
   mediaLengthSeconds,
   currentSeconds,
   secondsPlayed,
+  _prevSesssion = null,
   instrumentId = null,
   categoryId = null,
   isLivestream = false,


### PR DESCRIPTION
Reverting breaking change to method signature of `recordWatchSession` since MPF and MA didn't pick up the change.

Fixes `resumeTimeSeconds` not persisting properly