### PR TITLE
feat(BEHSTP-441): New method: getWeeklyPracticeSessions and expose We…

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -241,6 +241,7 @@ import {
 
 import {
 	getPracticeSessionsOffline,
+	getWeeklyPracticeSessionsOffline,
 	otherStatsOffline
 } from './services/offline/practices.ts';
 
@@ -502,6 +503,7 @@ import {
 	getStreaksAndMessage,
 	getUserMonthlyStats,
 	getUserWeeklyStats,
+	getWeeklyPracticeSessions,
 	recordUserActivity,
 	recordUserPractice,
 	removeUserPractice,
@@ -759,6 +761,8 @@ declare module 'musora-content-services' {
 		getUserSignature,
 		getUserWeeklyStats,
 		getWeekNumber,
+		getWeeklyPracticeSessions,
+		getWeeklyPracticeSessionsOffline,
 		globalConfig,
 		grant30DaysAccessForLifetime,
 		guidedCourses,

--- a/src/index.js
+++ b/src/index.js
@@ -245,6 +245,7 @@ import {
 
 import {
 	getPracticeSessionsOffline,
+	getWeeklyPracticeSessionsOffline,
 	otherStatsOffline
 } from './services/offline/practices.ts';
 
@@ -506,6 +507,7 @@ import {
 	getStreaksAndMessage,
 	getUserMonthlyStats,
 	getUserWeeklyStats,
+	getWeeklyPracticeSessions,
 	recordUserActivity,
 	recordUserPractice,
 	removeUserPractice,
@@ -758,6 +760,8 @@ export {
 	getUserSignature,
 	getUserWeeklyStats,
 	getWeekNumber,
+	getWeeklyPracticeSessions,
+	getWeeklyPracticeSessionsOffline,
 	globalConfig,
 	grant30DaysAccessForLifetime,
 	guidedCourses,

--- a/src/services/offline/practices.ts
+++ b/src/services/offline/practices.ts
@@ -3,16 +3,22 @@ import { Q } from '@nozbe/watermelondb'
 import dayjs from 'dayjs'
 import { globalConfig } from '../config'
 import { calculateLongestStreaks } from '../userActivity.js'
+import { getMonday } from '../dateUtils.js'
 
 /**
  * @param offlineTimestamp - Minimum `updated_at` epoch ms to include
  * @param day
  * @param options.day - Date in YYYY-MM-DD format, defaults to today
- * @returns {Promise<{data: {practices: object[], practiceDuration: number}}>}
+ * @param options.page - Page number, only applied when `limit` is set (default 1)
+ * @param options.limit - Max sessions to return
+ * @returns {Promise<{data: {practices: object[], practiceDuration: number, total: number, currentPage: number, totalPages: number}}>}
  */
 export async function getPracticeSessionsOffline(
   offlineTimestamp: number, {
-    day = dayjs().format('YYYY-MM-DD') }: { day?: string } = {}
+    day = dayjs().format('YYYY-MM-DD'),
+    page = 1,
+    limit
+  }: { day?: string, page?: number, limit?: number } = {}
 ) {
 
   const query = await db.practices.queryAll(
@@ -20,14 +26,67 @@ export async function getPracticeSessionsOffline(
     Q.sortBy('created_at', 'asc'))
   const practices = query.data
 
-  if (!practices.length) return { data: { practices: [], practiceDuration: 0 } }
+  if (!practices.length)
+    return { data: { practices: [], practiceDuration: 0, total: 0, currentPage: page, totalPages: 1 } }
 
   const practiceDuration = Math.round(practices.reduce(
     (total, practice) => total + (practice.duration_seconds || 0),
     0
   ))
 
-  return { data: { practices, practiceDuration } }
+  const pagedPractices = limit ? practices.slice((page - 1) * limit, page * limit) : practices
+
+  return {
+    data: {
+      practices: pagedPractices,
+      practiceDuration,
+      total: practices.length,
+      currentPage: page,
+      totalPages: limit ? Math.ceil(practices.length / limit) : 1,
+    },
+  }
+}
+
+/**
+ * @param offlineTimestamp - Minimum `updated_at` epoch ms to include
+ * @param options.page - Page number, only applied when `limit` is set (default 1)
+ * @param options.limit - Max sessions to return
+ * @returns {Promise<{data: {practices: object[], practiceDuration: number, total: number, currentPage: number, totalPages: number}}>}
+ */
+export async function getWeeklyPracticeSessionsOffline(
+  offlineTimestamp: number, {
+    page = 1,
+    limit
+  }: { page?: number, limit?: number } = {}
+) {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const startOfWeek = getMonday(new Date(), timeZone)
+  const weekDays = Array.from({ length: 7 }, (_, i) => startOfWeek.add(i, 'day').format('YYYY-MM-DD'))
+
+  const query = await db.practices.queryAll(
+    Q.where('date', Q.oneOf(weekDays)),
+    Q.sortBy('created_at', 'asc'))
+  const practices = query.data
+
+  if (!practices.length)
+    return { data: { practices: [], practiceDuration: 0, total: 0, currentPage: page, totalPages: 1 } }
+
+  const practiceDuration = Math.round(practices.reduce(
+    (total, practice) => total + (practice.duration_seconds || 0),
+    0
+  ))
+
+  const pagedPractices = limit ? practices.slice((page - 1) * limit, page * limit) : practices
+
+  return {
+    data: {
+      practices: pagedPractices,
+      practiceDuration,
+      total: practices.length,
+      currentPage: page,
+      totalPages: limit ? Math.ceil(practices.length / limit) : 1,
+    },
+  }
 }
 
 export async function otherStatsOffline(userId = globalConfig.sessionConfig.userId) {

--- a/src/services/offline/practices.ts
+++ b/src/services/offline/practices.ts
@@ -24,27 +24,8 @@ export async function getPracticeSessionsOffline(
   const query = await db.practices.queryAll(
     Q.where('date', day),
     Q.sortBy('created_at', 'asc'))
-  const practices = query.data
 
-  if (!practices.length)
-    return { data: { practices: [], practiceDuration: 0, total: 0, currentPage: page, totalPages: 1 } }
-
-  const practiceDuration = Math.round(practices.reduce(
-    (total, practice) => total + (practice.duration_seconds || 0),
-    0
-  ))
-
-  const pagedPractices = limit ? practices.slice((page - 1) * limit, page * limit) : practices
-
-  return {
-    data: {
-      practices: pagedPractices,
-      practiceDuration,
-      total: practices.length,
-      currentPage: page,
-      totalPages: limit ? Math.ceil(practices.length / limit) : 1,
-    },
-  }
+  return formatPracticeSessionDataOffline(query.data, page, limit)
 }
 
 /**
@@ -66,8 +47,11 @@ export async function getWeeklyPracticeSessionsOffline(
   const query = await db.practices.queryAll(
     Q.where('date', Q.oneOf(weekDays)),
     Q.sortBy('created_at', 'asc'))
-  const practices = query.data
 
+  return formatPracticeSessionDataOffline(query.data, page, limit)
+}
+
+function formatPracticeSessionDataOffline(practices: any[], page: number, limit?: number) {
   if (!practices.length)
     return { data: { practices: [], practiceDuration: 0, total: 0, currentPage: page, totalPages: 1 } }
 

--- a/src/services/user/streakCalculator.ts
+++ b/src/services/user/streakCalculator.ts
@@ -6,6 +6,8 @@ export interface StreakData {
   currentDailyStreak: number
   currentWeeklyStreak: number
   streakMessage: string
+  streakMessagePart1: string
+  streakMessagePart2: string
   calculatedAt: number // timestamp
   lastPracticeDate: string | null
   currentWeekPracticeDays: number
@@ -30,13 +32,21 @@ class StreakCalculator {
   async recalculate(): Promise<StreakData> {
     const allPractices = await this.fetchAllPractices()
 
-    const { currentDailyStreak, currentWeeklyStreak, streakMessage, currentWeekPracticeDays } =
-      getStreaksAndMessage(allPractices)
+    const {
+      currentDailyStreak,
+      currentWeeklyStreak,
+      streakMessage,
+      streakMessagePart1,
+      streakMessagePart2,
+      currentWeekPracticeDays,
+    } = getStreaksAndMessage(allPractices)
 
     this.cache = {
       currentDailyStreak: currentDailyStreak,
       currentWeeklyStreak: currentWeeklyStreak,
       streakMessage: streakMessage,
+      streakMessagePart1: streakMessagePart1,
+      streakMessagePart2: streakMessagePart2,
       calculatedAt: Date.now(),
       lastPracticeDate: this.getLastPracticeDate(allPractices),
       currentWeekPracticeDays: currentWeekPracticeDays,

--- a/src/services/user/streakCalculator.ts
+++ b/src/services/user/streakCalculator.ts
@@ -8,12 +8,7 @@ export interface StreakData {
   streakMessage: string
   calculatedAt: number // timestamp
   lastPracticeDate: string | null
-  // Calendar days with at least one recorded practice since Monday of the current
-  // week — used for the weekly practice-days target progress (US-CPT-2/US-CPT-4).
   currentWeekPracticeDays: number
-  // Total practice seconds recorded today — used for the daily practice-minutes
-  // target progress (US-CPT-2). Derived from the same already-fetched practice
-  // data as the rest of this cache, so it costs nothing extra to include here.
   todaysPracticeSeconds: number
 }
 export interface PracticeData {

--- a/src/services/user/streakCalculator.ts
+++ b/src/services/user/streakCalculator.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import { db } from '../sync'
 import { getStreaksAndMessage } from '../../services/userActivity.js'
 
@@ -7,6 +8,13 @@ export interface StreakData {
   streakMessage: string
   calculatedAt: number // timestamp
   lastPracticeDate: string | null
+  // Calendar days with at least one recorded practice since Monday of the current
+  // week — used for the weekly practice-days target progress (US-CPT-2/US-CPT-4).
+  currentWeekPracticeDays: number
+  // Total practice seconds recorded today — used for the daily practice-minutes
+  // target progress (US-CPT-2). Derived from the same already-fetched practice
+  // data as the rest of this cache, so it costs nothing extra to include here.
+  todaysPracticeSeconds: number
 }
 export interface PracticeData {
   [date: string]: Array<{
@@ -27,14 +35,17 @@ class StreakCalculator {
   async recalculate(): Promise<StreakData> {
     const allPractices = await this.fetchAllPractices()
 
-    const { currentDailyStreak, currentWeeklyStreak, streakMessage } = getStreaksAndMessage(allPractices)
+    const { currentDailyStreak, currentWeeklyStreak, streakMessage, currentWeekPracticeDays } =
+      getStreaksAndMessage(allPractices)
 
     this.cache = {
       currentDailyStreak: currentDailyStreak,
       currentWeeklyStreak: currentWeeklyStreak,
       streakMessage: streakMessage,
       calculatedAt: Date.now(),
-      lastPracticeDate: this.getLastPracticeDate(allPractices)
+      lastPracticeDate: this.getLastPracticeDate(allPractices),
+      currentWeekPracticeDays: currentWeekPracticeDays,
+      todaysPracticeSeconds: this.getTodaysPracticeSeconds(allPractices),
     }
     return this.cache
   }
@@ -58,6 +69,11 @@ class StreakCalculator {
   private getLastPracticeDate(practices: PracticeData): string | null {
     const dates = Object.keys(practices).sort()
     return dates.length > 0 ? dates[dates.length - 1] : null
+  }
+
+  private getTodaysPracticeSeconds(practices: PracticeData): number {
+    const today = dayjs().format('YYYY-MM-DD')
+    return (practices[today] || []).reduce((total, practice) => total + practice.duration_seconds, 0)
   }
 }
 

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -113,15 +113,7 @@ export async function getUserWeeklyStats() {
   }
 
   const streakData = await streakCalculator.getStreakData()
- console.log('rox::: getUserWeeklyStats ',  {
-   data: {
-     dailyActiveStats: dailyStats,
-     streakMessage: streakData.streakMessage,
-     practices: weekPractices,
-     currentWeekPracticeDays: streakData.currentWeekPracticeDays,
-     todaysPracticeSeconds: streakData.todaysPracticeSeconds,
-   }
- })
+
   return {
     data: {
       dailyActiveStats: dailyStats,
@@ -493,7 +485,7 @@ export async function getPracticeSessions(params = {}, options = {}) {
  * @param {number} [params.page=1] - The page number, only applied when `limit` is set.
  * @param {number} [params.limit] - Max sessions to return; omit to return all of the week's sessions unpaginated.
  * @returns {Promise<Object>} - A promise that resolves to an object containing:
- *   - `sessionsByDate`: Formatted practice sessions grouped by date (YYYY-MM-DD), paginated if `limit` is set.
+ *   - `practices`: An array of formatted practice session data for the week (paginated if `limit` is set).
  *   - `practiceDuration`: Total practice duration (in seconds) for the whole week, regardless of pagination.
  *   - `total`: Total number of sessions for the week, regardless of pagination.
  *
@@ -515,10 +507,10 @@ export async function getWeeklyPracticeSessions(params = {}, options = {}) {
     db.practices.pull()
   }
 
-  const query = await db.practices.queryAll(Q.where('date', Q.oneOf(weekDays)), Q.sortBy('date', 'desc'))
+  const query = await db.practices.queryAll(Q.where('date', Q.oneOf(weekDays)), Q.sortBy('created_at', 'asc'))
   const data = query.data
 
-  if (!data.length) return { data: { sessionsByDate: {}, practiceDuration: 0, total: 0 } }
+  if (!data.length) return { data: { practices: [], practiceDuration: 0, total: 0 } }
 
   // Total reflects the full week, not just the current page, so goal-progress
   // math stays correct regardless of how the session list is paginated.
@@ -529,13 +521,7 @@ export async function getWeeklyPracticeSessions(params = {}, options = {}) {
   const pagedData = limit ? data.slice((page - 1) * limit, page * limit) : data
   const formattedMeta = await formatPracticeMeta(pagedData)
 
-  const sessionsByDate = formattedMeta.reduce((acc, practice) => {
-    acc[practice.date] = acc[practice.date] || []
-    acc[practice.date].push(practice)
-    return acc
-  }, {})
-
-  return { data: { sessionsByDate, practiceDuration, total: data.length } }
+  return { data: { practices: formattedMeta, practiceDuration, total: data.length } }
 }
 
 /**
@@ -651,12 +637,7 @@ export function getStreaksAndMessage(practices) {
     practices,
     true
   )
-console.log('rox::: getStreakMessage', {
-  currentDailyStreak,
-  currentWeeklyStreak,
-  streakMessage,
-  currentWeekPracticeDays,
-})
+
   return {
     currentDailyStreak,
     currentWeeklyStreak,

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -18,32 +18,50 @@ import { mapContentsThatWereLastProgressedFromMethod } from "./content-org/learn
 const DAYS = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
 
 const streakMessages = {
-  startStreak: 'Start your streak by taking any lesson!',
-  restartStreak: 'Restart your streak by taking any lesson!',
+  startStreak: { part1: 'Start your streak by taking any lesson!', part2: '' },
+  restartStreak: { part1: 'Restart your streak by taking any lesson!', part2: '' },
 
   // Messages when last active day is today
-  dailyStreak: (streak) =>
-    `Nice! You have ${getIndefiniteArticle(streak)} ${streak} day streak! Way to keep it going!`,
-  dailyStreakShort: (streak) =>
-    `Nice! You have ${getIndefiniteArticle(streak)} ${streak} day streak!`,
-  weeklyStreak: (streak) =>
-    `You have ${getIndefiniteArticle(streak)} ${streak} week streak! Way to keep up the momentum!`,
-  greatJobWeeklyStreak: (streak) =>
-    `Great job! You have ${getIndefiniteArticle(streak)} ${streak} week streak! Way to keep it going!`,
+  dailyStreak: (streak) => ({
+    part1: `Nice! You have ${getIndefiniteArticle(streak)} ${streak} day streak!`,
+    part2: 'Way to keep it going!',
+  }),
+  dailyStreakShort: (streak) => ({
+    part1: `Nice! You have ${getIndefiniteArticle(streak)} ${streak} day streak!`,
+    part2: '',
+  }),
+  weeklyStreak: (streak) => ({
+    part1: `You have ${getIndefiniteArticle(streak)} ${streak} week streak!`,
+    part2: 'Way to keep up the momentum!',
+  }),
+  greatJobWeeklyStreak: (streak) => ({
+    part1: `Great job! You have ${getIndefiniteArticle(streak)} ${streak} week streak!`,
+    part2: 'Way to keep it going!',
+  }),
 
   // Messages when last active day is NOT today
-  dailyStreakReminder: (streak) =>
-    `You have ${getIndefiniteArticle(streak)} ${streak} day streak! Keep it going with any lesson or song!`,
-  weeklyStreakKeepUp: (streak) =>
-    `You have ${getIndefiniteArticle(streak)} ${streak} week streak! Keep up the momentum!`,
-  weeklyStreakReminder: (streak) =>
-    `You have ${getIndefiniteArticle(streak)} ${streak} week streak! Keep it going with any lesson or song!`,
+  dailyStreakReminder: (streak) => ({
+    part1: `You have ${getIndefiniteArticle(streak)} ${streak} day streak!`,
+    part2: 'Keep it going with any lesson or song!',
+  }),
+  weeklyStreakKeepUp: (streak) => ({
+    part1: `You have ${getIndefiniteArticle(streak)} ${streak} week streak!`,
+    part2: 'Keep up the momentum!',
+  }),
+  weeklyStreakReminder: (streak) => ({
+    part1: `You have ${getIndefiniteArticle(streak)} ${streak} week streak!`,
+    part2: 'Keep it going with any lesson or song!',
+  }),
 }
 
 function getIndefiniteArticle(streak) {
   return streak === 8 || (streak >= 80 && streak <= 89) || (streak >= 800 && streak <= 899)
     ? 'an'
     : 'a'
+}
+
+function joinStreakMessageParts(part1, part2) {
+  return part2 ? `${part1} ${part2}` : part1
 }
 
 async function getUserPractices(userId) {
@@ -118,6 +136,8 @@ export async function getUserWeeklyStats() {
     data: {
       dailyActiveStats: dailyStats,
       streakMessage: streakData.streakMessage,
+      streakMessagePart1: streakData.streakMessagePart1,
+      streakMessagePart2: streakData.streakMessagePart2,
       practices: weekPractices,
       currentWeekPracticeDays: streakData.currentWeekPracticeDays,
       todaysPracticeSeconds: streakData.todaysPracticeSeconds,
@@ -633,15 +653,21 @@ export async function updatePracticeNotes(payload) {
 }
 
 export function getStreaksAndMessage(practices) {
-  let { currentDailyStreak, currentWeeklyStreak, streakMessage, currentWeekPracticeDays } = calculateStreaks(
-    practices,
-    true
-  )
+  let {
+    currentDailyStreak,
+    currentWeeklyStreak,
+    streakMessage,
+    streakMessagePart1,
+    streakMessagePart2,
+    currentWeekPracticeDays,
+  } = calculateStreaks(practices, true)
 
   return {
     currentDailyStreak,
     currentWeeklyStreak,
     streakMessage,
+    streakMessagePart1,
+    streakMessagePart2,
     currentWeekPracticeDays,
   }
 }
@@ -651,7 +677,7 @@ function calculateStreaks(practices, includeStreakMessage = false) {
   let currentDailyStreak = 0
   let currentWeeklyStreak = 0
   let lastActiveDay = null
-  let streakMessage = ''
+  let streakMessageParts = { part1: '', part2: '' }
 
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
   let sortedPracticeDays = Object.keys(practices)
@@ -667,7 +693,12 @@ function calculateStreaks(practices, includeStreakMessage = false) {
       currentDailyStreak: 0,
       currentWeeklyStreak: 0,
       currentWeekPracticeDays: 0,
-      streakMessage: streakMessages.startStreak,
+      streakMessage: joinStreakMessageParts(
+        streakMessages.startStreak.part1,
+        streakMessages.startStreak.part2
+      ),
+      streakMessagePart1: streakMessages.startStreak.part1,
+      streakMessagePart2: streakMessages.startStreak.part2,
     }
   }
   lastActiveDay = sortedPracticeDays[sortedPracticeDays.length - 1]
@@ -737,13 +768,13 @@ function calculateStreaks(practices, includeStreakMessage = false) {
 
     if (isSameDate(lastActiveDay, today)) {
       if (hasYesterdayPractice) {
-        streakMessage = streakMessages.dailyStreak(currentDailyStreak)
+        streakMessageParts = streakMessages.dailyStreak(currentDailyStreak)
       } else if (hasCurrentWeekPreviousPractice) {
-        streakMessage = streakMessages.weeklyStreak(currentWeeklyStreak)
+        streakMessageParts = streakMessages.weeklyStreak(currentWeeklyStreak)
       } else if (hasLastWeekPractice) {
-        streakMessage = streakMessages.greatJobWeeklyStreak(currentWeeklyStreak)
+        streakMessageParts = streakMessages.greatJobWeeklyStreak(currentWeeklyStreak)
       } else {
-        streakMessage = streakMessages.dailyStreakShort(currentDailyStreak)
+        streakMessageParts = streakMessages.dailyStreakShort(currentDailyStreak)
       }
     } else {
       if (
@@ -751,18 +782,25 @@ function calculateStreaks(practices, includeStreakMessage = false) {
         (hasYesterdayPractice && sortedPracticeDays.length == 1) ||
         (hasYesterdayPractice && !hasLastWeekPractice && hasOlderPractice)
       ) {
-        streakMessage = streakMessages.dailyStreakReminder(currentDailyStreak)
+        streakMessageParts = streakMessages.dailyStreakReminder(currentDailyStreak)
       } else if (hasCurrentWeekPractice) {
-        streakMessage = streakMessages.weeklyStreakKeepUp(currentWeeklyStreak)
+        streakMessageParts = streakMessages.weeklyStreakKeepUp(currentWeeklyStreak)
       } else if (hasLastWeekPractice) {
-        streakMessage = streakMessages.weeklyStreakReminder(currentWeeklyStreak)
+        streakMessageParts = streakMessages.weeklyStreakReminder(currentWeeklyStreak)
       } else {
-        streakMessage = streakMessages.restartStreak
+        streakMessageParts = streakMessages.restartStreak
       }
     }
   }
 
-  return { currentDailyStreak, currentWeeklyStreak, streakMessage, currentWeekPracticeDays }
+  return {
+    currentDailyStreak,
+    currentWeeklyStreak,
+    streakMessage: joinStreakMessageParts(streakMessageParts.part1, streakMessageParts.part2),
+    streakMessagePart1: streakMessageParts.part1,
+    streakMessagePart2: streakMessageParts.part2,
+    currentWeekPracticeDays,
+  }
 }
 
 /**

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -462,35 +462,11 @@ export async function getPracticeSessions(params = {}, options = {}) {
     data = query.data
   }
 
-  if (!data.length)
-    return { data: { practices: [], practiceDuration: 0, total: 0, currentPage: page, totalPages: 1 } }
-
-  // Total reflects the full day, not just the current page, so goal-progress
-  // math stays correct regardless of how the session list is paginated.
-  const practiceDuration = Math.round(
-    data.reduce((total, practice) => total + (practice.duration_seconds || 0), 0)
-  )
-
-  const pagedData = limit ? data.slice((page - 1) * limit, page * limit) : data
-  const formattedMeta = await formatPracticeMeta(pagedData)
-
-  return {
-    data: {
-      practices: formattedMeta,
-      practiceDuration,
-      total: data.length,
-      currentPage: page,
-      totalPages: limit ? Math.ceil(data.length / limit) : 1,
-    },
-  }
+  return formatPracticeSessionData(data, page, limit)
 }
 
 /**
- * Retrieves and formats the current user's practice sessions for the current
- * Monday-Sunday week, enriched with content metadata (title, thumbnail, etc.) in a
- * single batched lookup — for the weekly practice view where individual sessions can
- * be displayed, edited, or deleted (unlike getUserWeeklyStats, which only returns raw
- * per-day counts).
+ * Retrieves and formats the current user's practice sessions for the current Monday-Sunday week
  *
  * @param {Object} [params={}] - Parameters for fetching the week's practice sessions.
  * @param {number} [params.page=1] - The page number, only applied when `limit` is set.
@@ -523,11 +499,13 @@ export async function getWeeklyPracticeSessions(params = {}, options = {}) {
   const query = await db.practices.queryAll(Q.where('date', Q.oneOf(weekDays)), Q.sortBy('created_at', 'asc'))
   const data = query.data
 
+  return formatPracticeSessionData(data, page, limit)
+}
+
+async function formatPracticeSessionData(data, page, limit) {
   if (!data.length)
     return { data: { practices: [], practiceDuration: 0, total: 0, currentPage: page, totalPages: 1 } }
 
-  // Total reflects the full week, not just the current page, so goal-progress
-  // math stays correct regardless of how the session list is paginated.
   const practiceDuration = Math.round(
     data.reduce((total, practice) => total + (practice.duration_seconds || 0), 0)
   )

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -425,6 +425,8 @@ export async function restorePracticeSession(date) {
  *   - `practices`: An array of formatted practice session data (paginated if `limit` is set).
  *   - `practiceDuration`: Total practice duration (in seconds) for the whole day, regardless of pagination.
  *   - `total`: Total number of sessions for the day, regardless of pagination.
+ *   - `currentPage`: The page number returned
+ *   - `totalPages`: Total number of pages for the day
  *
  * @example
  * // Get practice sessions for the current user on a specific day
@@ -460,7 +462,8 @@ export async function getPracticeSessions(params = {}, options = {}) {
     data = query.data
   }
 
-  if (!data.length) return { data: { practices: [], practiceDuration: 0, total: 0 } }
+  if (!data.length)
+    return { data: { practices: [], practiceDuration: 0, total: 0, currentPage: page, totalPages: 1 } }
 
   // Total reflects the full day, not just the current page, so goal-progress
   // math stays correct regardless of how the session list is paginated.
@@ -471,7 +474,15 @@ export async function getPracticeSessions(params = {}, options = {}) {
   const pagedData = limit ? data.slice((page - 1) * limit, page * limit) : data
   const formattedMeta = await formatPracticeMeta(pagedData)
 
-  return { data: { practices: formattedMeta, practiceDuration, total: data.length } }
+  return {
+    data: {
+      practices: formattedMeta,
+      practiceDuration,
+      total: data.length,
+      currentPage: page,
+      totalPages: limit ? Math.ceil(data.length / limit) : 1,
+    },
+  }
 }
 
 /**
@@ -488,6 +499,8 @@ export async function getPracticeSessions(params = {}, options = {}) {
  *   - `practices`: An array of formatted practice session data for the week (paginated if `limit` is set).
  *   - `practiceDuration`: Total practice duration (in seconds) for the whole week, regardless of pagination.
  *   - `total`: Total number of sessions for the week, regardless of pagination.
+ *   - `currentPage`: The page number returned
+ *   - `totalPages`: Total number of pages for the week
  *
  * @example
  * getWeeklyPracticeSessions()
@@ -510,7 +523,8 @@ export async function getWeeklyPracticeSessions(params = {}, options = {}) {
   const query = await db.practices.queryAll(Q.where('date', Q.oneOf(weekDays)), Q.sortBy('created_at', 'asc'))
   const data = query.data
 
-  if (!data.length) return { data: { practices: [], practiceDuration: 0, total: 0 } }
+  if (!data.length)
+    return { data: { practices: [], practiceDuration: 0, total: 0, currentPage: page, totalPages: 1 } }
 
   // Total reflects the full week, not just the current page, so goal-progress
   // math stays correct regardless of how the session list is paginated.
@@ -521,7 +535,15 @@ export async function getWeeklyPracticeSessions(params = {}, options = {}) {
   const pagedData = limit ? data.slice((page - 1) * limit, page * limit) : data
   const formattedMeta = await formatPracticeMeta(pagedData)
 
-  return { data: { practices: formattedMeta, practiceDuration, total: data.length } }
+  return {
+    data: {
+      practices: formattedMeta,
+      practiceDuration,
+      total: data.length,
+      currentPage: page,
+      totalPages: limit ? Math.ceil(data.length / limit) : 1,
+    },
+  }
 }
 
 /**

--- a/src/services/userActivity.js
+++ b/src/services/userActivity.js
@@ -113,12 +113,22 @@ export async function getUserWeeklyStats() {
   }
 
   const streakData = await streakCalculator.getStreakData()
-
+ console.log('rox::: getUserWeeklyStats ',  {
+   data: {
+     dailyActiveStats: dailyStats,
+     streakMessage: streakData.streakMessage,
+     practices: weekPractices,
+     currentWeekPracticeDays: streakData.currentWeekPracticeDays,
+     todaysPracticeSeconds: streakData.todaysPracticeSeconds,
+   }
+ })
   return {
     data: {
       dailyActiveStats: dailyStats,
       streakMessage: streakData.streakMessage,
       practices: weekPractices,
+      currentWeekPracticeDays: streakData.currentWeekPracticeDays,
+      todaysPracticeSeconds: streakData.todaysPracticeSeconds,
     },
   }
 }
@@ -417,9 +427,12 @@ export async function restorePracticeSession(date) {
  * @param {Object} params - Parameters for fetching practice sessions.
  * @param {string} params.day - The date for which practice sessions should be retrieved (format: YYYY-MM-DD).
  * @param {number} [params.userId=globalConfig.sessionConfig.userId] - Optional user ID to retrieve sessions for a specific user. Defaults to the logged-in user.
+ * @param {number} [params.page=1] - The page number, only applied when `limit` is set.
+ * @param {number} [params.limit] - Max sessions to return; omit to return all of the day's sessions unpaginated.
  * @returns {Promise<Object>} - A promise that resolves to an object containing:
- *   - `practices`: An array of formatted practice session data.
- *   - `practiceDuration`: Total practice duration (in seconds) for the given day.
+ *   - `practices`: An array of formatted practice session data (paginated if `limit` is set).
+ *   - `practiceDuration`: Total practice duration (in seconds) for the whole day, regardless of pagination.
+ *   - `total`: Total number of sessions for the day, regardless of pagination.
  *
  * @example
  * // Get practice sessions for the current user on a specific day
@@ -434,7 +447,7 @@ export async function restorePracticeSession(date) {
  *   .catch(error => console.error(error));
  */
 export async function getPracticeSessions(params = {}, options = {}) {
-  const { day, userId = globalConfig.sessionConfig.userId } = params
+  const { day, userId = globalConfig.sessionConfig.userId, page = 1, limit } = params
 
   let data
 
@@ -455,15 +468,74 @@ export async function getPracticeSessions(params = {}, options = {}) {
     data = query.data
   }
 
-  if (!data.length) return { data: { practices: [], practiceDuration: 0 } }
+  if (!data.length) return { data: { practices: [], practiceDuration: 0, total: 0 } }
 
-  const formattedMeta = await formatPracticeMeta(data)
-  const practiceDuration = Math.round(formattedMeta.reduce(
-    (total, practice) => total + (practice.duration || 0),
-    0
-  ))
+  // Total reflects the full day, not just the current page, so goal-progress
+  // math stays correct regardless of how the session list is paginated.
+  const practiceDuration = Math.round(
+    data.reduce((total, practice) => total + (practice.duration_seconds || 0), 0)
+  )
 
-  return { data: { practices: formattedMeta, practiceDuration } }
+  const pagedData = limit ? data.slice((page - 1) * limit, page * limit) : data
+  const formattedMeta = await formatPracticeMeta(pagedData)
+
+  return { data: { practices: formattedMeta, practiceDuration, total: data.length } }
+}
+
+/**
+ * Retrieves and formats the current user's practice sessions for the current
+ * Monday-Sunday week, enriched with content metadata (title, thumbnail, etc.) in a
+ * single batched lookup — for the weekly practice view where individual sessions can
+ * be displayed, edited, or deleted (unlike getUserWeeklyStats, which only returns raw
+ * per-day counts).
+ *
+ * @param {Object} [params={}] - Parameters for fetching the week's practice sessions.
+ * @param {number} [params.page=1] - The page number, only applied when `limit` is set.
+ * @param {number} [params.limit] - Max sessions to return; omit to return all of the week's sessions unpaginated.
+ * @returns {Promise<Object>} - A promise that resolves to an object containing:
+ *   - `sessionsByDate`: Formatted practice sessions grouped by date (YYYY-MM-DD), paginated if `limit` is set.
+ *   - `practiceDuration`: Total practice duration (in seconds) for the whole week, regardless of pagination.
+ *   - `total`: Total number of sessions for the week, regardless of pagination.
+ *
+ * @example
+ * getWeeklyPracticeSessions()
+ *   .then(response => console.log(response))
+ *   .catch(error => console.error(error));
+ */
+export async function getWeeklyPracticeSessions(params = {}, options = {}) {
+  const { page = 1, limit } = params
+
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const startOfWeek = getMonday(new Date(), timeZone)
+  const weekDays = Array.from({ length: 7 }, (_, i) => startOfWeek.add(i, 'day').format('YYYY-MM-DD'))
+
+  if (options.pull) {
+    await db.practices.pull()
+  } else {
+    db.practices.pull()
+  }
+
+  const query = await db.practices.queryAll(Q.where('date', Q.oneOf(weekDays)), Q.sortBy('date', 'desc'))
+  const data = query.data
+
+  if (!data.length) return { data: { sessionsByDate: {}, practiceDuration: 0, total: 0 } }
+
+  // Total reflects the full week, not just the current page, so goal-progress
+  // math stays correct regardless of how the session list is paginated.
+  const practiceDuration = Math.round(
+    data.reduce((total, practice) => total + (practice.duration_seconds || 0), 0)
+  )
+
+  const pagedData = limit ? data.slice((page - 1) * limit, page * limit) : data
+  const formattedMeta = await formatPracticeMeta(pagedData)
+
+  const sessionsByDate = formattedMeta.reduce((acc, practice) => {
+    acc[practice.date] = acc[practice.date] || []
+    acc[practice.date].push(practice)
+    return acc
+  }, {})
+
+  return { data: { sessionsByDate, practiceDuration, total: data.length } }
 }
 
 /**
@@ -575,12 +647,21 @@ export async function updatePracticeNotes(payload) {
 }
 
 export function getStreaksAndMessage(practices) {
-  let { currentDailyStreak, currentWeeklyStreak, streakMessage } = calculateStreaks(practices, true)
-
+  let { currentDailyStreak, currentWeeklyStreak, streakMessage, currentWeekPracticeDays } = calculateStreaks(
+    practices,
+    true
+  )
+console.log('rox::: getStreakMessage', {
+  currentDailyStreak,
+  currentWeeklyStreak,
+  streakMessage,
+  currentWeekPracticeDays,
+})
   return {
     currentDailyStreak,
     currentWeeklyStreak,
     streakMessage,
+    currentWeekPracticeDays,
   }
 }
 
@@ -604,6 +685,7 @@ function calculateStreaks(practices, includeStreakMessage = false) {
     return {
       currentDailyStreak: 0,
       currentWeeklyStreak: 0,
+      currentWeekPracticeDays: 0,
       streakMessage: streakMessages.startStreak,
     }
   }
@@ -649,13 +731,17 @@ function calculateStreaks(practices, includeStreakMessage = false) {
   }
   currentWeeklyStreak = weeklyStreak
 
+  // Qualifying days (calendar days with at least one recorded practice) within the
+  // current Monday-anchored week — used for the weekly practice-days target progress.
+  let today = new Date()
+  let currentWeekStart = getMonday(today, timeZone)
+  let currentWeekPracticeDays = sortedPracticeDays.filter((date) => date >= currentWeekStart).length
+
   // Calculate streak message only if includeStreakMessage is true
   if (includeStreakMessage) {
-    let today = new Date()
     let yesterday = new Date(today)
     yesterday.setDate(today.getDate() - 1)
 
-    let currentWeekStart = getMonday(today, timeZone)
     let lastWeekStart = currentWeekStart.subtract(7, 'days')
 
     let hasYesterdayPractice = sortedPracticeDays.some((date) => isSameDate(date, yesterday))
@@ -695,7 +781,7 @@ function calculateStreaks(practices, includeStreakMessage = false) {
     }
   }
 
-  return { currentDailyStreak, currentWeeklyStreak, streakMessage }
+  return { currentDailyStreak, currentWeeklyStreak, streakMessage, currentWeekPracticeDays }
 }
 
 /**
@@ -806,6 +892,7 @@ async function formatPracticeMeta(practices = []) {
     return {
       id: practice.id,
       auto: practice.auto,
+      date: practice.date,
       thumbnail: practice.content_id ? content?.thumbnail : practice.thumbnail_url || '',
       thumbnail_url: practice.content_id ? content?.thumbnail : practice.thumbnail_url || '',
       duration: practice.duration_seconds || 0,

--- a/test/integration/userActivity.test.ts
+++ b/test/integration/userActivity.test.ts
@@ -1,5 +1,11 @@
 import { initializeTestService } from '../initializeTests.js'
-import { getUserMonthlyStats, getUserWeeklyStats, recordUserPractice } from '../../src/services/userActivity.js'
+import {
+  getUserMonthlyStats,
+  getUserWeeklyStats,
+  recordUserPractice,
+  getPracticeSessions,
+  getWeeklyPracticeSessions,
+} from '../../src/services/userActivity.js'
 
 let mockPracticesData: {
   date: string;
@@ -12,10 +18,24 @@ jest.mock('../../src/services/sync/repository-proxy.ts', () => {
       queryAll: jest.fn().mockImplementation(() => Promise.resolve({ data: mockPracticesData })),
       getAll: jest.fn().mockImplementation(() => Promise.resolve({ data: mockPracticesData })),
       recordManualPractice: jest.fn().mockResolvedValue({ success: true }),
+      pull: jest.fn().mockResolvedValue(undefined),
     }
   }
   return { default: mockFns, ...mockFns }
 })
+
+jest.mock('../../src/services/sanity.js', () => ({
+  ...jest.requireActual('../../src/services/sanity.js'),
+  fetchByRailContentIds: jest.fn(),
+}))
+
+jest.mock('../../src/services/contentAggregator.js', () => ({
+  addContextToContent: jest.fn().mockResolvedValue([]),
+}))
+
+jest.mock('../../src/services/content-org/learning-paths.ts', () => ({
+  mapContentsThatWereLastProgressedFromMethod: jest.fn((contents) => Promise.resolve(contents)),
+}))
 
 jest.mock('../../src/services/user/streakCalculator.ts', () => ({
   streakCalculator: {
@@ -98,5 +118,83 @@ describe('User Activity API Tests', function () {
       300,
       { title: null, category_id: null, thumbnail_url: null, instrument_id: null }
     )
+  })
+
+  describe('getPracticeSessions', () => {
+    test('returns all sessions unpaginated when limit is omitted', async () => {
+      const result = await getPracticeSessions({ day: '2025-03-16' })
+
+      expect(result.data.practices).toHaveLength(mockPracticesData.length)
+      expect(result.data.total).toBe(mockPracticesData.length)
+      expect(result.data.currentPage).toBe(1)
+      expect(result.data.totalPages).toBe(1)
+      expect(result.data.practiceDuration).toBe(
+        mockPracticesData.reduce((sum, p) => sum + p.duration_seconds, 0)
+      )
+    })
+
+    test('paginates when limit is provided', async () => {
+      const result = await getPracticeSessions({ day: '2025-03-16', page: 2, limit: 5 })
+
+      expect(result.data.practices).toHaveLength(5)
+      expect(result.data.total).toBe(mockPracticesData.length)
+      expect(result.data.currentPage).toBe(2)
+      expect(result.data.totalPages).toBe(Math.ceil(mockPracticesData.length / 5))
+      expect(result.data.practiceDuration).toBe(
+        mockPracticesData.reduce((sum, p) => sum + p.duration_seconds, 0)
+      )
+    })
+
+    test('returns an empty result when there are no sessions', async () => {
+      mockPracticesData = []
+      const result = await getPracticeSessions({ day: '2025-03-16' })
+
+      expect(result.data).toEqual({
+        practices: [],
+        practiceDuration: 0,
+        total: 0,
+        currentPage: 1,
+        totalPages: 1,
+      })
+    })
+  })
+
+  describe('getWeeklyPracticeSessions', () => {
+    test('returns all sessions unpaginated when limit is omitted', async () => {
+      const result = await getWeeklyPracticeSessions()
+
+      expect(result.data.practices).toHaveLength(mockPracticesData.length)
+      expect(result.data.total).toBe(mockPracticesData.length)
+      expect(result.data.currentPage).toBe(1)
+      expect(result.data.totalPages).toBe(1)
+    })
+
+    test('paginates when limit is provided', async () => {
+      const result = await getWeeklyPracticeSessions({ page: 1, limit: 4 })
+
+      expect(result.data.practices).toHaveLength(4)
+      expect(result.data.total).toBe(mockPracticesData.length)
+      expect(result.data.currentPage).toBe(1)
+      expect(result.data.totalPages).toBe(Math.ceil(mockPracticesData.length / 4))
+    })
+
+    test('awaits the sync pull when options.pull is true', async () => {
+      const result = await getWeeklyPracticeSessions({}, { pull: true })
+
+      expect(result.data.total).toBe(mockPracticesData.length)
+    })
+
+    test('returns an empty result when there are no sessions', async () => {
+      mockPracticesData = []
+      const result = await getWeeklyPracticeSessions()
+
+      expect(result.data).toEqual({
+        practices: [],
+        practiceDuration: 0,
+        total: 0,
+        currentPage: 1,
+        totalPages: 1,
+      })
+    })
   })
 })


### PR DESCRIPTION
…ekly Goal Progress in getUserWeeklyStats

## Jira Ticket(s)/RelatedPR(s)

- [BEHSTP-440](https://musora.atlassian.net/browse/BEHSTP-440)
- [BEHSTP-441](https://musora.atlassian.net/browse/BEHSTP-441)
- [BEHSTP-442](https://musora.atlassian.net/browse/BEHSTP-442)
- 
## Description/Design

- Adds MCS support for Custom Practice Targets: exposes weekly/daily goal progress from the existing streak cache, adds pagination to practice session lookups, and adds a new  method for fetching a whole week's practice sessions. 

 **getUserWeeklyStats**() — weekly/daily goal progress                                                                                                                                 
  - Adds currentWeekPracticeDays (distinct calendar days with practice since Monday of the current week) and todaysPracticeSeconds (total practice seconds recorded today).         
  - Both are derived from the practice data already fetched for the streak calculation — no extra query or sync pull — and live in streakCalculator's cache, so they invalidate together with the rest of the streak data.                                                                                                                                        
  - Additive only; existing consumers are unaffected.                                                                                                                               
                                                                                                                                                                                    
  **getPracticeSessions**({ day, userId, page, limit }) — add pagination                                                                                                                    
  - Accepts page/limit.                   
  - practiceDuration and the new total field always reflect the full day, independent of pagination, so goal-progress math stays correct on any page.
  
  **getWeeklyPracticeSessions**({ page, limit }, options) — new method
  - Returns the current Monday–Sunday week's practice sessions, enriched with the same content metadata as getPracticeSessions (title, thumbnail, category, etc.).
  - Same response shape and sort order as getPracticeSessions (flat practices array, oldest-first): { practices, practiceDuration, total }.
  - practiceDuration/total reflect the full week regardless of pagination.

## Testing

- _How can this be verified?_
- _Setup required_
- _what page(s) are applicable_
- _what action(s) should a user take_
- _what is the expected outcome?_

## Additional Notes

- _Provide any additional context or notes that might be helpful for the reviewer._


[BEHSTP-440]: https://musora.atlassian.net/browse/BEHSTP-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BEHSTP-441]: https://musora.atlassian.net/browse/BEHSTP-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BEHSTP-442]: https://musora.atlassian.net/browse/BEHSTP-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ