### PR TITLE
chore(MU2-1724): add song and lesson count query

### DIFF
--- a/.agent/decisions/2026-07-20-mu2-1724-songs-lessons-counts.md
+++ b/.agent/decisions/2026-07-20-mu2-1724-songs-lessons-counts.md
@@ -1,0 +1,33 @@
+---
+date: 2026-07-20
+branch: chore/MU2-1724-songs-lessons-counts
+pr: https://github.com/railroadmedia/musora-content-services/pull/1012
+status: open
+tags: [[chore]]
+---
+
+# Song and lesson counts query
+
+## Context
+Needed a way to get the total number of songs vs. individual playable lessons in Sanity, globally or scoped to a brand. Content types don't map 1:1 onto "song" vs "lesson" — songs include `song`, `play-along`, `jam-track`, `song-tutorial-lesson` per `SONG_TYPES` in `contentTypeConfig.js`, and a "lesson" is any published, top-level (no `parent_type` / empty `parent_content_reference`) document with a `railcontent_id`, regardless of `_type`. The final filter definitions came out of a discussion with teammates, converging on `status == 'published' && defined(railcontent_id)` plus the parent-less check for lessons.
+
+## Decision
+Added `fetchSongAndLessonCounts(brand?)` in `src/services/content/counts.ts`, returning `{ songs, lessons, total }`.
+- Filter logic built with the `Filters` helper (`src/lib/sanity/filter.ts`) and `query()` builder (`src/lib/sanity/query.ts`) instead of hand-interpolated GROQ strings, for consistency with `artist.ts`/`genre.ts`/`instructor.ts`.
+- Query executed via `SanityClient.executeQuery` (`src/infrastructure/sanity/SanityClient.ts`) rather than the legacy `fetchSanity` in `sanity.js` — `executeQuery` returns the raw object result directly, which fits an object-shaped `{songs, lessons}` GROQ query better than `fetchSanity`'s array-oriented `isList` handling.
+- `total` is computed in application code (`songs + lessons`) after the query resolves, not inside GROQ, keeping the query itself to two independent counts.
+- Kept `content.ts` as a types-only file (its original purpose) — the new function and its `SongAndLessonCounts` interface live in the new `counts.ts` file instead, matching the one-file-per-concern convention in `src/services/content/`.
+
+## Alternatives Considered
+- Hand-built GROQ query with `${brand}` string interpolation (the version worked out iteratively with the Sanity MCP) — rejected in favor of the `Filters`/`query` builder for composability and to match existing code style.
+- A fluent `.then().then()` chain for the `total` calculation — tried during review, rejected as unnecessary indirection versus a plain `await` + object literal; reverted to match house style (`artist.ts`, `sanity.js` use plain `await` throughout).
+- Putting the function directly in `content.ts` — rejected once it became clear that file is types-only elsewhere in the codebase; moved to a dedicated `counts.ts`.
+
+## Process Notes
+- `course` vs `course-lesson`: `course` is the parent course entity, `course-lesson` is the individual playable video inside it — easy to conflate when first scoping "lesson" types.
+- Lesson types span several groupings in `contentTypeConfig.js` (`individualLessonsTypes`, `entertainmentLessonTypes`, `skill-pack-lesson`, `guided-course-lesson`, `pack-bundle-lesson`, live/student archive types) — rather than enumerate all `_type` values, the final query avoids the type-list entirely and instead filters on the structural "no parent" condition, which is more robust to new content types being added later.
+- `pack-bundle-lesson` appears in `SINGLE_PARENT_TYPES` but nowhere else in `contentTypeConfig.js` — possibly legacy/unused; not specifically verified against the live Sanity schema.
+
+## Consequences
+- New public function `fetchSongAndLessonCounts` exported from `src/services/content/counts.ts`; needs `npm run build-index` to surface in the generated package index/types.
+- Introduces the first consumer of `SanityClient.executeQuery` outside `src/infrastructure/sanity/` — establishes a pattern for future count/aggregate-style queries to use the client class over `fetchSanity`.

--- a/src/services/content/counts.ts
+++ b/src/services/content/counts.ts
@@ -1,0 +1,47 @@
+import { SONG_TYPES } from '../../contentTypeConfig.js'
+import { SanityClient } from '../../infrastructure/sanity/SanityClient'
+import { Brands } from '../../lib/brands'
+import { Filters as f } from '../../lib/sanity/filter'
+import { query } from '../../lib/sanity/query'
+
+const sanityClient = new SanityClient()
+
+export interface SongAndLessonCounts {
+  songs: number
+  lessons: number
+  total: number
+}
+
+/**
+ * @param {Brands|string} [brand] - Filters by brand; omit for a global count.
+ * @returns {Promise<SongAndLessonCounts>}
+ */
+export async function fetchSongAndLessonCounts(
+  brand?: Brands | string
+): Promise<SongAndLessonCounts> {
+  const songsFilter = await f.combineAsync(
+    f.typeIn(SONG_TYPES),
+    f.statusIn(['published']),
+    f.defined('railcontent_id'),
+    brand ? f.brand(brand) : f.empty
+  )
+
+  const lessonsFilter = await f.combineAsync(
+    f.defined('railcontent_id'),
+    f.statusIn(['published']),
+    f.combineOr(f.notDefined('parent_type'), 'count(parent_content_reference) == 0'),
+    brand ? f.brand(brand) : f.empty
+  )
+
+  const q = `{
+    "songs": count(${query().and(songsFilter).build()}),
+    "lessons": count(${query().and(lessonsFilter).build()})
+  }`
+
+  const counts = (await sanityClient.executeQuery<Omit<SongAndLessonCounts, 'total'>>(q)) ?? {
+    songs: 0,
+    lessons: 0,
+  }
+
+  return { ...counts, total: counts.songs + counts.lessons }
+}

--- a/test/unit/content/counts.test.ts
+++ b/test/unit/content/counts.test.ts
@@ -1,0 +1,69 @@
+import { fetchSongAndLessonCounts } from '../../../src/services/content/counts'
+import { SanityClient } from '../../../src/infrastructure/sanity/SanityClient'
+
+describe('fetchSongAndLessonCounts', () => {
+  let executeQuerySpy: jest.SpyInstance
+
+  beforeEach(() => {
+    executeQuerySpy = jest.spyOn(SanityClient.prototype, 'executeQuery')
+  })
+
+  afterEach(() => {
+    executeQuerySpy.mockRestore()
+  })
+
+  test('sums songs and lessons into total', async () => {
+    executeQuerySpy.mockResolvedValue({ songs: 14297, lessons: 12826 })
+
+    const result = await fetchSongAndLessonCounts()
+
+    expect(result).toEqual({ songs: 14297, lessons: 12826, total: 27123 })
+  })
+
+  test('defaults to zero counts when the query returns nothing', async () => {
+    executeQuerySpy.mockResolvedValue(null)
+
+    const result = await fetchSongAndLessonCounts()
+
+    expect(result).toEqual({ songs: 0, lessons: 0, total: 0 })
+  })
+
+  test('queries globally when no brand is provided', async () => {
+    executeQuerySpy.mockResolvedValue({ songs: 1, lessons: 1 })
+
+    await fetchSongAndLessonCounts()
+
+    const query = executeQuerySpy.mock.calls[0][0] as string
+    expect(query).not.toContain('brand ==')
+  })
+
+  test('scopes both counts to the given brand', async () => {
+    executeQuerySpy.mockResolvedValue({ songs: 1, lessons: 1 })
+
+    await fetchSongAndLessonCounts('drumeo')
+
+    const query = executeQuerySpy.mock.calls[0][0] as string
+    const brandFilterCount = query.split('brand == "drumeo"').length - 1
+    expect(brandFilterCount).toBe(2)
+  })
+
+  test('scopes the songs filter to the known song types', async () => {
+    executeQuerySpy.mockResolvedValue({ songs: 1, lessons: 1 })
+
+    await fetchSongAndLessonCounts()
+
+    const query = executeQuerySpy.mock.calls[0][0] as string
+    expect(query).toContain("_type in ['song','play-along','jam-track','song-tutorial-lesson']")
+  })
+
+  test('scopes the lessons filter to top-level published content with a railcontent_id', async () => {
+    executeQuerySpy.mockResolvedValue({ songs: 1, lessons: 1 })
+
+    await fetchSongAndLessonCounts()
+
+    const query = executeQuerySpy.mock.calls[0][0] as string
+    expect(query).toContain('defined(railcontent_id)')
+    expect(query).toContain("status in ['published']")
+    expect(query).toContain('(!defined(parent_type) || count(parent_content_reference) == 0)')
+  })
+})


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- MU2-1724

## Description/Design

- Adds `fetchSongAndLessonCounts` in `src/services/content/counts.ts` to give a single global or brand-scoped count of songs and lessons in Sanity, driven from a teammate-reviewed GROQ query.
- Uses the `Filters`/`query` builder helpers (`lib/sanity/filter.ts`, `lib/sanity/query.ts`) and `SanityClient.executeQuery` for composability and consistency with the newer infra layer, rather than the legacy `fetchSanity` GET/POST helper in `sanity.js`.
- `total` is derived in application code (`songs + lessons`) after the query returns, rather than in GROQ, to keep the query itself simple.

## Testing

- How to verify: call `fetchSongAndLessonCounts()` for a global count, and `fetchSongAndLessonCounts('drumeo')` (or another brand) for a brand-scoped count; confirm counts match manual GROQ queries run against the `production_v2` dataset.
- Environment: local
- Expected outcome: returns `{ songs, lessons, total }` with `total === songs + lessons`.