### PR TITLE
feat(BEHSTP-370): add need_lifetime_upgrade flag and grant30DaysAccessForLifetime

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -73,6 +73,7 @@ export const DEFAULT_FIELDS = [
   'live_event_end_time',
   'enrollment_start_time',
   'enrollment_end_time',
+  'membership_tier',
 ]
 
 // these are identical... why

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -428,6 +428,7 @@ import {
 	fetchMemberships,
 	fetchRechargeTokens,
 	getUpgradePrice,
+	grant30DaysAccessForLifetime,
 	restorePurchases,
 	upgradeSubscription
 } from './services/user/memberships.ts';
@@ -742,6 +743,7 @@ declare module 'musora-content-services' {
 		getUserWeeklyStats,
 		getWeekNumber,
 		globalConfig,
+		grant30DaysAccessForLifetime,
 		guidedCourses,
 		hasAnyMethodV2IntroCompleted,
 		initializeEnvVar,

--- a/src/index.js
+++ b/src/index.js
@@ -432,6 +432,7 @@ import {
 	fetchMemberships,
 	fetchRechargeTokens,
 	getUpgradePrice,
+	grant30DaysAccessForLifetime,
 	restorePurchases,
 	upgradeSubscription
 } from './services/user/memberships.ts';
@@ -741,6 +742,7 @@ export {
 	getUserWeeklyStats,
 	getWeekNumber,
 	globalConfig,
+	grant30DaysAccessForLifetime,
 	guidedCourses,
 	hasAnyMethodV2IntroCompleted,
 	initializeEnvVar,

--- a/src/lib/sanity/decorators/need-lifetime-upgrade.ts
+++ b/src/lib/sanity/decorators/need-lifetime-upgrade.ts
@@ -1,0 +1,49 @@
+import { decorate, type FieldDecorator } from './base'
+import { type UserPermissions } from '../../../services/permissions'
+import { type AccessDecoratable } from './need-access'
+import { MEMBERSHIP_PERMISSIONS } from '../../../constants/membership-permissions'
+
+export const NEED_LIFETIME_UPGRADE_FIELD = 'need_lifetime_upgrade' as const
+
+type LifetimeUpgradeDecoratable = AccessDecoratable & { need_access?: boolean }
+
+export type WithNeedLifetimeUpgrade<T extends AccessDecoratable> = T & {
+  need_lifetime_upgrade: boolean
+  children?: WithNeedLifetimeUpgrade<NonNullable<T['children']>[number]>[]
+}
+
+export function lifetimeUpgradeDecorator(
+  userPermissions: UserPermissions
+): FieldDecorator<LifetimeUpgradeDecoratable, typeof NEED_LIFETIME_UPGRADE_FIELD, boolean> {
+  const userPermSet = new Set(userPermissions?.permissions ?? [])
+  const hasLifetime = userPermSet.has(MEMBERSHIP_PERMISSIONS.lifetime)
+  const hasPlus = userPermSet.has(MEMBERSHIP_PERMISSIONS.plus)
+
+  return {
+    field: NEED_LIFETIME_UPGRADE_FIELD,
+    compute: (item) => {
+      if (userPermissions?.isAdmin || !hasLifetime || hasPlus) return false
+      if (!item.need_access) return false
+      const contentPerms = new Set(item?.permission_id ?? [])
+      return contentPerms.has(MEMBERSHIP_PERMISSIONS.plus)
+    },
+  }
+}
+
+export function decorateLifetimeUpgrade<T extends LifetimeUpgradeDecoratable>(
+  items: T[],
+  userPermissions: UserPermissions
+): WithNeedLifetimeUpgrade<T>[]
+export function decorateLifetimeUpgrade<T extends LifetimeUpgradeDecoratable>(
+  items: T,
+  userPermissions: UserPermissions
+): WithNeedLifetimeUpgrade<T>
+export function decorateLifetimeUpgrade<T extends LifetimeUpgradeDecoratable>(
+  items: T | T[],
+  userPermissions: UserPermissions
+): WithNeedLifetimeUpgrade<T> | WithNeedLifetimeUpgrade<T>[] {
+  const { field, compute } = lifetimeUpgradeDecorator(userPermissions)
+  return decorate(items as T, field, compute) as
+    | WithNeedLifetimeUpgrade<T>
+    | WithNeedLifetimeUpgrade<T>[]
+}

--- a/src/lib/sanity/decorators/need-lifetime-upgrade.ts
+++ b/src/lib/sanity/decorators/need-lifetime-upgrade.ts
@@ -5,7 +5,7 @@ import { MEMBERSHIP_PERMISSIONS } from '../../../constants/membership-permission
 
 export const NEED_LIFETIME_UPGRADE_FIELD = 'need_lifetime_upgrade' as const
 
-type LifetimeUpgradeDecoratable = AccessDecoratable & { need_access?: boolean }
+type LifetimeUpgradeDecoratable = AccessDecoratable & { need_access?: boolean; membership_tier?: string }
 
 export type WithNeedLifetimeUpgrade<T extends AccessDecoratable> = T & {
   need_lifetime_upgrade: boolean
@@ -24,9 +24,8 @@ export function lifetimeUpgradeDecorator(
     compute: (item) => {
       if (userPermissions?.isAdmin || !hasLifetime || hasPlus) return false
       if (!item.need_access) return false
-      const contentPerms = new Set(item?.permission_id ?? [])
-      return contentPerms.has(MEMBERSHIP_PERMISSIONS.plus)
-    },
+      return item.membership_tier === 'plus'
+      },
   }
 }
 

--- a/src/services/content/content.ts
+++ b/src/services/content/content.ts
@@ -40,5 +40,6 @@ export interface Lesson {
   title: string
   type: LessonType
   need_access: boolean
+  need_lifetime_upgrade: boolean
   page_type: LessonPageType
 }

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -46,6 +46,7 @@ import { globalConfig } from './config.js'
 
 import { arrayToStringRepresentation, FilterBuilder } from '../filterBuilder.js'
 import { getPermissionsAdapter } from './permissions/index.ts'
+import { MEMBERSHIP_PERMISSIONS } from '../constants/membership-permissions.ts'
 import {
   getAllCompleted,
   getAllCompletedByIds,
@@ -1639,6 +1640,7 @@ export async function fetchSanity(
         return null
       }
       results = processNeedAccess ? await needsAccessDecorator(results, userPermissions) : results
+      results = processNeedAccess ? needsLifetimeUpgradeDecorator(results, userPermissions) : results
       results = processPageType ? pageTypeDecorator(results) : results
       return customPostProcess ? customPostProcess(results) : results
     } else {
@@ -1731,6 +1733,19 @@ function needsAccessDecorator(results, userPermissions) {
   const adapter = getPermissionsAdapter()
   return contentResultsDecorator(results, 'need_access', function (content) {
     return adapter.doesUserNeedAccess(content, userPermissions)
+  })
+}
+
+function needsLifetimeUpgradeDecorator(results, userPermissions) {
+  if (globalConfig.sanityConfig.useDummyRailContentMethods) return results
+  const userPermSet = new Set(userPermissions?.permissions ?? [])
+  const hasLifetime = userPermSet.has(MEMBERSHIP_PERMISSIONS.lifetime)
+  const hasPlus = userPermSet.has(MEMBERSHIP_PERMISSIONS.plus)
+  return contentResultsDecorator(results, 'need_lifetime_upgrade', function (content) {
+    if (userPermissions?.isAdmin || !hasLifetime || hasPlus) return false
+    if (!content.need_access) return false
+    const contentPerms = new Set(content?.permission_id ?? [])
+    return contentPerms.has(MEMBERSHIP_PERMISSIONS.plus)
   })
 }
 

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -46,7 +46,7 @@ import { globalConfig } from './config.js'
 
 import { arrayToStringRepresentation, FilterBuilder } from '../filterBuilder.js'
 import { getPermissionsAdapter } from './permissions/index.ts'
-import { MEMBERSHIP_PERMISSIONS } from '../constants/membership-permissions.ts'
+import { lifetimeUpgradeDecorator, NEED_LIFETIME_UPGRADE_FIELD } from '../lib/sanity/decorators/need-lifetime-upgrade.ts'
 import {
   getAllCompleted,
   getAllCompletedByIds,
@@ -1738,15 +1738,8 @@ function needsAccessDecorator(results, userPermissions) {
 
 function needsLifetimeUpgradeDecorator(results, userPermissions) {
   if (globalConfig.sanityConfig.useDummyRailContentMethods) return results
-  const userPermSet = new Set(userPermissions?.permissions ?? [])
-  const hasLifetime = userPermSet.has(MEMBERSHIP_PERMISSIONS.lifetime)
-  const hasPlus = userPermSet.has(MEMBERSHIP_PERMISSIONS.plus)
-  return contentResultsDecorator(results, 'need_lifetime_upgrade', function (content) {
-    if (userPermissions?.isAdmin || !hasLifetime || hasPlus) return false
-    if (!content.need_access) return false
-    const contentPerms = new Set(content?.permission_id ?? [])
-    return contentPerms.has(MEMBERSHIP_PERMISSIONS.plus)
-  })
+  const { compute } = lifetimeUpgradeDecorator(userPermissions)
+  return contentResultsDecorator(results, NEED_LIFETIME_UPGRADE_FIELD, compute)
 }
 
 function doesUserNeedAccessToContent(result, userPermissions) {

--- a/src/services/user/memberships.ts
+++ b/src/services/user/memberships.ts
@@ -291,3 +291,11 @@ export async function fetchHasActivePlatformSubscription(): Promise<boolean> {
   const response = await httpClient.get<SubscriptionPlatform>(`${baseUrl}/v1/subscription-platform`)
   return response.has_active_platform_subscription
 }
+
+/**
+ * @returns {Promise<void>}
+ */
+export async function grant30DaysAccessForLifetime(): Promise<void> {
+  const httpClient = new HttpClient(globalConfig.baseUrl)
+  return httpClient.post(`${baseUrl}/v1/grant-30-days-access-for-lifetime`, {})
+}

--- a/src/services/user/memberships.ts
+++ b/src/services/user/memberships.ts
@@ -297,5 +297,5 @@ export async function fetchHasActivePlatformSubscription(): Promise<boolean> {
  */
 export async function grant30DaysAccessForLifetime(): Promise<void> {
   const httpClient = new HttpClient(globalConfig.baseUrl)
-  return httpClient.post(`${baseUrl}/v1/grant-30-days-access-for-lifetime`, {})
+  await httpClient.post<void>(`${baseUrl}/v1/grant-30-days-access-for-lifetime`, {})
 }

--- a/test/unit/lib/sanity/decorators/need-lifetime-upgrade.test.ts
+++ b/test/unit/lib/sanity/decorators/need-lifetime-upgrade.test.ts
@@ -8,31 +8,28 @@ const PLUS = 92
 const LIFETIME = 108
 const BASE = 91
 
-const lifetimeOnly = { permissions: [LIFETIME], isAdmin: false, isModerator: false, isABasicMember: false }
-const lifetimePlus = { permissions: [LIFETIME, PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
-const plusOnly = { permissions: [PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
-const baseOnly = { permissions: [BASE], isAdmin: false, isModerator: false, isABasicMember: false }
-const admin = { permissions: [LIFETIME], isAdmin: true, isModerator: false, isABasicMember: false }
+const lifetimeBase = { permissions: [LIFETIME, BASE], isAdmin: false, isModerator: false, isABasicMember: true }
+const lifetimeBasePlus = { permissions: [LIFETIME, BASE, PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
+const baseOnly = { permissions: [BASE], isAdmin: false, isModerator: false, isABasicMember: true }
 
-const plusGatedLocked = { permission_id: [PLUS], need_access: true }
-const plusGatedUnlocked = { permission_id: [PLUS], need_access: false }
-const baseGatedLocked = { permission_id: [BASE], need_access: true }
+const plusGatedLocked = { permission_id: [BASE, PLUS], need_access: true, membership_tier: 'plus' }
+const plusGatedUnlocked = { permission_id: [BASE, PLUS], need_access: false, membership_tier: 'plus' }
 
 describe('need-lifetime-upgrade decorator', () => {
   describe('lifetimeUpgradeDecorator (factory)', () => {
     test('field is need_lifetime_upgrade', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimeOnly)
+      const dec = lifetimeUpgradeDecorator(lifetimeBase)
       expect(dec.field).toBe('need_lifetime_upgrade')
       expect(NEED_LIFETIME_UPGRADE_FIELD).toBe('need_lifetime_upgrade')
     })
 
     test('true for lifetime member on Plus-gated content they cannot access', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimeOnly)
+      const dec = lifetimeUpgradeDecorator(lifetimeBase)
       expect(dec.compute(plusGatedLocked)).toBe(true)
     })
 
     test('false when user already has Plus', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimePlus)
+      const dec = lifetimeUpgradeDecorator(lifetimeBasePlus)
       expect(dec.compute(plusGatedLocked)).toBe(false)
     })
 
@@ -41,57 +38,39 @@ describe('need-lifetime-upgrade decorator', () => {
       expect(dec.compute(plusGatedLocked)).toBe(false)
     })
 
-    test('false for Plus-only member', () => {
-      const dec = lifetimeUpgradeDecorator(plusOnly)
-      expect(dec.compute(plusGatedLocked)).toBe(false)
-    })
-
-    test('false for admin', () => {
-      const dec = lifetimeUpgradeDecorator(admin)
-      expect(dec.compute(plusGatedLocked)).toBe(false)
-    })
-
-    test('false when content does not require Plus', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimeOnly)
-      expect(dec.compute(baseGatedLocked)).toBe(false)
-    })
-
     test('false when user already has access to content (need_access false)', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimeOnly)
+      const dec = lifetimeUpgradeDecorator(lifetimeBase)
       expect(dec.compute(plusGatedUnlocked)).toBe(false)
-    })
-
-    test('false when userPermissions is null', () => {
-      const dec = lifetimeUpgradeDecorator(null as any)
-      expect(dec.compute(plusGatedLocked)).toBe(false)
     })
   })
 
   describe('decorateLifetimeUpgrade', () => {
     test('decorates array of items', () => {
-      const items = [plusGatedLocked, baseGatedLocked, plusGatedUnlocked]
-      const decorated = decorateLifetimeUpgrade(items, lifetimeOnly)
-      expect(decorated.map((i) => i.need_lifetime_upgrade)).toEqual([true, false, false])
+      const items = [plusGatedLocked, plusGatedUnlocked]
+      const decorated = decorateLifetimeUpgrade(items, lifetimeBase)
+      expect(decorated.map((i) => i.need_lifetime_upgrade)).toEqual([true, false])
     })
 
     test('decorates a single item', () => {
-      const decorated = decorateLifetimeUpgrade(plusGatedLocked, lifetimeOnly)
+      const decorated = decorateLifetimeUpgrade(plusGatedLocked, lifetimeBase)
       expect(decorated.need_lifetime_upgrade).toBe(true)
     })
 
     test('decorates children recursively', () => {
       const tree = {
-        permission_id: [PLUS],
+        permission_id: [BASE, PLUS],
         need_access: true,
+        membership_tier: 'plus',
         children: [
           {
-            permission_id: [PLUS],
+            permission_id: [BASE, PLUS],
             need_access: true,
-            children: [{ permission_id: [PLUS], need_access: true }],
+            membership_tier: 'plus',
+            children: [{ permission_id: [BASE, PLUS], need_access: true, membership_tier: 'plus' }],
           },
         ],
       }
-      const decorated = decorateLifetimeUpgrade(tree, lifetimeOnly)
+      const decorated = decorateLifetimeUpgrade(tree, lifetimeBase)
       expect(decorated.need_lifetime_upgrade).toBe(true)
       expect(decorated.children![0].need_lifetime_upgrade).toBe(true)
       expect(decorated.children![0].children![0].need_lifetime_upgrade).toBe(true)
@@ -99,7 +78,7 @@ describe('need-lifetime-upgrade decorator', () => {
 
     test('returns the same reference it was given', () => {
       const items = [plusGatedLocked]
-      const decorated = decorateLifetimeUpgrade(items, lifetimeOnly)
+      const decorated = decorateLifetimeUpgrade(items, lifetimeBase)
       expect(decorated).toBe(items)
     })
   })

--- a/test/unit/lib/sanity/decorators/need-lifetime-upgrade.test.ts
+++ b/test/unit/lib/sanity/decorators/need-lifetime-upgrade.test.ts
@@ -2,87 +2,85 @@ import {
   NEED_LIFETIME_UPGRADE_FIELD,
   lifetimeUpgradeDecorator,
   decorateLifetimeUpgrade,
-  type WithNeedLifetimeUpgrade,
 } from '../../../../../src/lib/sanity/decorators/need-lifetime-upgrade'
-import { type AccessDecoratable } from '../../../../../src/lib/sanity/decorators/need-access'
 
 const PLUS = 92
 const LIFETIME = 108
 const BASE = 91
 
-const lifetimeOnlyPerms = { permissions: [LIFETIME], isAdmin: false, isModerator: false, isABasicMember: false }
-const lifetimePlusPerms = { permissions: [LIFETIME, PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
-const plusOnlyPerms = { permissions: [PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
-const basePerms = { permissions: [BASE], isAdmin: false, isModerator: false, isABasicMember: false }
-const adminPerms = { permissions: [LIFETIME], isAdmin: true, isModerator: false, isABasicMember: false }
+const lifetimeOnly = { permissions: [LIFETIME], isAdmin: false, isModerator: false, isABasicMember: false }
+const lifetimePlus = { permissions: [LIFETIME, PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
+const plusOnly = { permissions: [PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
+const baseOnly = { permissions: [BASE], isAdmin: false, isModerator: false, isABasicMember: false }
+const admin = { permissions: [LIFETIME], isAdmin: true, isModerator: false, isABasicMember: false }
 
-const plusContent: AccessDecoratable = { permission_id: [PLUS], need_access: true }
-const baseContent: AccessDecoratable = { permission_id: [BASE], need_access: true }
-const freeContent: AccessDecoratable = { permission_id: [], need_access: false }
+const plusGatedLocked = { permission_id: [PLUS], need_access: true }
+const plusGatedUnlocked = { permission_id: [PLUS], need_access: false }
+const baseGatedLocked = { permission_id: [BASE], need_access: true }
 
 describe('need-lifetime-upgrade decorator', () => {
   describe('lifetimeUpgradeDecorator (factory)', () => {
     test('field is need_lifetime_upgrade', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimeOnlyPerms)
+      const dec = lifetimeUpgradeDecorator(lifetimeOnly)
       expect(dec.field).toBe('need_lifetime_upgrade')
       expect(NEED_LIFETIME_UPGRADE_FIELD).toBe('need_lifetime_upgrade')
     })
 
-    test('returns true for lifetime member on Plus-gated content they cannot access', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimeOnlyPerms)
-      expect(dec.compute(plusContent)).toBe(true)
+    test('true for lifetime member on Plus-gated content they cannot access', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimeOnly)
+      expect(dec.compute(plusGatedLocked)).toBe(true)
     })
 
-    test('returns false when user already has Plus', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimePlusPerms)
-      expect(dec.compute(plusContent)).toBe(false)
+    test('false when user already has Plus', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimePlus)
+      expect(dec.compute(plusGatedLocked)).toBe(false)
     })
 
-    test('returns false when user does not have lifetime', () => {
-      const dec = lifetimeUpgradeDecorator(basePerms)
-      expect(dec.compute(plusContent)).toBe(false)
+    test('false when user does not have lifetime', () => {
+      const dec = lifetimeUpgradeDecorator(baseOnly)
+      expect(dec.compute(plusGatedLocked)).toBe(false)
     })
 
-    test('returns false for Plus-only member', () => {
-      const dec = lifetimeUpgradeDecorator(plusOnlyPerms)
-      expect(dec.compute(plusContent)).toBe(false)
+    test('false for Plus-only member', () => {
+      const dec = lifetimeUpgradeDecorator(plusOnly)
+      expect(dec.compute(plusGatedLocked)).toBe(false)
     })
 
-    test('returns false for admin', () => {
-      const dec = lifetimeUpgradeDecorator(adminPerms)
-      expect(dec.compute(plusContent)).toBe(false)
+    test('false for admin', () => {
+      const dec = lifetimeUpgradeDecorator(admin)
+      expect(dec.compute(plusGatedLocked)).toBe(false)
     })
 
-    test('returns false when content does not require Plus', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimeOnlyPerms)
-      expect(dec.compute(baseContent)).toBe(false)
+    test('false when content does not require Plus', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimeOnly)
+      expect(dec.compute(baseGatedLocked)).toBe(false)
     })
 
-    test('returns false when content is free (need_access false)', () => {
-      const dec = lifetimeUpgradeDecorator(lifetimeOnlyPerms)
-      expect(dec.compute(freeContent)).toBe(false)
+    test('false when user already has access to content (need_access false)', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimeOnly)
+      expect(dec.compute(plusGatedUnlocked)).toBe(false)
     })
 
-    test('returns false when userPermissions is null', () => {
+    test('false when userPermissions is null', () => {
       const dec = lifetimeUpgradeDecorator(null as any)
-      expect(dec.compute(plusContent)).toBe(false)
+      expect(dec.compute(plusGatedLocked)).toBe(false)
     })
   })
 
   describe('decorateLifetimeUpgrade', () => {
     test('decorates array of items', () => {
-      const items: AccessDecoratable[] = [plusContent, baseContent, freeContent]
-      const decorated = decorateLifetimeUpgrade(items, lifetimeOnlyPerms)
+      const items = [plusGatedLocked, baseGatedLocked, plusGatedUnlocked]
+      const decorated = decorateLifetimeUpgrade(items, lifetimeOnly)
       expect(decorated.map((i) => i.need_lifetime_upgrade)).toEqual([true, false, false])
     })
 
     test('decorates a single item', () => {
-      const decorated = decorateLifetimeUpgrade(plusContent, lifetimeOnlyPerms)
+      const decorated = decorateLifetimeUpgrade(plusGatedLocked, lifetimeOnly)
       expect(decorated.need_lifetime_upgrade).toBe(true)
     })
 
     test('decorates children recursively', () => {
-      const tree: AccessDecoratable = {
+      const tree = {
         permission_id: [PLUS],
         need_access: true,
         children: [
@@ -93,15 +91,15 @@ describe('need-lifetime-upgrade decorator', () => {
           },
         ],
       }
-      const decorated = decorateLifetimeUpgrade(tree, lifetimeOnlyPerms) as WithNeedLifetimeUpgrade<AccessDecoratable>
+      const decorated = decorateLifetimeUpgrade(tree, lifetimeOnly)
       expect(decorated.need_lifetime_upgrade).toBe(true)
       expect(decorated.children![0].need_lifetime_upgrade).toBe(true)
       expect(decorated.children![0].children![0].need_lifetime_upgrade).toBe(true)
     })
 
     test('returns the same reference it was given', () => {
-      const items: AccessDecoratable[] = [plusContent]
-      const decorated = decorateLifetimeUpgrade(items, lifetimeOnlyPerms)
+      const items = [plusGatedLocked]
+      const decorated = decorateLifetimeUpgrade(items, lifetimeOnly)
       expect(decorated).toBe(items)
     })
   })

--- a/test/unit/lib/sanity/decorators/need-lifetime-upgrade.test.ts
+++ b/test/unit/lib/sanity/decorators/need-lifetime-upgrade.test.ts
@@ -1,0 +1,108 @@
+import {
+  NEED_LIFETIME_UPGRADE_FIELD,
+  lifetimeUpgradeDecorator,
+  decorateLifetimeUpgrade,
+  type WithNeedLifetimeUpgrade,
+} from '../../../../../src/lib/sanity/decorators/need-lifetime-upgrade'
+import { type AccessDecoratable } from '../../../../../src/lib/sanity/decorators/need-access'
+
+const PLUS = 92
+const LIFETIME = 108
+const BASE = 91
+
+const lifetimeOnlyPerms = { permissions: [LIFETIME], isAdmin: false, isModerator: false, isABasicMember: false }
+const lifetimePlusPerms = { permissions: [LIFETIME, PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
+const plusOnlyPerms = { permissions: [PLUS], isAdmin: false, isModerator: false, isABasicMember: false }
+const basePerms = { permissions: [BASE], isAdmin: false, isModerator: false, isABasicMember: false }
+const adminPerms = { permissions: [LIFETIME], isAdmin: true, isModerator: false, isABasicMember: false }
+
+const plusContent: AccessDecoratable = { permission_id: [PLUS], need_access: true }
+const baseContent: AccessDecoratable = { permission_id: [BASE], need_access: true }
+const freeContent: AccessDecoratable = { permission_id: [], need_access: false }
+
+describe('need-lifetime-upgrade decorator', () => {
+  describe('lifetimeUpgradeDecorator (factory)', () => {
+    test('field is need_lifetime_upgrade', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimeOnlyPerms)
+      expect(dec.field).toBe('need_lifetime_upgrade')
+      expect(NEED_LIFETIME_UPGRADE_FIELD).toBe('need_lifetime_upgrade')
+    })
+
+    test('returns true for lifetime member on Plus-gated content they cannot access', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimeOnlyPerms)
+      expect(dec.compute(plusContent)).toBe(true)
+    })
+
+    test('returns false when user already has Plus', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimePlusPerms)
+      expect(dec.compute(plusContent)).toBe(false)
+    })
+
+    test('returns false when user does not have lifetime', () => {
+      const dec = lifetimeUpgradeDecorator(basePerms)
+      expect(dec.compute(plusContent)).toBe(false)
+    })
+
+    test('returns false for Plus-only member', () => {
+      const dec = lifetimeUpgradeDecorator(plusOnlyPerms)
+      expect(dec.compute(plusContent)).toBe(false)
+    })
+
+    test('returns false for admin', () => {
+      const dec = lifetimeUpgradeDecorator(adminPerms)
+      expect(dec.compute(plusContent)).toBe(false)
+    })
+
+    test('returns false when content does not require Plus', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimeOnlyPerms)
+      expect(dec.compute(baseContent)).toBe(false)
+    })
+
+    test('returns false when content is free (need_access false)', () => {
+      const dec = lifetimeUpgradeDecorator(lifetimeOnlyPerms)
+      expect(dec.compute(freeContent)).toBe(false)
+    })
+
+    test('returns false when userPermissions is null', () => {
+      const dec = lifetimeUpgradeDecorator(null as any)
+      expect(dec.compute(plusContent)).toBe(false)
+    })
+  })
+
+  describe('decorateLifetimeUpgrade', () => {
+    test('decorates array of items', () => {
+      const items: AccessDecoratable[] = [plusContent, baseContent, freeContent]
+      const decorated = decorateLifetimeUpgrade(items, lifetimeOnlyPerms)
+      expect(decorated.map((i) => i.need_lifetime_upgrade)).toEqual([true, false, false])
+    })
+
+    test('decorates a single item', () => {
+      const decorated = decorateLifetimeUpgrade(plusContent, lifetimeOnlyPerms)
+      expect(decorated.need_lifetime_upgrade).toBe(true)
+    })
+
+    test('decorates children recursively', () => {
+      const tree: AccessDecoratable = {
+        permission_id: [PLUS],
+        need_access: true,
+        children: [
+          {
+            permission_id: [PLUS],
+            need_access: true,
+            children: [{ permission_id: [PLUS], need_access: true }],
+          },
+        ],
+      }
+      const decorated = decorateLifetimeUpgrade(tree, lifetimeOnlyPerms) as WithNeedLifetimeUpgrade<AccessDecoratable>
+      expect(decorated.need_lifetime_upgrade).toBe(true)
+      expect(decorated.children![0].need_lifetime_upgrade).toBe(true)
+      expect(decorated.children![0].children![0].need_lifetime_upgrade).toBe(true)
+    })
+
+    test('returns the same reference it was given', () => {
+      const items: AccessDecoratable[] = [plusContent]
+      const decorated = decorateLifetimeUpgrade(items, lifetimeOnlyPerms)
+      expect(decorated).toBe(items)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `need_lifetime_upgrade` flag on Sanity content documents — set to `true` for lifetime members who don't have Plus and encounter Plus-gated content they cannot access (used to show a Plus upsell)
- Adds `grant30DaysAccessForLifetime()` API method that calls `/v1/grant-30-days-access-for-lifetime`

## Test plan
- [ ] Verify `need_lifetime_upgrade` is `true` for a lifetime (non-Plus) member on Plus-gated content they can't access
- [ ] Verify `need_lifetime_upgrade` is `false` for admin, Plus members, non-lifetime members, or content the user already has access to
- [ ] Verify `grant30DaysAccessForLifetime()` hits the correct endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)