### PR TITLE
fix(BEHLTP-210): add non-destructive notification polling pause

### DIFF
--- a/src/services/eventsAPI.js
+++ b/src/services/eventsAPI.js
@@ -3,7 +3,7 @@ import {fetchLiveEvent} from "./sanity"
 import { DataContext, PollingStateVersionKey } from './dataContext'
 
 const pollingStateContext = new DataContext(PollingStateVersionKey, fetchLiveEventPollingState)
-const notificationPollingIntervalMs = 60000
+const NOTIFICATION_POLLING_INTERVAL_MS = 60_000
 
 /**
  * API for managing notifications and live event polling.
@@ -100,7 +100,7 @@ class EventsAPI {
 
     this.pollingInterval = setInterval(() => {
       this.checkNotifications();
-    }, notificationPollingIntervalMs);
+    }, NOTIFICATION_POLLING_INTERVAL_MS);
   }
 
   /**

--- a/src/services/eventsAPI.js
+++ b/src/services/eventsAPI.js
@@ -3,6 +3,7 @@ import {fetchLiveEvent} from "./sanity"
 import { DataContext, PollingStateVersionKey } from './dataContext'
 
 const pollingStateContext = new DataContext(PollingStateVersionKey, fetchLiveEventPollingState)
+const notificationPollingIntervalMs = 60000
 
 /**
  * API for managing notifications and live event polling.
@@ -12,6 +13,7 @@ class EventsAPI {
     this.brand = 'drumeo'
     this.onNotificationStateUpdated = []
     this.pollingInterval = null
+    this.isNotificationPollingPaused = false
     this.isLiveEventPollingActive = true
     this.resumeLiveEventTimeout = null
   }
@@ -27,6 +29,7 @@ class EventsAPI {
    */
   async initialize({ brand = 'drumeo' } = {}) {
     this.brand = brand;
+    this.isNotificationPollingPaused = false;
     await this.setupAutoEvents();
     await this.checkNotifications();
   }
@@ -80,13 +83,54 @@ class EventsAPI {
         const ttlMs = pauseUntil - now;
         await this.pauseLiveEventCheck(ttlMs);
       }
-      this.pollingInterval = setInterval(() => {
-        this.checkNotifications();
-      }, 60000);
+      this.startNotificationInterval();
     } catch (error) {
       console.error('EventsApi: Failed to setup auto events:', error);
       this.checkNotifications();
     }
+  }
+
+  /**
+   * Starts notification polling unless it is already active or explicitly paused.
+   */
+  startNotificationInterval() {
+    if (this.pollingInterval || this.isNotificationPollingPaused) {
+      return;
+    }
+
+    this.pollingInterval = setInterval(() => {
+      this.checkNotifications();
+    }, notificationPollingIntervalMs);
+  }
+
+  /**
+   * Stops notification polling without removing notification subscribers.
+   */
+  stopNotificationInterval() {
+    if (!this.pollingInterval) {
+      return;
+    }
+
+    clearInterval(this.pollingInterval);
+    this.pollingInterval = null;
+  }
+
+  /**
+   * Pauses notification polling without resetting initialized state or subscribers.
+   */
+  pauseNotificationPolling() {
+    this.isNotificationPollingPaused = true;
+    this.stopNotificationInterval();
+  }
+
+  /**
+   * Resumes notification polling and immediately refreshes notification state.
+   * @returns {Promise<void>}
+   */
+  resumeNotificationPolling() {
+    this.isNotificationPollingPaused = false;
+    this.startNotificationInterval();
+    return this.checkNotifications();
   }
 
 
@@ -149,10 +193,8 @@ class EventsAPI {
   }
 
   destroy() {
-    if (this.pollingInterval) {
-      clearInterval(this.pollingInterval);
-      this.pollingInterval = null;
-    }
+    this.isNotificationPollingPaused = true;
+    this.stopNotificationInterval();
 
     if (this.resumeLiveEventTimeout) {
       clearTimeout(this.resumeLiveEventTimeout);

--- a/test/unit/eventsAPI.test.ts
+++ b/test/unit/eventsAPI.test.ts
@@ -1,0 +1,159 @@
+import eventsAPISingleton from '../../src/services/eventsAPI.js'
+import { initializeTestService } from '../initializeTests.js'
+
+const notificationsModule = require('../../src/services/user/notifications.js')
+const EventsAPI = eventsAPISingleton.constructor as new () => typeof eventsAPISingleton
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+describe('EventsAPI notification polling lifecycle', () => {
+  let api: typeof eventsAPISingleton
+  let fetchUnreadCountMock: jest.SpyInstance
+
+  beforeEach(() => {
+    initializeTestService()
+    jest.useFakeTimers()
+
+    api = new EventsAPI()
+    jest.spyOn(api, 'initPollingControl').mockResolvedValue({})
+    fetchUnreadCountMock = jest
+      .spyOn(notificationsModule, 'fetchUnreadCount')
+      .mockResolvedValue({ data: 0 })
+  })
+
+  afterEach(() => {
+    api.destroy()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  test('initialize keeps the existing polling behavior', async () => {
+    await api.initialize({ brand: 'pianote' })
+
+    expect(fetchUnreadCountMock).toHaveBeenCalledWith({ brand: 'pianote' })
+    expect(api.pollingInterval).not.toBeNull()
+
+    fetchUnreadCountMock.mockClear()
+    await jest.advanceTimersByTimeAsync(60000)
+
+    expect(fetchUnreadCountMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('pause stops polling without removing subscribers', async () => {
+    const handler = jest.fn()
+    api.addNotificationStateUpdatedHandler(handler)
+    await api.initialize()
+    handler.mockClear()
+    fetchUnreadCountMock.mockClear()
+
+    api.pauseNotificationPolling()
+    await jest.advanceTimersByTimeAsync(120000)
+
+    expect(api.pollingInterval).toBeNull()
+    expect(api.onNotificationStateUpdated).toEqual([handler])
+    expect(fetchUnreadCountMock).not.toHaveBeenCalled()
+  })
+
+  test('resume starts one interval and immediately refreshes existing subscribers', async () => {
+    const handler = jest.fn()
+    api.addNotificationStateUpdatedHandler(handler)
+    await api.initialize()
+    api.pauseNotificationPolling()
+    fetchUnreadCountMock.mockResolvedValue({ data: 1, liveEvent: null })
+    fetchUnreadCountMock.mockClear()
+    handler.mockClear()
+
+    await api.resumeNotificationPolling()
+    const resumedInterval = api.pollingInterval
+    await api.resumeNotificationPolling()
+
+    expect(resumedInterval).not.toBeNull()
+    expect(api.pollingInterval).toBe(resumedInterval)
+    expect(fetchUnreadCountMock).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenLastCalledWith({ unreadCount: 1, liveEvent: null })
+  })
+
+  test('repeated pause calls are safe', async () => {
+    await api.initialize()
+
+    api.pauseNotificationPolling()
+    api.pauseNotificationPolling()
+
+    expect(api.pollingInterval).toBeNull()
+  })
+
+  test('pause during asynchronous setup prevents the interval from being created', async () => {
+    const pollingControl = deferred<Record<string, never>>()
+    jest.spyOn(api, 'initPollingControl').mockReturnValue(pollingControl.promise)
+
+    const initializePromise = api.initialize()
+    api.pauseNotificationPolling()
+    pollingControl.resolve({})
+    await initializePromise
+
+    expect(api.pollingInterval).toBeNull()
+    expect(fetchUnreadCountMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('resume during asynchronous setup creates no duplicate interval', async () => {
+    const pollingControl = deferred<Record<string, never>>()
+    jest.spyOn(api, 'initPollingControl').mockReturnValue(pollingControl.promise)
+
+    const initializePromise = api.initialize()
+    api.pauseNotificationPolling()
+    const resumePromise = api.resumeNotificationPolling()
+    const resumedInterval = api.pollingInterval
+    pollingControl.resolve({})
+    await Promise.all([initializePromise, resumePromise])
+
+    expect(resumedInterval).not.toBeNull()
+    expect(api.pollingInterval).toBe(resumedInterval)
+  })
+
+  test('pause and resume while the initial unread request is pending restores polling', async () => {
+    const initialUnreadCount = deferred<{ data: number }>()
+    fetchUnreadCountMock
+      .mockReturnValueOnce(initialUnreadCount.promise)
+      .mockResolvedValue({ data: 1 })
+
+    const initializePromise = api.initialize()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(api.pollingInterval).not.toBeNull()
+
+    api.pauseNotificationPolling()
+    const resumePromise = api.resumeNotificationPolling()
+
+    expect(api.pollingInterval).not.toBeNull()
+    initialUnreadCount.resolve({ data: 0 })
+    await Promise.all([initializePromise, resumePromise])
+
+    fetchUnreadCountMock.mockClear()
+    await jest.advanceTimersByTimeAsync(60000)
+    expect(fetchUnreadCountMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('destroy remains a full teardown and initialize can start again', async () => {
+    api.addNotificationStateUpdatedHandler(jest.fn())
+    await api.initialize()
+
+    api.destroy()
+
+    expect(api.pollingInterval).toBeNull()
+    expect(api.onNotificationStateUpdated).toEqual([])
+    expect(api.isLiveEventPollingActive).toBe(false)
+
+    fetchUnreadCountMock.mockClear()
+    await api.initialize()
+
+    expect(api.pollingInterval).not.toBeNull()
+    expect(fetchUnreadCountMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [BEHLTP-210 — Alert notifications do not show up for manager after someone leaves plan](https://musora.atlassian.net/browse/BEHLTP-210)

## Description/Design

The web application currently stops notification polling when the document becomes hidden - for example, when the user switches to another browser tab or minimizes the browser - by calling `EventsAPI.destroy()`.

`destroy()` is a full teardown: in addition to stopping the polling interval, it removes all notification state subscribers. When polling is initialized again, unread-count requests continue, but the original subscriber no longer receives their results. As a result, the notification bell can remain out of sync even when `/notifications/v1/unread-count` returns a non-zero value.

This change introduces a non-destructive polling lifecycle:

- `pauseNotificationPolling()` stops the polling interval while retaining subscribers and initialized configuration.
- `resumeNotificationPolling()` restores the interval and immediately refreshes the unread notification state.
- Polling interval creation is idempotent to prevent duplicate intervals.
- `destroy()` remains the full teardown operation for final cleanup.

The implementation intentionally keeps the existing `initialize()`, `checkNotifications()`, subscription, and `destroy()` behavior intact.

## Testing

Automated verification:

- Added 8 notification polling lifecycle unit tests.

## Additional Notes

- This change is additive and backward-compatible.
- The default MCS export and existing public methods remain unchanged.
- Existing consumers, including mobile applications, do not need to change their current lifecycle usage.
- Consumers must explicitly opt into the new pause/resume methods.
- A follow-up frontend PR will replace temporary `destroy()`/`initialize()` calls on document visibility changes with `pauseNotificationPolling()`/`resumeNotificationPolling()`.
- `destroy()` should continue to be used for final cleanup when all polling state and subscribers must be removed.