### PR TITLE
fix: add gen-version script in MCS version log

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src/version-info.js
 scripts/
 test/
 coverage/

--- a/scripts/gen-version.cjs
+++ b/scripts/gen-version.cjs
@@ -1,0 +1,7 @@
+const fs = require('fs')
+const path = require('path')
+
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'))
+
+const outPath = path.join(__dirname, '../src/version-info.js')
+fs.writeFileSync(outPath, `export const MCS_VERSION = '${pkg.version}'\n`)

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -82,6 +82,8 @@ export async function getMCSVersion() {
 }
 
 if (process.env.NODE_ENV === 'development') {
+  getMCSVersion().then(v => v && console.log('[MCS] last tagged version:', v))
+} else {
   getMCSVersion().then(v => v && console.log('[MCS] version:', v))
 }
 
@@ -107,4 +109,3 @@ export function initializeService(config) {
 export function initializeEnvVar(config) {
   globalConfig.appEnv = config.appEnv
 }
-


### PR DESCRIPTION
Actually adds the key version-logging that was missing in #986  