### PR TITLE
feat: adds create pending user fn

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -382,6 +382,7 @@ import {
 
 import {
 	confirmEmailChange,
+	createPendingAccount,
 	deleteAccount,
 	numberOfActiveUsers,
 	requestEmailChange,
@@ -540,6 +541,7 @@ declare module 'musora-content-services' {
 		createComment,
 		createForumCategory,
 		createInvites,
+		createPendingAccount,
 		createPlaylist,
 		createPost,
 		createPracticeNotes,

--- a/src/index.js
+++ b/src/index.js
@@ -386,6 +386,7 @@ import {
 
 import {
 	confirmEmailChange,
+	createPendingAccount,
 	deleteAccount,
 	numberOfActiveUsers,
 	requestEmailChange,
@@ -539,6 +540,7 @@ export {
 	createComment,
 	createForumCategory,
 	createInvites,
+	createPendingAccount,
 	createPlaylist,
 	createPost,
 	createPracticeNotes,

--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -91,6 +91,30 @@ export async function setupAccount(props: AccountSetupProps): Promise<AccountSet
   return res
 }
 
+export interface PendingAccountProps {
+  email: string
+  revenuecatAppUserId?: string
+}
+
+/**
+ * @param {Object} props - The parameters for creating the pending account.
+ * @property {string} email - The email address for the account.
+ * @property {string} [revenuecatAppUserId] - The RevenueCat App User ID for MA environments.
+ *
+ * @returns {Promise<AccountSetupResponse>} - A promise that resolves when the pending account is created or an HttpError if the request fails.
+ * @throws {HttpError} - Throws an HttpError if the HTTP request fails.
+ */
+export async function createPendingAccount(props: PendingAccountProps): Promise<AccountSetupResponse> {
+  const httpClient = new HttpClient(globalConfig.baseUrl)
+  return await httpClient.post<AccountSetupResponse>(
+    `/api/user-management-system/v1/accounts/pending`,
+    {
+      email: props.email,
+      mobile_app_id: props.revenuecatAppUserId,
+    }
+  )
+}
+
 /**
  * @param {string} email - The email address to send the password reset email to.
  * @returns {Promise<void>} - A promise that resolves when the email change request is made.


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

[BEHSTP-481](https://musora.atlassian.net/browse/BEHSTP-481)
[MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/1468)

## Description/Design

An MCS endpoint for MA to call on the email input screen to create a user ID right away. This allows MA to call `Purchases.logIn(userId)` and scope the signup flow to that user alone, thus avoiding users with duplicate RC ids in the db.

[BEHSTP-481]: https://musora.atlassian.net/browse/BEHSTP-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ