### PR TITLE
fix(BR-654): dont set resume-time to null

### DIFF
--- a/src/services/contentProgress.js
+++ b/src/services/contentProgress.js
@@ -841,7 +841,7 @@ export function filterOutLearningPathsForDuplication(progresses, collection) {
 
 export async function duplicateProgressForIds(entries) {
   return Promise.all(Object.entries(entries).map(([id, pct]) => {
-    return saveContentProgress(parseInt(id), null, pct, null, { skipPush: true, accessedDirectly: false })
+    return saveContentProgress(parseInt(id), null, pct, undefined, { skipPush: true, accessedDirectly: false })
   }))
 }
 


### PR DESCRIPTION
[BR-654](https://musora.atlassian.net/browse/BR-654)

`null` was being passed to `saveContentProgress`, which means something different than `undefined`. Passing `undefined` instead will not alter resume time at all.

[BR-654]: https://musora.atlassian.net/browse/BR-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ