### PR TITLE
refactor(MU2-1620, MU2-1592): update preboarding interface and pass token to account setup email

### DIFF
--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -27,11 +27,13 @@ export async function status(email: string): Promise<{ requires_setup: boolean }
  * @returns {Promise<void>} - A promise that resolves when the email is sent or an HttpError if the request fails.
  * @throws {HttpError} - Throws HttpError if the request fails.
  */
-export async function sendAccountSetupEmail(email: string): Promise<void> {
+export async function sendAccountSetupEmail(email: string, token?: string): Promise<void> {
   const httpClient = new HttpClient(globalConfig.baseUrl)
   return httpClient.post<void>(
     `/api/user-management-system/v1/accounts/${encodeURIComponent(email)}/send-setup-email`,
-    {}
+    {
+      token,
+    }
   )
 }
 

--- a/src/services/user/onboarding.ts
+++ b/src/services/user/onboarding.ts
@@ -120,15 +120,27 @@ export async function userOnboardingForBrand(brand: string): Promise<Onboarding>
 export interface OnboardingRecommendedContent {
   id: number
   title: string
+  brand: string
+  content_type: string
+  type: string
   difficulty: string
   lesson_count: number
   skill_count: number
   badge: string
+  badge_rear: string
+  badge_logo: string
   description: string
+  thumbnail: string
   video: {
     external_id: string
     hlsManifestUrl: string
     type: string
+  }
+  lessons: {
+    id: number
+    title: string
+    thumbnail: string
+    skill_pack_title?: string
   }
 }
 

--- a/src/services/user/onboarding.ts
+++ b/src/services/user/onboarding.ts
@@ -141,7 +141,7 @@ export interface OnboardingRecommendedContent {
     title: string
     thumbnail: string
     skill_pack_title?: string
-  }
+  }[]
 }
 
 export interface OnboardingRecommendationResponse {

--- a/test/unit/user/account.test.ts
+++ b/test/unit/user/account.test.ts
@@ -1,0 +1,55 @@
+import { sendAccountSetupEmail } from '@/services/user/account'
+
+const mockPost = jest.fn()
+
+jest.mock('@/infrastructure/http/HttpClient', () => ({
+  HttpClient: jest.fn().mockImplementation(() => ({
+    post: mockPost,
+  })),
+}))
+
+jest.mock('@/services/config.js', () => ({
+  globalConfig: {
+    baseUrl: 'https://test.musora.com',
+    sessionConfig: { token: null, userId: null },
+  },
+}))
+
+describe('sendAccountSetupEmail', () => {
+  beforeEach(() => {
+    mockPost.mockReset()
+  })
+
+  it('posts to the correct url with token in body when token provided', async () => {
+    mockPost.mockResolvedValueOnce(undefined)
+
+    await sendAccountSetupEmail('user@example.com', 'abc123')
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/user-management-system/v1/accounts/user%40example.com/send-setup-email',
+      { token: 'abc123' }
+    )
+  })
+
+  it('posts to the correct url with undefined token when token omitted', async () => {
+    mockPost.mockResolvedValueOnce(undefined)
+
+    await sendAccountSetupEmail('user@example.com')
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/user-management-system/v1/accounts/user%40example.com/send-setup-email',
+      { token: undefined }
+    )
+  })
+
+  it('encodes special characters in email for the url', async () => {
+    mockPost.mockResolvedValueOnce(undefined)
+
+    await sendAccountSetupEmail('user+tag@example.com', 'tok')
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/user-management-system/v1/accounts/user%2Btag%40example.com/send-setup-email',
+      { token: 'tok' }
+    )
+  })
+})


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- https://musora.atlassian.net/browse/MU2-1620
- https://musora.atlassian.net/browse/MU2-1592

## Description/Design

- `sendAccountSetupEmail` now accepts an optional `token` param and forwards it in the request body, allowing callers to pass a pre-generated token during account setup flows
- `OnboardingRecommendedContent` interface expanded with fields the API already returns (`brand`, `content_type`, `type`, `badge_rear`, `badge_logo`, `thumbnail`, `lessons`) so consumers have proper type coverage without casting

## Testing

- How to verify: trigger account setup email flow with and without a token; confirm token is passed in the POST body when provided
- Environment: local / staging
- Expected outcome: email sends correctly in both cases; TypeScript consumers can access the new interface fields without type errors