### PR TITLE
fix(BR-671): fix Latin/World style search

### DIFF
--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -877,9 +877,12 @@ function createTypeConditions(lessonTypes) {
  */
 const filterHandlers = {
   style: (value) => {
-    return (value === 'Latin/World')
-      ? (`("Latin" in genre[]->name || "World" in genre[]->name)`)
-      : (`"${value}" in genre[]->name`)
+    const hasMultipleStyles = value.includes('/')
+    const styles = [value]
+    if (hasMultipleStyles) {
+      styles.push(...value.split('/').map((s) => s.trim()))
+    }
+    return styles.map((style) => `"${style}" in genre[]->name`).join(' || ')
   },
 
   difficulty: (value) => {

--- a/src/contentTypeConfig.js
+++ b/src/contentTypeConfig.js
@@ -876,7 +876,11 @@ function createTypeConditions(lessonTypes) {
  * Filter handler registry - maps filter keys to their handler functions
  */
 const filterHandlers = {
-  style: (value) => `"${value}" in genre[]->name`,
+  style: (value) => {
+    return (value === 'Latin/World')
+      ? (`("Latin" in genre[]->name || "World" in genre[]->name)`)
+      : (`"${value}" in genre[]->name`)
+  },
 
   difficulty: (value) => {
     return `difficulty_string == "${value}"`


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- https://musora.atlassian.net/browse/BR-671

## Description/Design

- Most Styles in the search filters are 1-1 naming with their respective genre, like "Hard Rock/Metal". "Latin/World", however is stored as 2 separate genres, "Latin" and "World". This fixes queries by explicitly splitting the genre search for this case.

## Testing

- verify results show for https://devapp.musora.com:5174/guitareo/lessons/filters?filters=style,Latin/World