### PR TITLE
fix(live-events): fetch permission ids

### DIFF
--- a/.agent/decisions/2026-05-20-live-event-fetch-permissions-id.md
+++ b/.agent/decisions/2026-05-20-live-event-fetch-permissions-id.md
@@ -1,0 +1,23 @@
+---
+date: 2026-05-20
+branch: fix/live-event-fetch-permissions-id
+pr: https://github.com/railroadmedia/musora-content-services/pull/982
+status: open
+tags: [bug-fix]
+---
+
+# Include permission_id in live event minimum fields
+
+## Context
+Live event consumers downstream of `getLiveFields()` need `permission_id` to resolve access to events. Without it on the returned payload, callers had to issue an extra query (or fall back to defaults) to determine whether the current user is permitted to view a given live event.
+
+## Decision
+Add `'permission_id'` to the `minimumFields` array in `getLiveFields()` in `src/contentTypeConfig.js` so the field is projected from Sanity alongside the other core live event fields (`live_event_start_time`, `live_event_end_time`, `live_event_stream_id`, `vimeo_live_event_id`, etc.).
+
+## Alternatives Considered
+- Put `permission_id` in `additionalFields` instead of `minimumFields`. Rejected — callers requesting the minimum projection are the ones that gate playback, so they need permission resolution by default.
+- Fetch `permission_id` in a separate query at the consumer layer. Rejected — duplicates Sanity round-trips and spreads access logic.
+
+## Consequences
+- All live event responses produced via `getLiveFields()` now include `permission_id`.
+- Incidental formatting (single-quote and trailing-comma normalization) was applied to the same file by the editor — not behavioral.

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -146,22 +146,23 @@ export const assignmentsField = `"assignments":assignment[]{
 // todo: refactor live event queries to use this
 export function getLiveFields(minimum = false) {
   const minimumFields = [
-    "live_event_start_time",
-    "live_event_end_time",
-    "live_event_stream_id",
-    "vimeo_live_event_id",
+    'live_event_start_time',
+    'live_event_end_time',
+    'live_event_stream_id',
+    'vimeo_live_event_id',
     "'live_event_is_global': live_global_event == true",
     "'videoId': coalesce(live_event_stream_id, video.external_id)",
+    'permission_id',
   ]
   const additionalFields = [
     "'slug': slug.current",
     "'id': railcontent_id",
-    "title",
-    "published_on",
+    'title',
+    'published_on',
     "'thumbnail': thumbnail.asset->url",
     `${artistOrInstructorName()}`,
-    "difficulty_string",
-    "railcontent_id",
+    'difficulty_string',
+    'railcontent_id',
     `'instructors': ${instructorField}`,
   ]
 
@@ -694,10 +695,7 @@ export let contentTypeConfig = {
     }`,
   ],
   'new-and-scheduled': {
-    fields: [
-      'show_in_new_feed',
-      isLiveField(),
-    ],
+    fields: ['show_in_new_feed', isLiveField()],
     includeChildFields: true,
   },
 }
@@ -816,7 +814,7 @@ export function artistOrInstructorNameAsArray(key = 'artists') {
 
 export async function getFieldsForContentTypeWithFilteredChildren(
   contentType,
-  asQueryString = true,
+  asQueryString = true
 ) {
   const childFields = getChildFieldsForContentType(contentType, true)
   const parentFields = getFieldsForContentType(contentType, false)
@@ -831,7 +829,7 @@ export async function getFieldsForContentTypeWithFilteredChildren(
         "children": child[${childFilter}]->{
           ${childFields}
         },
-      }`,
+      }`
     )
   }
   return asQueryString ? parentFields.toString() + ',' : parentFields
@@ -921,7 +919,7 @@ const filterHandlers = {
   length: (value) => {
     // Find the matching length option by name
     const lengthOption = Object.values(LengthFilterOptions).find(
-      (opt) => typeof opt === 'object' && opt.name === value,
+      (opt) => typeof opt === 'object' && opt.name === value
     )
 
     if (!lengthOption) return ''

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -152,7 +152,7 @@ export function getLiveFields(minimum = false) {
     'vimeo_live_event_id',
     "'live_event_is_global': live_global_event == true",
     "'videoId': coalesce(live_event_stream_id, video.external_id)",
-    'permission_id',
+    "'permission_id': permission_v2",
   ]
   const additionalFields = [
     "'slug': slug.current",


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- N/A

## Description/Design

- Add `permission_id` to the minimum live event fields returned by `getLiveFields()` so live event consumers can resolve access without an extra query.

## Testing

- How to verify: call any live event query path that uses `getLiveFields()` and confirm `permission_id` is present on the returned payload.
- Environment: local
- Expected outcome: live event responses include `permission_id` alongside existing live fields.

## Additional Notes

- Remaining diff in `contentTypeConfig.js` is incidental Prettier-style formatting (quote and trailing-comma normalization).