### PR TITLE
fix(BR-716): apply timezone handling to practice streak calculations

### DIFF
--- a/src/services/dateUtils.js
+++ b/src/services/dateUtils.js
@@ -46,9 +46,9 @@ export function isSameDate(date1, date2) {
 
 // Check if two dates are consecutive days
 export function isNextDay(date1, date2) {
-  const d1 = dayjs(date1).startOf('day')
-  const d2 = dayjs(date2).startOf('day')
-  return d2.diff(d1, 'day') === 1
+  const d1 = toLocalDay(date1)
+  const d2 = toLocalDay(date2)
+  return Math.round(d2.diff(d1, 'day', true)) === 1
 }
 export function getTimeRemainingUntilLocal(targetUtcIsoString, { withTotalSeconds } = {}) {
   const targetUTC = new Date(targetUtcIsoString)

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -595,9 +595,7 @@ function calculateStreaks(practices, includeStreakMessage = false) {
   let sortedPracticeDays = Object.keys(practices)
     .map((dateStr) => {
       const [year, month, day] = dateStr.split('-').map(Number)
-      const newDate = new Date()
-      newDate.setFullYear(year, month - 1, day)
-      return newDate
+      return new Date(year, month - 1, day, 0, 0, 0, 0)
     })
     .sort((a, b) => a - b)
   if (sortedPracticeDays.length === 0) {

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -650,6 +650,7 @@ function calculateStreaks(practices, includeStreakMessage = false) {
   // Calculate streak message only if includeStreakMessage is true
   if (includeStreakMessage) {
     let today = new Date()
+    today.setHours(0, 0, 0, 0)
     let yesterday = new Date(today)
     yesterday.setDate(today.getDate() - 1)
 


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [BR-716](https://musora.atlassian.net/browse/BR-716)

## Description/Design

- Bug report: the practice tracker/streak was rolling over to "the next day" around 4 hours before midnight PST.
- `isNextDay()` in `dateUtils.js` parsed dates with a bare `dayjs(date)`, which treats date-only strings as UTC midnight — in negative-UTC-offset zones (like PST/PDT) this shifts the effective day backward, causing an early rollover. `isSameDate()` right above it already avoids this via the `toLocalDay()` helper, but `isNextDay()` never got the same treatment. It now routes through `toLocalDay()` and rounds the day-diff so it also tolerates 23h/25h DST-transition days.
- `calculateStreaks()` in `userActivity.js` (the function behind the live current-streak the user sees) built day markers via `new Date()` + `setFullYear(...)`, which retains "now"'s time-of-day instead of pinning to local midnight. Its sibling `calculateLongestStreaks()` already received this exact fix in a previous commit, but `calculateStreaks()` was missed. It's now pinned to local midnight the same way.

## Testing

- `npm test test/unit/dateUtils.test.ts` — all 27 tests pass.
- Verify: practicing late in the evening (e.g. 5pm PST should be the breaking point) no longer causes the streak/tracker to register as the following day.

## Additional Notes

- No API or schema changes — purely client-side day-boundary math.


[BR-716]: https://musora.atlassian.net/browse/BR-716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ