### PR TITLE
feat(TP-1195): optimize live event loading

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -695,7 +695,9 @@ export let contentTypeConfig = {
     }`,
   ],
   'new-and-scheduled': {
-    fields: ['show_in_new_feed', isLiveField()],
+    fields: [
+      'show_in_new_feed',
+    ],
     includeChildFields: true,
   },
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1216,7 +1216,7 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
   const filter = await new FilterBuilder(baseFilter, { bypassPermissions: true }).buildFilter()
 
   const events = await fetchSanity(
-    `*[${filter}]{${liveEventFields}} | order(live_event_start_time asc)`,
+    `*[${filter}]{${fieldsString}} | order(live_event_start_time asc)`,
     true,
     { processNeedAccess: false }
   )

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1193,13 +1193,11 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
     default:
       break
   }
-  let startDateTemp = new Date()
-  let endDateTemp = new Date()
 
-  startDateTemp = new Date(
-    startDateTemp.setMinutes(startDateTemp.getMinutes() + LIVE_EXTRA_MINUTES)
-  )
-  endDateTemp = new Date(endDateTemp.setMinutes(endDateTemp.getMinutes() - LIVE_EXTRA_MINUTES))
+  const now = new Date()
+  now.setMinutes(now.getMinutes() - LIVE_EXTRA_MINUTES)
+
+  const startOfToday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())).toISOString()
 
   const liveEventFields = getLiveFields().concat(
     `'event_coach_calendar_id': coalesce(calendar_id, '${defaultCalendarID}')`
@@ -1212,15 +1210,24 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
       : `status == 'scheduled'
       && (brand == '${brand}' || live_global_event == true)
       && defined(live_event_start_time)
-      && live_event_start_time <= '${getSanityDate(startDateTemp, false)}'
-      && live_event_end_time >= '${getSanityDate(endDateTemp, false)}'`
+      && live_event_start_time >= '${startOfToday}'`
 
   const filter = await new FilterBuilder(baseFilter, { bypassPermissions: true }).buildFilter()
 
-  // This query finds the first scheduled event (sorted by start_time) that ends after now()
-  const query = `*[${filter}]{${fieldsString}} | order(live_event_start_time)[0...1]`
+  const events = await fetchSanity(
+    `*[${filter}]{${liveEventFields}} | order(live_event_start_time asc)`,
+    true,
+    { processNeedAccess: false }
+  )
 
-  return await fetchSanity(query, false, { processNeedAccess: true })
+  const clientNow = new Date()
+  const windowStart = new Date(clientNow.getTime() - LIVE_EXTRA_MINUTES * 60000).toISOString()
+  const windowEnd = new Date(clientNow.getTime() + LIVE_EXTRA_MINUTES * 60000).toISOString()
+
+  return events?.find(event =>
+    event.live_event_end_time >= windowStart &&
+    event.live_event_start_time <= windowEnd
+  ) ?? null
 }
 
 /**
@@ -2224,7 +2231,14 @@ export async function fetchScheduledAndNewReleases(
     return []
   }
 
-  return reorderScheduledAndNewReleases(r, limit)
+  const reordered = reorderScheduledAndNewReleases(r, limit)
+  const computedNow = new Date()
+  return reordered.map(item => ({
+    ...item,
+    isLive: item.live_event_start_time && item.live_event_end_time
+      ? new Date(item.live_event_start_time) <= computedNow && new Date(item.live_event_end_time) >= computedNow
+      : false,
+  }))
 }
 
 function reorderScheduledAndNewReleases(r, limit) {

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1195,9 +1195,9 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
   }
 
   const now = new Date()
-  now.setMinutes(now.getMinutes() - LIVE_EXTRA_MINUTES)
 
-  const startOfToday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())).toISOString()
+  const startOfYesterday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1)).toISOString()
+  const endOfTomorrow = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 2)).toISOString()
 
   const liveEventFields = getLiveFields().concat(
     `'event_coach_calendar_id': coalesce(calendar_id, '${defaultCalendarID}')`
@@ -1210,7 +1210,8 @@ export async function fetchLiveEvent(brand, forcedContentId = null) {
       : `status == 'scheduled'
       && (brand == '${brand}' || live_global_event == true)
       && defined(live_event_start_time)
-      && live_event_start_time >= '${startOfToday}'`
+      && live_event_start_time >= '${startOfYesterday}'
+      && live_event_start_time < '${endOfTomorrow}'`
 
   const filter = await new FilterBuilder(baseFilter, { bypassPermissions: true }).buildFilter()
 


### PR DESCRIPTION
Improvement off of #930.

Adds an upper bound to sanity query, and changes filter to be start-of-yesterday to end-of-tomorrow (UTC) to avoid edge cases around when clock passes midnight

Will change base to `main` once re-approved