### PR TITLE
feat: adds stale record cleanup

### DIFF
--- a/src/services/sync/manager.ts
+++ b/src/services/sync/manager.ts
@@ -13,6 +13,7 @@ import { SyncEffect } from './effects'
 import { SyncTelemetry } from './telemetry/index'
 import createStoreConfigs from './store-configs'
 import { contentProgressObserver } from '../awards/internal/content-progress-observer'
+import { repairStaleSyncedRecords } from './stale-record-cleanup'
 
 export type SyncTeardownMode = 'reset' | 'destroyOrReset' | 'abortWrites'
 
@@ -179,6 +180,10 @@ export default class SyncManager {
 
     contentProgressObserver.start(database).catch((error) => {
       this.telemetry.error('[SyncManager] Failed to start contentProgressObserver', error)
+    })
+
+    repairStaleSyncedRecords(this.storesRegistry).catch((error) => {
+      this.telemetry.error('[SyncManager] Failed stale record cleanup', error)
     })
 
     const teardown = async (mode: SyncTeardownMode = 'reset') => {

--- a/src/services/sync/stale-record-cleanup.ts
+++ b/src/services/sync/stale-record-cleanup.ts
@@ -1,6 +1,5 @@
 import { Q } from '@nozbe/watermelondb'
 import { POST } from '../../infrastructure/http/HttpClient'
-import { globalConfig } from '../config.js'
 import BaseModel from './models/Base'
 import type { default as SyncStore } from './store'
 import type { EpochMs } from './index'
@@ -10,22 +9,9 @@ const CLEANUP_FLAG_KEY = 'stale_synced_cleanup_v1'
 const STALE_CUTOFF_MS = 10_000
 const SYNC_TABLES = ['progress', 'content_likes', 'practices', 'practice_day_notes', 'user_award_progress']
 
-async function getCleanupFlag(): Promise<string | null> {
-  return globalConfig.isMA
-    ? globalConfig.localStorage.getItem(CLEANUP_FLAG_KEY)
-    : Promise.resolve(globalConfig.localStorage.getItem(CLEANUP_FLAG_KEY))
-}
-
-async function setCleanupFlag(): Promise<void> {
-  if (globalConfig.isMA) {
-    await globalConfig.localStorage.setItem(CLEANUP_FLAG_KEY, '1')
-  } else {
-    globalConfig.localStorage.setItem(CLEANUP_FLAG_KEY, '1')
-  }
-}
-
 export async function repairStaleSyncedRecords(storesRegistry: Record<string, SyncStore<any>>) {
-  if (await getCleanupFlag()) return
+  const db = Object.values(storesRegistry)[0]!.db
+  // if (await db.localStorage.get<string>(CLEANUP_FLAG_KEY)) return // todo
 
   const cutoff = Date.now() - STALE_CUTOFF_MS
   const payload: Record<string, [id: string, updated_at: EpochMs][]> = {}
@@ -71,11 +57,10 @@ export async function repairStaleSyncedRecords(storesRegistry: Record<string, Sy
 
   if (preparedUpdates.length === 0) return
 
-  const db = Object.values(storesRegistry)[0]!.db
   await db.write(async () => {
     await db.batch(...preparedUpdates)
   })
 
   SyncTelemetry.getInstance()?.info('[SyncManager] repaired stale synced records', { records: repairedByTable })
-  await setCleanupFlag()
+  await db.write(() => db.localStorage.set(CLEANUP_FLAG_KEY, '1'))
 }

--- a/src/services/sync/stale-record-cleanup.ts
+++ b/src/services/sync/stale-record-cleanup.ts
@@ -1,0 +1,80 @@
+import { Q } from '@nozbe/watermelondb'
+import { POST } from '../../infrastructure/http/HttpClient'
+import { globalConfig } from '../config.js'
+import BaseModel from './models/Base'
+import type { default as SyncStore } from './store'
+import { SyncTelemetry } from './telemetry/index'
+
+const CLEANUP_FLAG_KEY = 'stale_synced_cleanup_v1'
+const STALE_CUTOFF_MS = 10_000
+const SYNC_TABLES = ['progress', 'content_likes', 'practices', 'practice_day_notes', 'user_award_progress']
+
+async function getCleanupFlag(): Promise<string | null> {
+  return globalConfig.isMA
+    ? globalConfig.localStorage.getItem(CLEANUP_FLAG_KEY)
+    : Promise.resolve(globalConfig.localStorage.getItem(CLEANUP_FLAG_KEY))
+}
+
+async function setCleanupFlag(): Promise<void> {
+  if (globalConfig.isMA) {
+    await globalConfig.localStorage.setItem(CLEANUP_FLAG_KEY, '1')
+  } else {
+    globalConfig.localStorage.setItem(CLEANUP_FLAG_KEY, '1')
+  }
+}
+
+export async function repairStaleSyncedRecords(storesRegistry: Record<string, SyncStore<any>>) {
+  if (await getCleanupFlag()) return
+
+  const cutoff = Date.now() - STALE_CUTOFF_MS
+  const payload: Record<string, [id: string, updated_at: number][]> = {}
+  const recordsByTable: Record<string, BaseModel[]> = {}
+
+  for (const table of SYNC_TABLES) {
+    const store = storesRegistry[table]
+    if (!store) continue
+
+    const records = (await store.db.read(() =>
+      store.db.get(table).query(
+        Q.where('_status', 'synced'),
+        Q.where('updated_at', Q.lt(cutoff))
+      ).fetch()
+    )) as BaseModel[]
+
+    if (records.length === 0) continue
+
+    payload[table] = records.map((r) => [r._raw.id, r._raw.updated_at as number])
+    recordsByTable[table] = records
+  }
+
+  if (Object.keys(payload).length === 0) return
+
+  const staleEntries: Record<string, [id: string, serverUpdatedAt: number][]> = await POST('/api/sync/v1/stale-record-check', payload)
+
+  const repairedByTable: Record<string, [id: string, localUpdatedAt: number, serverUpdatedAt: number][]> = {}
+  const preparedUpdates = Object.entries(staleEntries).flatMap(([table, entries]) => {
+    const records = recordsByTable[table] ?? []
+    const serverTimestampById = new Map(entries.map(([id, serverTs]) => [id, serverTs]))
+    return records
+      .filter((r) => serverTimestampById.has(r._raw.id))
+      .map((record) => {
+        const savedUpdatedAt = record._raw.updated_at as number
+        repairedByTable[table] ??= []
+        repairedByTable[table].push([record._raw.id, savedUpdatedAt, serverTimestampById.get(record._raw.id)!])
+        return record.prepareUpdate((r) => {
+          r._raw._status = 'updated'
+          r._raw.updated_at = savedUpdatedAt
+        })
+      })
+  })
+
+  if (preparedUpdates.length === 0) return
+
+  const db = Object.values(storesRegistry)[0]!.db
+  await db.write(async () => {
+    await db.batch(...preparedUpdates)
+  })
+
+  SyncTelemetry.getInstance()?.info('[SyncManager] repaired stale synced records', { records: repairedByTable })
+  await setCleanupFlag()
+}

--- a/src/services/sync/stale-record-cleanup.ts
+++ b/src/services/sync/stale-record-cleanup.ts
@@ -44,7 +44,7 @@ export async function repairStaleSyncedRecords(storesRegistry: Record<string, Sy
 
     if (records.length === 0) continue
 
-    payload[table] = records.map((r) => [r._raw.id, r._raw.updated_at as number])
+    payload[table] = records.map((r) => [r._raw.id, r._raw.updated_at as EpochMs])
     recordsByTable[table] = records
   }
 

--- a/src/services/sync/stale-record-cleanup.ts
+++ b/src/services/sync/stale-record-cleanup.ts
@@ -3,6 +3,7 @@ import { POST } from '../../infrastructure/http/HttpClient'
 import { globalConfig } from '../config.js'
 import BaseModel from './models/Base'
 import type { default as SyncStore } from './store'
+import type { EpochMs } from './index'
 import { SyncTelemetry } from './telemetry/index'
 
 const CLEANUP_FLAG_KEY = 'stale_synced_cleanup_v1'
@@ -27,7 +28,7 @@ export async function repairStaleSyncedRecords(storesRegistry: Record<string, Sy
   if (await getCleanupFlag()) return
 
   const cutoff = Date.now() - STALE_CUTOFF_MS
-  const payload: Record<string, [id: string, updated_at: number][]> = {}
+  const payload: Record<string, [id: string, updated_at: EpochMs][]> = {}
   const recordsByTable: Record<string, BaseModel[]> = {}
 
   for (const table of SYNC_TABLES) {
@@ -51,14 +52,14 @@ export async function repairStaleSyncedRecords(storesRegistry: Record<string, Sy
 
   const staleEntries: Record<string, [id: string, serverUpdatedAt: number][]> = await POST('/api/sync/v1/stale-record-check', payload)
 
-  const repairedByTable: Record<string, [id: string, localUpdatedAt: number, serverUpdatedAt: number][]> = {}
+  const repairedByTable: Record<string, [id: string, localUpdatedAt: EpochMs, serverUpdatedAt: number][]> = {}
   const preparedUpdates = Object.entries(staleEntries).flatMap(([table, entries]) => {
     const records = recordsByTable[table] ?? []
     const serverTimestampById = new Map(entries.map(([id, serverTs]) => [id, serverTs]))
     return records
       .filter((r) => serverTimestampById.has(r._raw.id))
       .map((record) => {
-        const savedUpdatedAt = record._raw.updated_at as number
+        const savedUpdatedAt = record._raw.updated_at as EpochMs
         repairedByTable[table] ??= []
         repairedByTable[table].push([record._raw.id, savedUpdatedAt, serverTimestampById.get(record._raw.id)!])
         return record.prepareUpdate((r) => {

--- a/src/services/sync/stale-record-cleanup.ts
+++ b/src/services/sync/stale-record-cleanup.ts
@@ -61,6 +61,6 @@ export async function repairStaleSyncedRecords(storesRegistry: Record<string, Sy
     await db.batch(...preparedUpdates)
   })
 
-  SyncTelemetry.getInstance()?.info('[SyncManager] repaired stale synced records', { records: repairedByTable })
+  SyncTelemetry.getInstance()?.log('[SyncManager] repaired stale synced records', { records: repairedByTable })
   await db.write(() => db.localStorage.set(CLEANUP_FLAG_KEY, '1'))
 }

--- a/test/unit/sync/stale-record-cleanup.test.ts
+++ b/test/unit/sync/stale-record-cleanup.test.ts
@@ -1,0 +1,107 @@
+import { Database } from '@nozbe/watermelondb'
+import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs'
+import schema, { SYNC_TABLES } from '@/services/sync/schema/index'
+import * as modelClasses from '@/services/sync/models/index'
+import { makeStore } from './helpers/index'
+import { repairStaleSyncedRecords } from '@/services/sync/stale-record-cleanup'
+import * as HttpClient from '@/infrastructure/http/HttpClient'
+
+function makeDatabase() {
+  const adapter = new LokiJSAdapter({
+    schema,
+    useWebWorker: false,
+    useIncrementalIndexedDB: false,
+    dbName: `test_stale_${Date.now()}_${Math.random()}`,
+    extraLokiOptions: { autosave: false },
+  })
+  return new Database({ adapter, modelClasses: Object.values(modelClasses) })
+}
+
+let db: Database
+let postMock: jest.SpyInstance
+
+beforeEach(() => {
+  db = makeDatabase()
+  postMock = jest.spyOn(HttpClient, 'POST').mockResolvedValue({})
+})
+
+afterEach(async () => {
+  await db.write(() => db.unsafeResetDatabase())
+  jest.restoreAllMocks()
+})
+
+test('marks stale synced records as updated when server has older updated_at', async () => {
+  const { store } = makeStore(modelClasses.ContentProgress, db)
+
+  const localUpdatedAt = Date.now() - 60_000
+  const serverUpdatedAt = localUpdatedAt - 5_000 // server is behind
+
+  await store.importUpsert([
+    {
+      id: 'stale-1',
+      server_record_id: 0,
+      content_id: 123,
+      content_brand: 'drumeo',
+      content_type: 'lesson',
+      content_parent_id: 0,
+      state: 'started',
+      progress_percent: 50,
+      collection_type: 'self',
+      collection_id: 0,
+      resume_time_seconds: null,
+      last_interacted_a_la_carte: 0,
+      created_at: localUpdatedAt,
+      updated_at: localUpdatedAt,
+      _status: 'synced',
+      _changed: '',
+    } as any,
+  ])
+
+  postMock.mockResolvedValue({
+    [SYNC_TABLES.CONTENT_PROGRESS]: [['stale-1', serverUpdatedAt]],
+  })
+
+  const storesRegistry = { [SYNC_TABLES.CONTENT_PROGRESS]: store }
+  await repairStaleSyncedRecords(storesRegistry)
+
+  const record = await db.read(() => db.get(SYNC_TABLES.CONTENT_PROGRESS).find('stale-1')) as any
+  store.destroy()
+
+  expect(record._raw._status).toBe('updated')
+})
+
+test('leaves records unchanged when server finds no stale entries', async () => {
+  const { store } = makeStore(modelClasses.ContentProgress, db)
+
+  const updatedAt = Date.now() - 60_000
+  await store.importUpsert([
+    {
+      id: 'fine-1',
+      server_record_id: 0,
+      content_id: 456,
+      content_brand: 'drumeo',
+      content_type: 'lesson',
+      content_parent_id: 0,
+      state: 'started',
+      progress_percent: 10,
+      collection_type: 'self',
+      collection_id: 0,
+      resume_time_seconds: null,
+      last_interacted_a_la_carte: 0,
+      created_at: updatedAt,
+      updated_at: updatedAt,
+      _status: 'synced',
+      _changed: '',
+    } as any,
+  ])
+
+  postMock.mockResolvedValue({})
+
+  const storesRegistry = { [SYNC_TABLES.CONTENT_PROGRESS]: store }
+  await repairStaleSyncedRecords(storesRegistry)
+
+  const record = await db.read(() => db.get(SYNC_TABLES.CONTENT_PROGRESS).find('fine-1')) as any
+  store.destroy()
+
+  expect(record._raw._status).toBe('synced')
+})


### PR DESCRIPTION
[Related MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/1136)

Adds stale record cleanup to fix broken stale records after #956.

Rough overall flow:
1. FE queries WatermelonDB: `_status='synced'`, `updated_at < NOW` → `[{id, updated_at}]`
2. POST to BE with that payload
3. BE: `SELECT id, client_updated_at WHERE id IN (...)`, returns IDs where `payload.updated_at > client_updated_at`
4. FE marks returned IDs as `_status='updated'`
5. Normal push runs, LWW resolves on server
6. Gate whole thing behind one-time flag so it never runs twice