### PR TITLE
fix: do immediate push after record repair

### DIFF
--- a/src/services/sync/stale-record-cleanup.ts
+++ b/src/services/sync/stale-record-cleanup.ts
@@ -63,4 +63,11 @@ export async function repairStaleSyncedRecords(storesRegistry: Record<string, Sy
 
   SyncTelemetry.getInstance()?.log('[SyncManager] repaired stale synced records', { records: repairedByTable })
   await db.write(() => db.localStorage.set(CLEANUP_FLAG_KEY, '1'))
+
+  for (const table of SYNC_TABLES) {
+    const store = storesRegistry[table]
+    if (!store) continue
+
+    await store.pushUnsyncedWithRetry()
+  }
 }


### PR DESCRIPTION
Does an immediate push of repaired records, for #963.

Easier debugging/verification in production.

Tested push call locally.