### PR TITLE
feat(BEHSTP-439): fetch/update user practice goals 

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,7 @@ import {
 } from './services/awards/award-query.js';
 
 import {
+	getMCSVersion,
 	globalConfig,
 	initializeEnvVar,
 	initializeService
@@ -27,6 +28,10 @@ import {
 	fetchArtistLessons,
 	fetchArtists
 } from './services/content/artist.ts';
+
+import {
+	fetchSongAndLessonCounts
+} from './services/content/counts.ts';
 
 import {
 	fetchGenreBySlug,
@@ -468,6 +473,11 @@ import {
 } from './services/user/playerSettings.ts';
 
 import {
+	fetchPracticeGoals,
+	updatePracticeGoals
+} from './services/user/practiceGoals.ts';
+
+import {
 	deleteProfilePicture,
 	otherStats,
 	updateProfileVisibility
@@ -636,6 +646,7 @@ declare module 'musora-content-services' {
 		fetchPlaylistItems,
 		fetchPost,
 		fetchPosts,
+		fetchPracticeGoals,
 		fetchRecent,
 		fetchRecentActivitiesActiveTabs,
 		fetchRecentUserActivities,
@@ -651,6 +662,7 @@ declare module 'musora-content-services' {
 		fetchShowsData,
 		fetchSiblingContent,
 		fetchSimilarItems,
+		fetchSongAndLessonCounts,
 		fetchSongArtistCount,
 		fetchSongById,
 		fetchTabData,
@@ -702,6 +714,7 @@ declare module 'musora-content-services' {
 		getLearningPathLessonsByIds,
 		getLegacyMethods,
 		getLessonContentRows,
+		getMCSVersion,
 		getMonday,
 		getNavigateTo,
 		getNavigateToForMethod,
@@ -854,6 +867,7 @@ declare module 'musora-content-services' {
 		updatePlayerSettings,
 		updatePlaylist,
 		updatePost,
+		updatePracticeGoals,
 		updatePracticeNotes,
 		updateProfileVisibility,
 		updateThread,

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import {
 } from './services/awards/award-query.js';
 
 import {
+	getMCSVersion,
 	globalConfig,
 	initializeEnvVar,
 	initializeService
@@ -31,6 +32,10 @@ import {
 	fetchArtistLessons,
 	fetchArtists
 } from './services/content/artist.ts';
+
+import {
+	fetchSongAndLessonCounts
+} from './services/content/counts.ts';
 
 import {
 	fetchGenreBySlug,
@@ -472,6 +477,11 @@ import {
 } from './services/user/playerSettings.ts';
 
 import {
+	fetchPracticeGoals,
+	updatePracticeGoals
+} from './services/user/practiceGoals.ts';
+
+import {
 	deleteProfilePicture,
 	otherStats,
 	updateProfileVisibility
@@ -635,6 +645,7 @@ export {
 	fetchPlaylistItems,
 	fetchPost,
 	fetchPosts,
+	fetchPracticeGoals,
 	fetchRecent,
 	fetchRecentActivitiesActiveTabs,
 	fetchRecentUserActivities,
@@ -650,6 +661,7 @@ export {
 	fetchShowsData,
 	fetchSiblingContent,
 	fetchSimilarItems,
+	fetchSongAndLessonCounts,
 	fetchSongArtistCount,
 	fetchSongById,
 	fetchTabData,
@@ -701,6 +713,7 @@ export {
 	getLearningPathLessonsByIds,
 	getLegacyMethods,
 	getLessonContentRows,
+	getMCSVersion,
 	getMonday,
 	getNavigateTo,
 	getNavigateToForMethod,
@@ -853,6 +866,7 @@ export {
 	updatePlayerSettings,
 	updatePlaylist,
 	updatePost,
+	updatePracticeGoals,
 	updatePracticeNotes,
 	updateProfileVisibility,
 	updateThread,

--- a/src/services/user/practiceGoals.ts
+++ b/src/services/user/practiceGoals.ts
@@ -1,0 +1,27 @@
+/**
+ * @module PracticeGoals
+ */
+import { HttpClient } from '../../infrastructure/http/HttpClient'
+import { globalConfig } from '../config.js'
+import type { PracticeGoals, UpdatePracticeGoalsData } from './types'
+
+const baseUrl = '/api/user/practices/v1/goals'
+
+/**
+ * @returns {Promise<PracticeGoals>}
+ * @throws {HttpError}
+ */
+export async function fetchPracticeGoals(): Promise<PracticeGoals> {
+  const httpClient = new HttpClient(globalConfig.baseUrl, globalConfig.sessionConfig.token)
+  return httpClient.get<PracticeGoals>(baseUrl)
+}
+
+/**
+ * @param {UpdatePracticeGoalsData} data
+ * @returns {Promise<PracticeGoals>}
+ * @throws {HttpError}
+ */
+export async function updatePracticeGoals(data: UpdatePracticeGoalsData): Promise<PracticeGoals> {
+  const httpClient = new HttpClient(globalConfig.baseUrl, globalConfig.sessionConfig.token)
+  return httpClient.patch<PracticeGoals>(baseUrl, data)
+}

--- a/src/services/user/types.d.ts
+++ b/src/services/user/types.d.ts
@@ -110,6 +110,17 @@ export interface UpdatePlayerSettingsData {
   playlist_auto_next?: boolean
 }
 
+export interface PracticeGoals {
+  weekly_target_days: number | null
+  daily_target_minutes: number | null
+  updated_at: string | null
+}
+
+export interface UpdatePracticeGoalsData {
+  weekly_target_days?: number
+  daily_target_minutes?: number
+}
+
 export interface StreakDTO {
   type: 'week' | 'day'
   length: number


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [BEHSTP-439](https://musora.atlassian.net/browse/BEHSTP-439) && [BEHSTP-438](https://musora.atlassian.net/browse/BEHSTP-438)
- [ MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/1398)

## Description/Design

 Add MCS methods to fetch/update user practice goals                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  - New fetchPracticeGoals() / updatePracticeGoals(data) in src/services/user/practiceGoals.ts — GET/PATCH against the new backend endpoint /api/user/practices/v1/goals.                                                                                                                                                                                                     
  - Adds PracticeGoals / UpdatePracticeGoalsData types (weekly_target_days, daily_target_minutes, updated_at).                                                                                                                      
  - Regenerates index.js/index.d.ts to export the two new methods. This also picks up getMCSVersion and fetchSongAndLessonCounts, which existed in src/ but were missing from the generated index before this change (unrelated     
  pre-existing gap, fixed incidentally by the regeneration).   

## Testing

- fetchPracticeGoals() returns null fields for a user with no saved goals, and the saved values otherwise  
- updatePracticeGoals({ weeklyTargetDays }) / { dailyTargetMinutes } update independently
- updatePracticeGoals({ weeklyTargetDays, dailyTargetMinutes }) updates both at once

## Additional Notes

- _Provide any additional context or notes that might be helpful for the reviewer._


[BEHSTP-439]: https://musora.atlassian.net/browse/BEHSTP-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BEHSTP-438]: https://musora.atlassian.net/browse/BEHSTP-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ