### PR TITLE
feat: add previous_email param to pending account creation

### DIFF
--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -112,12 +112,14 @@ export async function setupAccount(props: AccountSetupProps): Promise<AccountSet
 export interface PendingAccountProps {
   email: string
   revenuecatAppUserId?: string
+  previousEmail?: string
 }
 
 /**
  * @param {Object} props - The parameters for creating the pending account.
  * @property {string} email - The email address for the account.
  * @property {string} [revenuecatAppUserId] - The RevenueCat App User ID for MA environments.
+ * @property {string} [previousEmail] - The previous email address, if this account replaces an existing one.
  *
  * @returns {Promise<AccountSetupResponse>} - A promise that resolves when the pending account is created or an HttpError if the request fails.
  * @throws {HttpError} - Throws an HttpError if the HTTP request fails.
@@ -129,6 +131,7 @@ export async function createPendingAccount(props: PendingAccountProps): Promise<
     {
       email: props.email,
       mobile_app_id: props.revenuecatAppUserId,
+      previous_email: props.previousEmail,
     }
   )
 }


### PR DESCRIPTION
Allows for `previous_email` param to be passed to pending account backend endpoint. Useful for MA when user adjusts email after a typo. Backend knows to update existing account's email instead of creating a new account this way