### PR TITLE
chore(sanity): typescript decorators

### DIFF
--- a/src/lib/sanity/decorators/base.ts
+++ b/src/lib/sanity/decorators/base.ts
@@ -1,0 +1,48 @@
+export interface Decoratable {
+  children?: Decoratable[]
+  [key: string]: unknown
+}
+
+export type DecorateFn<T extends Decoratable, V> = (item: T) => V
+
+export interface FieldDecorator<T extends Decoratable, V = unknown> {
+  field: string
+  compute: DecorateFn<T, V>
+}
+
+const MAX_CHILD_DEPTH = 3
+
+export function decorate<T extends Decoratable, V>(
+  items: T | T[],
+  field: string,
+  compute: DecorateFn<T, V>
+): T | T[] {
+  return decorateAll(items, [{ field, compute }])
+}
+
+export function decorateAll<T extends Decoratable>(
+  items: T | T[],
+  decorators: ReadonlyArray<FieldDecorator<T>>
+): T | T[] {
+  const list = Array.isArray(items) ? items : [items]
+  for (const item of list) visit(item, decorators, 0)
+  return items
+}
+
+function visit<T extends Decoratable>(
+  item: T,
+  decorators: ReadonlyArray<FieldDecorator<T>>,
+  depth: number
+): void {
+  if (!item) return
+  const target = item as Record<string, unknown>
+  for (const { field, compute } of decorators) {
+    target[field] = compute(item)
+  }
+  if (depth >= MAX_CHILD_DEPTH - 1) return
+  const children = item.children
+  if (!Array.isArray(children)) return
+  for (const child of children) {
+    visit(child as T, decorators, depth + 1)
+  }
+}

--- a/src/lib/sanity/decorators/examples.ts
+++ b/src/lib/sanity/decorators/examples.ts
@@ -1,0 +1,76 @@
+import { decorateAll, type FieldDecorator } from './base'
+import {
+  accessDecorator,
+  decorateAccess,
+  type AccessDecoratable,
+} from './need-access'
+import {
+  pageTypeDecorator,
+  decoratePageType,
+  type PageTypeDecoratable,
+} from './page-type'
+import type { UserPermissions } from '../../../services/permissions'
+
+interface ContentRow extends AccessDecoratable, PageTypeDecoratable {
+  id: number
+  type?: string
+  permission_id?: number[]
+  children?: ContentRow[]
+}
+
+const perms: UserPermissions = {
+  permissions: [78, 91],
+  isAdmin: false,
+  isModerator: false,
+  isABasicMember: true,
+}
+
+const rows: ContentRow[] = [
+  {
+    id: 1,
+    type: 'course',
+    permission_id: [78],
+    children: [
+      { id: 2, type: 'song', permission_id: [91] },
+      { id: 3, type: 'play-along' },
+    ],
+  },
+]
+
+export function singleDecoratorViaWrapper() {
+  const decorated = decorateAccess(rows, perms)
+  const _na: boolean = decorated[0].need_access
+  return decorated
+}
+
+export function chainedWrappers() {
+  const withAccess = decorateAccess(rows, perms)
+  const withBoth = decoratePageType(withAccess)
+  const _na: boolean = withBoth[0].need_access
+  const _pt: 'song' | 'lesson' = withBoth[0].page_type
+  return withBoth
+}
+
+export function composedSingleWalk() {
+  type Composed = AccessDecoratable & PageTypeDecoratable
+  const decorators: FieldDecorator<Composed>[] = [
+    accessDecorator(perms) as FieldDecorator<Composed>,
+    pageTypeDecorator as FieldDecorator<Composed>,
+  ]
+  return decorateAll(rows, decorators)
+}
+
+export function conditionalComposition(opts: {
+  withAccess: boolean
+  withPageType: boolean
+}) {
+  type Composed = AccessDecoratable & PageTypeDecoratable
+  const decorators: FieldDecorator<Composed>[] = []
+  if (opts.withAccess) {
+    decorators.push(accessDecorator(perms) as FieldDecorator<Composed>)
+  }
+  if (opts.withPageType) {
+    decorators.push(pageTypeDecorator as FieldDecorator<Composed>)
+  }
+  return decorateAll(rows, decorators)
+}

--- a/src/lib/sanity/decorators/need-access.ts
+++ b/src/lib/sanity/decorators/need-access.ts
@@ -1,11 +1,16 @@
 import { decorate, type Decoratable, type FieldDecorator } from './base'
 import { getPermissionsAdapter, type UserPermissions } from '../../../services/permissions'
 
-export const NEED_ACCESS_FIELD = 'need_access'
+export const NEED_ACCESS_FIELD = 'need_access' as const
 
 export interface AccessDecoratable extends Decoratable {
   permission_id?: number[]
   children?: AccessDecoratable[]
+}
+
+export type WithNeedAccess<T extends AccessDecoratable> = T & {
+  [NEED_ACCESS_FIELD]: boolean
+  children?: WithNeedAccess<NonNullable<T['children']>[number]>[]
 }
 
 export function accessDecorator(
@@ -19,9 +24,19 @@ export function accessDecorator(
 }
 
 export function decorateAccess<T extends AccessDecoratable>(
+  items: T[],
+  userPermissions: UserPermissions
+): WithNeedAccess<T>[]
+export function decorateAccess<T extends AccessDecoratable>(
+  items: T,
+  userPermissions: UserPermissions
+): WithNeedAccess<T>
+export function decorateAccess<T extends AccessDecoratable>(
   items: T | T[],
   userPermissions: UserPermissions
-): T | T[] {
+): WithNeedAccess<T> | WithNeedAccess<T>[] {
   const { field, compute } = accessDecorator(userPermissions)
-  return decorate<AccessDecoratable, boolean>(items, field, compute) as T | T[]
+  return decorate<AccessDecoratable, boolean>(items, field, compute) as
+    | WithNeedAccess<T>
+    | WithNeedAccess<T>[]
 }

--- a/src/lib/sanity/decorators/need-access.ts
+++ b/src/lib/sanity/decorators/need-access.ts
@@ -1,0 +1,27 @@
+import { decorate, type Decoratable, type FieldDecorator } from './base'
+import { getPermissionsAdapter, type UserPermissions } from '../../../services/permissions'
+
+export const NEED_ACCESS_FIELD = 'need_access'
+
+export interface AccessDecoratable extends Decoratable {
+  permission_id?: number[]
+  children?: AccessDecoratable[]
+}
+
+export function accessDecorator(
+  userPermissions: UserPermissions
+): FieldDecorator<AccessDecoratable, boolean> {
+  const adapter = getPermissionsAdapter()
+  return {
+    field: NEED_ACCESS_FIELD,
+    compute: (item) => adapter.doesUserNeedAccess(item, userPermissions),
+  }
+}
+
+export function decorateAccess<T extends AccessDecoratable>(
+  items: T | T[],
+  userPermissions: UserPermissions
+): T | T[] {
+  const { field, compute } = accessDecorator(userPermissions)
+  return decorate<AccessDecoratable, boolean>(items, field, compute) as T | T[]
+}

--- a/src/lib/sanity/decorators/page-type.ts
+++ b/src/lib/sanity/decorators/page-type.ts
@@ -1,0 +1,33 @@
+import { decorate, type Decoratable, type FieldDecorator } from './base'
+import { SONG_TYPES_WITH_CHILDREN } from '../../../contentTypeConfig.js'
+
+export const PAGE_TYPE_FIELD = 'page_type' as const
+
+export type PageType = 'song' | 'lesson'
+
+export interface PageTypeDecoratable extends Decoratable {
+  type?: string
+  children?: PageTypeDecoratable[]
+}
+
+export type WithPageType<T extends PageTypeDecoratable> = T & {
+  [PAGE_TYPE_FIELD]: PageType
+  children?: WithPageType<NonNullable<T['children']>[number]>[]
+}
+
+export const pageTypeDecorator: FieldDecorator<PageTypeDecoratable, PageType> = {
+  field: PAGE_TYPE_FIELD,
+  compute: (item) => (SONG_TYPES_WITH_CHILDREN.includes(item.type as string) ? 'song' : 'lesson'),
+}
+
+export function decoratePageType<T extends PageTypeDecoratable>(items: T[]): WithPageType<T>[]
+export function decoratePageType<T extends PageTypeDecoratable>(items: T): WithPageType<T>
+export function decoratePageType<T extends PageTypeDecoratable>(
+  items: T | T[]
+): WithPageType<T> | WithPageType<T>[] {
+  return decorate<PageTypeDecoratable, PageType>(
+    items,
+    pageTypeDecorator.field,
+    pageTypeDecorator.compute
+  ) as WithPageType<T> | WithPageType<T>[]
+}

--- a/test/unit/lib/sanity/decorators/base.test.ts
+++ b/test/unit/lib/sanity/decorators/base.test.ts
@@ -1,0 +1,102 @@
+import { decorate, decorateAll, type Decoratable, type FieldDecorator } from '../../../../../src/lib/sanity/decorators/base'
+
+describe('base decorator', () => {
+  describe('decorate', () => {
+    test('sets field on single object', () => {
+      const item: Decoratable = { id: 1 }
+      decorate(item, 'mark', () => 'A')
+      expect(item.mark).toBe('A')
+    })
+
+    test('sets field on every item in array', () => {
+      const items: Decoratable[] = [{ id: 1 }, { id: 2 }, { id: 3 }]
+      decorate(items, 'mark', (i) => i.id)
+      expect(items.map((i) => i.mark)).toEqual([1, 2, 3])
+    })
+
+    test('returns the same reference it was given', () => {
+      const items: Decoratable[] = [{ id: 1 }]
+      const result = decorate(items, 'mark', () => true)
+      expect(result).toBe(items)
+    })
+
+    test('recurses children up to 3 levels deep', () => {
+      const tree: Decoratable = {
+        id: 1,
+        children: [
+          {
+            id: 2,
+            children: [
+              {
+                id: 3,
+                children: [{ id: 4 }],
+              },
+            ],
+          },
+        ],
+      }
+      decorate(tree, 'visited', () => true)
+
+      expect(tree.visited).toBe(true)
+      const lvl1 = (tree.children as Decoratable[])[0]
+      const lvl2 = (lvl1.children as Decoratable[])[0]
+      const lvl3 = (lvl2.children as Decoratable[])[0]
+      expect(lvl1.visited).toBe(true)
+      expect(lvl2.visited).toBe(true)
+      expect(lvl3.visited).toBeUndefined()
+    })
+
+    test('ignores missing or non-array children', () => {
+      const item: Decoratable = { id: 1 }
+      expect(() => decorate(item, 'mark', () => 1)).not.toThrow()
+      expect(item.mark).toBe(1)
+
+      const bad: Decoratable = { id: 1, children: 'not-an-array' as unknown as Decoratable[] }
+      expect(() => decorate(bad, 'mark', () => 1)).not.toThrow()
+      expect(bad.mark).toBe(1)
+    })
+
+    test('passes the visited item to the compute callback', () => {
+      const item: Decoratable = { id: 7, label: 'x' }
+      const compute = jest.fn(() => 'ok')
+      decorate(item, 'mark', compute)
+      expect(compute).toHaveBeenCalledTimes(1)
+      expect(compute).toHaveBeenCalledWith(item)
+    })
+  })
+
+  describe('decorateAll', () => {
+    test('applies every decorator on a single walk', () => {
+      const items: Decoratable[] = [{ id: 1, children: [{ id: 2 }] }]
+      const a: FieldDecorator<Decoratable> = { field: 'a', compute: () => 'A' }
+      const b: FieldDecorator<Decoratable> = { field: 'b', compute: () => 'B' }
+      decorateAll(items, [a, b])
+
+      expect(items[0].a).toBe('A')
+      expect(items[0].b).toBe('B')
+      const child = (items[0].children as Decoratable[])[0]
+      expect(child.a).toBe('A')
+      expect(child.b).toBe('B')
+    })
+
+    test('empty decorator list is a no-op', () => {
+      const items: Decoratable[] = [{ id: 1 }]
+      decorateAll(items, [])
+      expect(Object.keys(items[0])).toEqual(['id'])
+    })
+
+    test('visits each item exactly once even with multiple decorators', () => {
+      const items: Decoratable[] = [{ id: 1, children: [{ id: 2 }, { id: 3 }] }]
+      const seen: number[] = []
+      const probe: FieldDecorator<Decoratable> = {
+        field: 'probe',
+        compute: (item) => {
+          seen.push(item.id as number)
+          return true
+        },
+      }
+      decorateAll(items, [probe, probe])
+      expect(seen.sort()).toEqual([1, 1, 2, 2, 3, 3])
+    })
+  })
+})

--- a/test/unit/lib/sanity/decorators/need-access.test.ts
+++ b/test/unit/lib/sanity/decorators/need-access.test.ts
@@ -1,0 +1,89 @@
+const mockDoesUserNeedAccess = jest.fn()
+
+jest.mock('../../../../../src/services/permissions', () => ({
+  getPermissionsAdapter: () => ({
+    doesUserNeedAccess: mockDoesUserNeedAccess,
+  }),
+}))
+
+import {
+  NEED_ACCESS_FIELD,
+  accessDecorator,
+  decorateAccess,
+  type AccessDecoratable,
+} from '../../../../../src/lib/sanity/decorators/need-access'
+
+const perms = {
+  permissions: [78, 91],
+  isAdmin: false,
+  isModerator: false,
+  isABasicMember: false,
+}
+
+describe('need-access decorator', () => {
+  beforeEach(() => {
+    mockDoesUserNeedAccess.mockReset()
+  })
+
+  describe('accessDecorator (factory)', () => {
+    test('field is need_access', () => {
+      const dec = accessDecorator(perms)
+      expect(dec.field).toBe('need_access')
+      expect(NEED_ACCESS_FIELD).toBe('need_access')
+    })
+
+    test('compute delegates to adapter with item + perms', () => {
+      mockDoesUserNeedAccess.mockReturnValue(true)
+      const dec = accessDecorator(perms)
+      const item: AccessDecoratable = { permission_id: [78] }
+
+      const result = dec.compute(item)
+
+      expect(result).toBe(true)
+      expect(mockDoesUserNeedAccess).toHaveBeenCalledWith(item, perms)
+    })
+  })
+
+  describe('decorateAccess', () => {
+    test('writes adapter result onto each item', () => {
+      mockDoesUserNeedAccess.mockImplementation((item) =>
+        item.permission_id?.includes(78) ? false : true
+      )
+
+      const items: AccessDecoratable[] = [
+        { permission_id: [78] },
+        { permission_id: [999] },
+        {},
+      ]
+      const decorated = decorateAccess(items, perms)
+
+      expect(decorated.map((i) => i.need_access)).toEqual([false, true, true])
+    })
+
+    test('decorates children recursively', () => {
+      mockDoesUserNeedAccess.mockReturnValue(true)
+      const tree: AccessDecoratable = {
+        permission_id: [],
+        children: [
+          {
+            permission_id: [],
+            children: [{ permission_id: [] }],
+          },
+        ],
+      }
+
+      const decorated = decorateAccess(tree, perms)
+
+      expect(decorated.need_access).toBe(true)
+      expect(decorated.children![0].need_access).toBe(true)
+      expect(decorated.children![0].children![0].need_access).toBe(true)
+    })
+
+    test('returns the same reference it was given', () => {
+      mockDoesUserNeedAccess.mockReturnValue(false)
+      const items: AccessDecoratable[] = [{ permission_id: [78] }]
+      const decorated = decorateAccess(items, perms)
+      expect(decorated).toBe(items)
+    })
+  })
+})

--- a/test/unit/lib/sanity/decorators/page-type.test.ts
+++ b/test/unit/lib/sanity/decorators/page-type.test.ts
@@ -1,0 +1,81 @@
+import {
+  PAGE_TYPE_FIELD,
+  decoratePageType,
+  pageTypeDecorator,
+  type PageTypeDecoratable,
+} from '../../../../../src/lib/sanity/decorators/page-type'
+
+describe('page-type decorator', () => {
+  describe('pageTypeDecorator (const)', () => {
+    test('field is page_type', () => {
+      expect(pageTypeDecorator.field).toBe('page_type')
+      expect(PAGE_TYPE_FIELD).toBe('page_type')
+    })
+
+    test.each([
+      ['song', 'song'],
+      ['play-along', 'song'],
+      ['jam-track', 'song'],
+      ['song-tutorial', 'song'],
+      ['song-tutorial-lesson', 'song'],
+      ['course', 'lesson'],
+      ['workout', 'lesson'],
+      ['', 'lesson'],
+    ])('type=%j -> %s', (type, expected) => {
+      expect(pageTypeDecorator.compute({ type })).toBe(expected)
+    })
+
+    test('missing type falls through to lesson', () => {
+      expect(pageTypeDecorator.compute({})).toBe('lesson')
+    })
+  })
+
+  describe('decoratePageType', () => {
+    test('decorates a single object', () => {
+      const item: PageTypeDecoratable = { type: 'song' }
+      const decorated = decoratePageType(item)
+      expect(decorated.page_type).toBe('song')
+    })
+
+    test('decorates every item in an array', () => {
+      const items: PageTypeDecoratable[] = [
+        { type: 'song' },
+        { type: 'course' },
+        { type: 'play-along' },
+      ]
+      const decorated = decoratePageType(items)
+      expect(decorated.map((i) => i.page_type)).toEqual(['song', 'lesson', 'song'])
+    })
+
+    test('decorates nested children up to depth 3', () => {
+      const tree: PageTypeDecoratable = {
+        type: 'course',
+        children: [
+          {
+            type: 'song',
+            children: [
+              {
+                type: 'play-along',
+                children: [{ type: 'song' }],
+              },
+            ],
+          },
+        ],
+      }
+      const decorated = decoratePageType(tree)
+      expect(decorated.page_type).toBe('lesson')
+      const lvl1 = decorated.children![0]
+      const lvl2 = lvl1.children![0]
+      const lvl3 = lvl2.children![0]
+      expect(lvl1.page_type).toBe('song')
+      expect(lvl2.page_type).toBe('song')
+      expect(lvl3.page_type).toBeUndefined()
+    })
+
+    test('preserves the input reference', () => {
+      const items: PageTypeDecoratable[] = [{ type: 'song' }]
+      const decorated = decoratePageType(items)
+      expect(decorated).toBe(items)
+    })
+  })
+})


### PR DESCRIPTION
## Description/Design

- Refactors our need access and page type decorators:
  - Type-safety with typescript
  - Strict interface for base and specialized decorators
  - Base decorator has a much simpler logic, content needs to be in the correct shape (not if-else extravaganza)
  - Single walk decorator pipeline
  - Extract unnecessary logic up to the caller. Decorators decorate based on explicit inputs.

## Next steps

- Allow async decorators: #968 
