### PR TITLE
chore: add cross-brand onboarding status endpoint

### DIFF
--- a/.agent/decisions/2026-07-17-onboarding-statuses.md
+++ b/.agent/decisions/2026-07-17-onboarding-statuses.md
@@ -1,0 +1,21 @@
+---
+date: 2026-07-17
+branch: chore/onboarding-statuses
+pr: https://github.com/railroadmedia/musora-content-services/pull/1011
+status: open
+tags: [[feature]]
+---
+
+# Add cross-brand onboarding status endpoint
+
+## Context
+`userOnboardingForBrand(brand)` only returns onboarding state for one brand at a time. Callers that need to know onboarding completion across all brands (e.g. Drumeo, Pianote, Guitareo, Singeo) for a user had no single call to get that.
+
+## Decision
+Added `getOnboardingStatus()` in `src/services/user/onboarding.ts`, hitting `GET /api/user-management-system/v1/users/{userId}/onboardings/status`. Returns `OnboardingStatus`: `has_completed_onboarding` plus a `brands: OnboardingBrandStatus[]` array (`brand`, `is_completed`, `completed_flow`, `completed_at`). Ran `npm run build-index` to regenerate `index.js`/`index.d.ts` so the new function is exported from the package.
+
+## Alternatives Considered
+No alternatives considered — this is additive to the existing per-brand `userOnboardingForBrand` function, not a replacement.
+
+## Consequences
+Consumers (musora-platform-frontend, MusoraApp) can now fetch all-brand onboarding status in a single request instead of looping `userOnboardingForBrand` per brand.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -451,6 +451,7 @@ import {
 
 import {
 	getOnboardingRecommendedContent,
+	getOnboardingStatus,
 	initializeOnboardingFlow,
 	startOnboarding,
 	updateOnboarding,
@@ -707,6 +708,7 @@ declare module 'musora-content-services' {
 		getNavigateToForPlaylists,
 		getNewAndUpcoming,
 		getOnboardingRecommendedContent,
+		getOnboardingStatus,
 		getOwnedContent,
 		getPermissionsAdapter,
 		getPermissionsVersion,

--- a/src/index.js
+++ b/src/index.js
@@ -455,6 +455,7 @@ import {
 
 import {
 	getOnboardingRecommendedContent,
+	getOnboardingStatus,
 	initializeOnboardingFlow,
 	startOnboarding,
 	updateOnboarding,
@@ -706,6 +707,7 @@ export {
 	getNavigateToForPlaylists,
 	getNewAndUpcoming,
 	getOnboardingRecommendedContent,
+	getOnboardingStatus,
 	getOwnedContent,
 	getPermissionsAdapter,
 	getPermissionsVersion,

--- a/src/services/user/onboarding.ts
+++ b/src/services/user/onboarding.ts
@@ -117,6 +117,28 @@ export async function userOnboardingForBrand(brand: string): Promise<Onboarding>
   )
 }
 
+export interface OnboardingBrandStatus {
+  brand: string
+  is_completed: boolean
+  completed_flow: string | null
+  completed_at: Date | null
+}
+
+export interface OnboardingStatus {
+  has_completed_onboarding: boolean
+  brands: OnboardingBrandStatus[]
+}
+
+/**
+ * Fetches the current user's onboarding completion status across all brands.
+ *
+ * @returns {Promise<OnboardingStatus>} - A promise that resolves with the cross-brand onboarding status.
+ * @throws {HttpError} - If the HTTP request fails.
+ */
+export async function getOnboardingStatus(): Promise<OnboardingStatus> {
+  return GET(`/api/user-management-system/v1/users/${globalConfig.sessionConfig.userId}/onboardings/status`)
+}
+
 export interface OnboardingRecommendedContent {
   id: number
   title: string


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/1375)

## Description/Design

- Adds `getOnboardingStatus()` so callers can check a user's onboarding completion across all brands in one call, instead of per-brand lookups via `userOnboardingForBrand`.
- Exposes `OnboardingBrandStatus`/`OnboardingStatus` types and regenerates `index.js`/`index.d.ts` to export the new function.

## Testing

- How to verify: call `getOnboardingStatus()` after `initializeService()` with a valid session, confirm response includes `has_completed_onboarding` and a `brands` array with per-brand completion state.
- Environment: local
- Expected outcome: returns onboarding status for all brands for the current user
