### PR TITLE
feat(BEHSTP-364): User video player settings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -461,6 +461,11 @@ import {
 } from './services/user/payments.ts';
 
 import {
+	fetchPlayerSettings,
+	updatePlayerSettings
+} from './services/user/playerSettings.ts';
+
+import {
 	deleteProfilePicture,
 	otherStats,
 	updateProfileVisibility
@@ -624,6 +629,7 @@ declare module 'musora-content-services' {
 		fetchPackData,
 		fetchParentChildRelationshipsFor,
 		fetchPlayAlongsCount,
+		fetchPlayerSettings,
 		fetchPlaylist,
 		fetchPlaylistItems,
 		fetchPost,
@@ -841,6 +847,7 @@ declare module 'musora-content-services' {
 		updateMultiUserAccount,
 		updateNotificationSetting,
 		updateOnboarding,
+		updatePlayerSettings,
 		updatePlaylist,
 		updatePost,
 		updatePracticeNotes,

--- a/src/index.js
+++ b/src/index.js
@@ -465,6 +465,11 @@ import {
 } from './services/user/payments.ts';
 
 import {
+	fetchPlayerSettings,
+	updatePlayerSettings
+} from './services/user/playerSettings.ts';
+
+import {
 	deleteProfilePicture,
 	otherStats,
 	updateProfileVisibility
@@ -623,6 +628,7 @@ export {
 	fetchPackData,
 	fetchParentChildRelationshipsFor,
 	fetchPlayAlongsCount,
+	fetchPlayerSettings,
 	fetchPlaylist,
 	fetchPlaylistItems,
 	fetchPost,
@@ -840,6 +846,7 @@ export {
 	updateMultiUserAccount,
 	updateNotificationSetting,
 	updateOnboarding,
+	updatePlayerSettings,
 	updatePlaylist,
 	updatePost,
 	updatePracticeNotes,

--- a/src/services/user/playerSettings.ts
+++ b/src/services/user/playerSettings.ts
@@ -23,5 +23,5 @@ export async function fetchPlayerSettings(): Promise<PlayerSettings> {
  */
 export async function updatePlayerSettings(data: UpdatePlayerSettingsData): Promise<PlayerSettings> {
   const httpClient = new HttpClient(globalConfig.baseUrl, globalConfig.sessionConfig.token)
-  return httpClient.put<PlayerSettings>(baseUrl, data)
+  return httpClient.patch<PlayerSettings>(baseUrl, data)
 }

--- a/src/services/user/playerSettings.ts
+++ b/src/services/user/playerSettings.ts
@@ -1,0 +1,27 @@
+/**
+ * @module PlayerSettings
+ */
+import { HttpClient } from '../../infrastructure/http/HttpClient'
+import { globalConfig } from '../config.js'
+import type { PlayerSettings, UpdatePlayerSettingsData } from './types'
+
+const baseUrl = '/api/user-management-system/v1/user/player-settings'
+
+/**
+ * @returns {Promise<PlayerSettings>}
+ * @throws {HttpError}
+ */
+export async function fetchPlayerSettings(): Promise<PlayerSettings> {
+  const httpClient = new HttpClient(globalConfig.baseUrl, globalConfig.sessionConfig.token)
+  return httpClient.get<PlayerSettings>(baseUrl)
+}
+
+/**
+ * @param {UpdatePlayerSettingsData} data
+ * @returns {Promise<PlayerSettings>}
+ * @throws {HttpError}
+ */
+export async function updatePlayerSettings(data: UpdatePlayerSettingsData): Promise<PlayerSettings> {
+  const httpClient = new HttpClient(globalConfig.baseUrl, globalConfig.sessionConfig.token)
+  return httpClient.put<PlayerSettings>(baseUrl, data)
+}

--- a/src/services/user/types.d.ts
+++ b/src/services/user/types.d.ts
@@ -96,6 +96,20 @@ export interface AuthResponse {
   user: User
 }
 
+export interface PlayerSettings {
+  auto_play: boolean
+  auto_next: boolean
+  auto_complete: boolean
+  playlist_auto_next: boolean
+}
+
+export interface UpdatePlayerSettingsData {
+  auto_play?: boolean
+  auto_next?: boolean
+  auto_complete?: boolean
+  playlist_auto_next?: boolean
+}
+
 export interface StreakDTO {
   type: 'week' | 'day'
   length: number

--- a/test/unit/playerSettings.test.ts
+++ b/test/unit/playerSettings.test.ts
@@ -13,14 +13,14 @@ const mockPlayerSettings: PlayerSettings = {
 
 describe('playerSettings', () => {
   let mockGet: jest.Mock
-  let mockPut: jest.Mock
+  let mockPatch: jest.Mock
 
   beforeEach(() => {
     mockGet = jest.fn().mockResolvedValue(mockPlayerSettings)
-    mockPut = jest.fn().mockResolvedValue(mockPlayerSettings)
+    mockPatch = jest.fn().mockResolvedValue(mockPlayerSettings)
     ;(HttpClient as jest.Mock).mockImplementation(() => ({
       get: mockGet,
-      put: mockPut,
+      patch: mockPatch,
     }))
   })
 
@@ -41,9 +41,9 @@ describe('playerSettings', () => {
   })
 
   describe('updatePlayerSettings', () => {
-    test('calls PUT on the correct endpoint with provided data', async () => {
+    test('calls PATCH on the correct endpoint with provided data', async () => {
       await updatePlayerSettings({ auto_next: false })
-      expect(mockPut).toHaveBeenCalledWith(
+      expect(mockPatch).toHaveBeenCalledWith(
         '/api/user-management-system/v1/user/player-settings',
         { auto_next: false }
       )
@@ -51,7 +51,7 @@ describe('playerSettings', () => {
 
     test('sends only the provided fields (partial update)', async () => {
       await updatePlayerSettings({ playlist_auto_next: false })
-      expect(mockPut).toHaveBeenCalledWith(
+      expect(mockPatch).toHaveBeenCalledWith(
         expect.any(String),
         { playlist_auto_next: false }
       )
@@ -60,12 +60,12 @@ describe('playerSettings', () => {
     test('sends all fields when all are provided', async () => {
       const allFields = { auto_play: false, auto_next: false, auto_complete: false, playlist_auto_next: false }
       await updatePlayerSettings(allFields)
-      expect(mockPut).toHaveBeenCalledWith(expect.any(String), allFields)
+      expect(mockPatch).toHaveBeenCalledWith(expect.any(String), allFields)
     })
 
     test('returns the updated player settings from the API', async () => {
       const updated = { ...mockPlayerSettings, auto_next: false }
-      mockPut.mockResolvedValue(updated)
+      mockPatch.mockResolvedValue(updated)
       const result = await updatePlayerSettings({ auto_next: false })
       expect(result).toEqual(updated)
     })

--- a/test/unit/playerSettings.test.ts
+++ b/test/unit/playerSettings.test.ts
@@ -1,0 +1,73 @@
+import { HttpClient } from '../../src/infrastructure/http/HttpClient'
+import { fetchPlayerSettings, updatePlayerSettings } from '../../src/services/user/playerSettings'
+import type { PlayerSettings } from '../../src/services/user/types'
+
+jest.mock('../../src/infrastructure/http/HttpClient')
+
+const mockPlayerSettings: PlayerSettings = {
+  auto_play: true,
+  auto_next: true,
+  auto_complete: true,
+  playlist_auto_next: true,
+}
+
+describe('playerSettings', () => {
+  let mockGet: jest.Mock
+  let mockPut: jest.Mock
+
+  beforeEach(() => {
+    mockGet = jest.fn().mockResolvedValue(mockPlayerSettings)
+    mockPut = jest.fn().mockResolvedValue(mockPlayerSettings)
+    ;(HttpClient as jest.Mock).mockImplementation(() => ({
+      get: mockGet,
+      put: mockPut,
+    }))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('fetchPlayerSettings', () => {
+    test('calls GET on the correct endpoint', async () => {
+      await fetchPlayerSettings()
+      expect(mockGet).toHaveBeenCalledWith('/api/user-management-system/v1/user/player-settings')
+    })
+
+    test('returns the player settings from the API', async () => {
+      const result = await fetchPlayerSettings()
+      expect(result).toEqual(mockPlayerSettings)
+    })
+  })
+
+  describe('updatePlayerSettings', () => {
+    test('calls PUT on the correct endpoint with provided data', async () => {
+      await updatePlayerSettings({ auto_next: false })
+      expect(mockPut).toHaveBeenCalledWith(
+        '/api/user-management-system/v1/user/player-settings',
+        { auto_next: false }
+      )
+    })
+
+    test('sends only the provided fields (partial update)', async () => {
+      await updatePlayerSettings({ playlist_auto_next: false })
+      expect(mockPut).toHaveBeenCalledWith(
+        expect.any(String),
+        { playlist_auto_next: false }
+      )
+    })
+
+    test('sends all fields when all are provided', async () => {
+      const allFields = { auto_play: false, auto_next: false, auto_complete: false, playlist_auto_next: false }
+      await updatePlayerSettings(allFields)
+      expect(mockPut).toHaveBeenCalledWith(expect.any(String), allFields)
+    })
+
+    test('returns the updated player settings from the API', async () => {
+      const updated = { ...mockPlayerSettings, auto_next: false }
+      mockPut.mockResolvedValue(updated)
+      const result = await updatePlayerSettings({ auto_next: false })
+      expect(result).toEqual(updated)
+    })
+  })
+})


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [ BEHSTP-365](https://musora.atlassian.net/browse/BEHSTP-365)
- [MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/1230)

## Description/Design

  - Added fetchPlayerSettings and updatePlayerSettings functions to fetch and partially update the user's video player settings (auto_play, auto_next, auto_complete, playlist_auto_next) via the MPB API.
  - Added PlayerSettings and UpdatePlayerSettingsData TypeScript interfaces to types.d.ts                                                                                                                                          
  - Exported both functions from index.js / index.d.ts                                                                                                                                                                             

## Testing

  - [ ] fetchPlayerSettings calls GET /api/user-management-system/v1/user/player-settings and returns the settings object.
  - [ ] updatePlayerSettings calls PATCH on the same endpoint with only the provided fields (partial update supported).
  - [ ] All 6 unit tests pass

## Additional Notes

- _Provide any additional context or notes that might be helpful for the reviewer._
