### PR TITLE
feat(MU2-1818): Add OAuth provider list/unlink session APIs

### DIFF
--- a/src/services/user/session.ts
+++ b/src/services/user/session.ts
@@ -39,6 +39,12 @@ export async function redirectToOAuthProvider(
   return httpClient.get(apiUrl)
 }
 
+export async function listOAuthProviders(): Promise<OAuthProvider[]> {
+  const userId = globalConfig.userId
+  const apiUrl = `/api/user-management-system/v1/sessions/${encodeURIComponent(userId)}/oauth`
+  return new HttpClient(globalConfig.baseUrl).get<OAuthProvider[]>(apiUrl)
+}
+
 export async function unlinkOAuthProvider(provider: OAuthProvider): Promise<void> {
   const userId = globalConfig.userId
   const apiUrl = `/api/user-management-system/v1/sessions/${encodeURIComponent(userId)}/oauth/${encodeURIComponent(provider)}`

--- a/src/services/user/session.ts
+++ b/src/services/user/session.ts
@@ -38,3 +38,9 @@ export async function redirectToOAuthProvider(
   const httpClient = new HttpClient(globalConfig.baseUrl)
   return httpClient.get(apiUrl)
 }
+
+export async function unlinkOAuthProvider(provider: OAuthProvider): Promise<void> {
+  const userId = globalConfig.userId
+  const apiUrl = `/api/user-management-system/v1/sessions/${encodeURIComponent(userId)}/oauth/${encodeURIComponent(provider)}`
+  return new HttpClient(globalConfig.baseUrl).delete(apiUrl)
+}


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- [MU2-1817](https://musora.atlassian.net/browse/MU2-1817) 
- [MU2-1818](https://musora.atlassian.net/browse/MU2-1818)
- [MPB PR](https://github.com/railroadmedia/musora-platform-backend/pull/1470)

## Description/Design

- Adds `listOAuthProviders` to fetch a user's linked OAuth providers, and `unlinkOAuthProvider` to disconnect one, both against the user-management-system sessions endpoint
- Supports upcoming OAuth account settings UI where users need to view and manage linked third-party logins

## Testing

- How to verify: call `listOAuthProviders()` / `unlinkOAuthProvider(provider)` from a consuming app after `initializeService`, confirm requests hit `/api/user-management-system/v1/sessions/{userId}/oauth`
- Environment: local
- Expected outcome: list returns linked providers; unlink issues DELETE and resolves without error

[MU2-1817]: https://musora.atlassian.net/browse/MU2-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MU2-1817]: https://musora.atlassian.net/browse/MU2-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MU2-1818]: https://musora.atlassian.net/browse/MU2-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ