### PR TITLE
feat: add need access logic branch for LPs

### DIFF
--- a/src/services/content-org/learning-paths.ts
+++ b/src/services/content-org/learning-paths.ts
@@ -222,7 +222,7 @@ export async function resetAllLearningPaths() {
  * @param {number} learningPathId - The learning path ID
  * @returns {Promise<Object>} Learning path with enriched lesson data
  */
-export async function getEnrichedLearningPath(learningPathId) {
+export async function getEnrichedLearningPath(learningPathId: number) {
   let response = (await addContextToLearningPaths(
     fetchByRailContentId,
     learningPathId,

--- a/src/services/permissions/PermissionsV2Adapter.ts
+++ b/src/services/permissions/PermissionsV2Adapter.ts
@@ -55,6 +55,9 @@ export class PermissionsV2Adapter extends PermissionsAdapter {
 
     // Content with no permissions is accessible to all
     if (contentPermissions.size === 0) {
+      if (content?.type === 'learning-path-v2' && content?.children?.length) {
+        return content.children.every(child => child.need_access)
+      }
       return false
     }
 

--- a/src/services/permissions/PermissionsV2Adapter.ts
+++ b/src/services/permissions/PermissionsV2Adapter.ts
@@ -19,7 +19,7 @@ import {
 } from './permissions'
 import {arrayToRawRepresentation, arrayToStringRepresentation} from '../../filterBuilder.js'
 import {basicMembershipTier, plusMembershipTier} from "../../contentTypeConfig";
-import { COLLECTION_TYPE } from '@/services/sync/models/ContentProgress'
+import { COLLECTION_TYPE } from '../sync/models/ContentProgress'
 
 /**
  * V2 Permissions Adapter for the new permissions system.

--- a/src/services/permissions/PermissionsV2Adapter.ts
+++ b/src/services/permissions/PermissionsV2Adapter.ts
@@ -19,6 +19,7 @@ import {
 } from './permissions'
 import {arrayToRawRepresentation, arrayToStringRepresentation} from '../../filterBuilder.js'
 import {basicMembershipTier, plusMembershipTier} from "../../contentTypeConfig";
+import { COLLECTION_TYPE } from '@/services/sync/models/ContentProgress'
 
 /**
  * V2 Permissions Adapter for the new permissions system.
@@ -55,7 +56,7 @@ export class PermissionsV2Adapter extends PermissionsAdapter {
 
     // Content with no permissions is accessible to all
     if (contentPermissions.size === 0) {
-      if (content?.type === 'learning-path-v2' && content?.children?.length) {
+      if (content?.type === COLLECTION_TYPE.LEARNING_PATH && content?.children?.length) {
         return content.children.every(child => child.need_access)
       }
       return false

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1675,8 +1675,8 @@ function contentResultsDecorator(results, fieldName, callback) {
           processChildren(contentItem)
         })
       } else {
-        result[fieldName] = callback(result)
         processChildren(result)
+        result[fieldName] = callback(result)
       }
     })
   } else if (results.entity && Array.isArray(results.entity)) {

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -1713,8 +1713,8 @@ function contentResultsDecorator(results, fieldName, callback) {
       }
     })
   } else {
+    processChildren(results)
     results[fieldName] = callback(results)
-    processChildren(results) // this on was always true
   }
 
   return results


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- LPs are a special case where they have no content permissions, but their children do. Their children are not "owned" by the LP but "borrowed" from skill packs and song tutorials. his means that our current need_access decorator reads the LP as having no permissions and therefore sets `need_access` as `false`, even if all lessons within it get set as `need_access=true`.

## Description/Design

- updates needAccessDecorator to run on children first (bottom of hierarchy up), and use children `need_access` values to determine parent's `need_access` if its an LP.

## Testing

- use `staging` sanity dataset, head to FE devendpoint. (or use BE mcs-call)
- call `fetchByRailContentIds` with `[452387], 'learning-path-v2'`
- call `fetchByRailContentId` with `452387, 'learning-path-v2'`
- both should set `need_access: true` on the parent. (and all children should be too)

## Additional Notes

- we could optionally remove the type check, since this is likely code we'd want run on all types.
