### PR TITLE
chore(BR-688): Consolidate algolia to BE

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -363,6 +363,10 @@ import {
 } from './services/sanity.js';
 
 import {
+	searchAlgolia
+} from './services/search.ts';
+
+import {
 	clearState
 } from './services/state.ts';
 
@@ -793,6 +797,7 @@ declare module 'musora-content-services' {
 		restoreUserActivity,
 		restoreUserPractice,
 		search,
+		searchAlgolia,
 		sendAccountSetupEmail,
 		sendPasswordResetEmail,
 		setStudentViewForUser,

--- a/src/index.js
+++ b/src/index.js
@@ -367,6 +367,10 @@ import {
 } from './services/sanity.js';
 
 import {
+	searchAlgolia
+} from './services/search.ts';
+
+import {
 	clearState
 } from './services/state.ts';
 
@@ -792,6 +796,7 @@ export {
 	restoreUserActivity,
 	restoreUserPractice,
 	search,
+	searchAlgolia,
 	sendAccountSetupEmail,
 	sendPasswordResetEmail,
 	setStudentViewForUser,

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -1,0 +1,19 @@
+import { POST } from '../infrastructure/http/HttpClient'
+
+export interface AlgoliaSearchRequest {
+    query?: string
+    hitsPerPage?: number
+    page?: number
+    [key: string]: unknown
+}
+
+export interface AlgoliaSearchResponse {
+    // Shape varies by index configuration and query — MPB passes Algolia's response through unchanged
+    results: unknown[]
+}
+
+export async function searchAlgolia(
+    requests: AlgoliaSearchRequest[]
+): Promise<AlgoliaSearchResponse> {
+    return POST('/api/content/v1/search', { requests }) as Promise<AlgoliaSearchResponse>
+}

--- a/test/unit/search.test.ts
+++ b/test/unit/search.test.ts
@@ -1,0 +1,44 @@
+import { searchAlgolia } from '../../src/services/search'
+
+const mockPost = jest.fn()
+
+jest.mock('../../src/infrastructure/http/HttpClient', () => ({
+    POST: (...args: unknown[]) => mockPost(...args),
+}))
+
+describe('searchAlgolia', () => {
+    beforeEach(() => {
+        mockPost.mockReset()
+    })
+
+    test('posts requests to the correct endpoint', async () => {
+        mockPost.mockResolvedValue({ results: [] })
+
+        await searchAlgolia([{ query: 'drum', hitsPerPage: 5 }])
+
+        expect(mockPost).toHaveBeenCalledWith('/api/content/v1/search', {
+            requests: [{ query: 'drum', hitsPerPage: 5 }],
+        })
+    })
+
+    test('returns the response from the endpoint', async () => {
+        const mockResponse = {
+            results: [{ hits: [{ objectID: 'abc123' }], nbHits: 1 }],
+        }
+        mockPost.mockResolvedValue(mockResponse)
+
+        const result = await searchAlgolia([{ query: 'drum' }])
+
+        expect(result).toEqual(mockResponse)
+    })
+
+    test('passes multiple requests', async () => {
+        mockPost.mockResolvedValue({ results: [] })
+
+        await searchAlgolia([{ query: 'drum' }, { query: 'piano' }])
+
+        expect(mockPost).toHaveBeenCalledWith('/api/content/v1/search', {
+            requests: [{ query: 'drum' }, { query: 'piano' }],
+        })
+    })
+})


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [BR-688](https://musora.atlassian.net/browse/BR-688) — BE: Consolidate Algolia search through BE to fix permission filter scaling issue
- [BR-634](https://musora.atlassian.net/browse/BR-634) — BE: Search Results Blank/Error Across All Platforms

## Description/Design

- Users with many permissions were hitting 414 Request-URI Too Large when Algolia secured keys embedded all permission filters as URL query params — the filter string simply grew too long.
- Added POST /api/content/v1/search endpoint that accepts standard Algolia multi-index request bodies, injects filters, optionalFilters, and indexName server-side, and proxies to Algolia using the real API key. The response is passed through unchanged so existing client libraries work without modification.
- Admin users get unrestricted passthrough with no filters injected.
- getSecuredKey endpoint is unchanged — still used for query suggestions.
- Added searchAlgolia() in MCS as a thin wrapper to call this endpoint.

## Testing

- Authenticate as a user with many permissions (or any user) and trigger an Algolia search
- Confirm search results return successfully with no 414 error
- Authenticate as an admin user and confirm unfiltered results are returned
- The existing getSecuredKey endpoint should still work for query suggestions

## Additional Notes

- indexName is now injected server-side from config — any indexName sent by the client is overwritten. This is intentional.
- FE (BR-691) and Mobile (BR-690) still need to swap their searchClient to call this endpoint via a custom adapter.

[BR-688]: https://musora.atlassian.net/browse/BR-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BR-634]: https://musora.atlassian.net/browse/BR-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ