### PR TITLE
fix: parse stringified json completion data

### DIFF
--- a/src/services/awards/award-query.js
+++ b/src/services/awards/award-query.js
@@ -391,6 +391,9 @@ export async function getCompletedAwardsByUser(userId = globalConfig.sessionConf
           return null
         }
 
+        // this data comes from BE so json is stringified
+        progress.completion_data = JSON.parse(progress.completion_data)
+
         const completionData = definition.type === awardDefinitions.CONTENT_AWARD
           ? enhanceCompletionData(progress.completion_data)
           : progress.completion_data


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- none

## Description/Design

- for public profiles, we fetch user award data from BE, and this data comes as stringified json. we need to parse it.

## Testing

- use `mcs call` to call `getCompletedAwardsByUser` and see that response is json data.