### PR TITLE
chore: add subscription platform(s) to membership controller  

### DIFF
--- a/src/services/user/memberships.ts
+++ b/src/services/user/memberships.ts
@@ -26,7 +26,7 @@ export interface UserMembershipResponse {
   need_lifetime_upgrade: boolean
   sub_account_data: MultiUserAccountResponse // post multiUserAccount data
   upgrade_options: UpgradeOption[] // post multiuser account data
-  subscription_data: {
+  user_subscriber_data: {
     has_had_apple_subscription: boolean
     has_had_google_subscription: boolean
     has_had_web_subscription: boolean

--- a/src/services/user/memberships.ts
+++ b/src/services/user/memberships.ts
@@ -26,6 +26,11 @@ export interface UserMembershipResponse {
   need_lifetime_upgrade: boolean
   sub_account_data: MultiUserAccountResponse // post multiUserAccount data
   upgrade_options: UpgradeOption[] // post multiuser account data
+  subscription_data: {
+    has_had_apple_subscription: boolean
+    has_had_google_subscription: boolean
+    has_had_web_subscription: boolean
+  }
 }
 
 /**


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)
[MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/1406)
- Chat with Steph regarding forward solution that will support Mua data and current implementation
<img width="688" height="472" alt="image" src="https://github.com/user-attachments/assets/6c1a5f7b-f5c0-4e06-a138-5434514b333a" />

## Description/Design

- We wanted a way to understand if we should show the iframe. The current usora_users fields are based on CURRENT subscription, and these are removed in the MUA project. 
- I check the user's uaps for any apple/google product (all subscriptions by nature), and any subscription web purchases.

## Testing

Added unit tests to BE, then tested quickly with MCS cli to ensure the structure matched.