### PR TITLE
feat(BEHLTP-306): add tier_key and rank to UpgradeProduct type

### DIFF
--- a/.agent/decisions/2026-08-13-behltp-306-add-plan-rank-and-tier-key.md
+++ b/.agent/decisions/2026-08-13-behltp-306-add-plan-rank-and-tier-key.md
@@ -1,0 +1,24 @@
+---
+date: 2026-08-13
+branch: feat/BEHLTP-306-add-plan-rank-and-tier-key
+pr: https://github.com/railroadmedia/musora-content-services/pull/1030
+status: open
+tags: [[feature]]
+---
+
+# Add tier_key and rank to MCS's UpgradeProduct type
+
+## Context
+BEHLTP-306 (musora-platform-backend PR #1463, already merged) added `tier_key` and `rank` fields to the backend's `upgrade_options` response, so MusoraApp can fetch canonical plan rank from the API instead of hardcoding its own copy. While working on an unrelated ticket (TP-1307), David noted MCS's TypeScript structure hadn't been updated to match, and asked to prepare a fix on its own branch.
+
+## Decision
+Add `tier_key: string` and `rank: number | null` to MCS's `UpgradeProduct` interface (`src/services/user/memberships.ts`), matching the backend's response shape exactly. Since MCS doesn't transform/strip this data at runtime (the interface is purely a type declaration), the actual field values were already flowing through — this change only restores type safety for consumers referencing `product.tier_key`/`product.rank`.
+
+## Alternatives Considered
+No alternatives considered — this is a straightforward type-sync fix with one correct shape to match.
+
+## Process Notes
+Verified with `npx tsc --noEmit` (via the manager container, sourcing nvm explicitly since a plain `bash -lc` login shell didn't pick it up) rather than assuming a dedicated typecheck script existed — none did.
+
+## Consequences
+Consumers of `UpgradeProduct` (e.g. MusoraApp) can now reference `tier_key`/`rank` without a TypeScript error.

--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -115,6 +115,7 @@ export interface PendingAccountProps {
   previousEmail?: string
 }
 
+// Not AccountSetupResponse -- this is the permanent shape for this endpoint.
 export interface PendingAccountResponse {
   user_id: number
 }

--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -115,18 +115,22 @@ export interface PendingAccountProps {
   previousEmail?: string
 }
 
+export interface PendingAccountResponse {
+  user_id: number
+}
+
 /**
  * @param {Object} props - The parameters for creating the pending account.
  * @property {string} email - The email address for the account.
  * @property {string} [revenuecatAppUserId] - The RevenueCat App User ID for MA environments.
  * @property {string} [previousEmail] - The previous email address, if this account replaces an existing one.
  *
- * @returns {Promise<AccountSetupResponse>} - A promise that resolves when the pending account is created or an HttpError if the request fails.
+ * @returns {Promise<PendingAccountResponse>} - A promise that resolves when the pending account is created or an HttpError if the request fails.
  * @throws {HttpError} - Throws an HttpError if the HTTP request fails.
  */
-export async function createPendingAccount(props: PendingAccountProps): Promise<AccountSetupResponse> {
+export async function createPendingAccount(props: PendingAccountProps): Promise<PendingAccountResponse> {
   const httpClient = new HttpClient(globalConfig.baseUrl)
-  return await httpClient.post<AccountSetupResponse>(
+  return await httpClient.post<PendingAccountResponse>(
     `/api/user-management-system/v1/accounts/pending`,
     {
       email: props.email,

--- a/src/services/user/memberships.ts
+++ b/src/services/user/memberships.ts
@@ -75,6 +75,8 @@ export interface UpgradeProduct {
   tier: 'plus' | 'basic' | '' // deprecated in favour of membership_level
   membership_level: 'plus' | 'basic' | ''
   plan_type: 'family' | 'duo' | 'solo'
+  tier_key: string
+  rank: number | null
 }
 
 export interface UpgradeOption {


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- https://musora.atlassian.net/browse/BEHLTP-306
- Related: musora-platform-backend PR #1463

## Description/Design

- The backend's `upgrade_options` response now includes `tier_key` and `rank` per product (added in BEHLTP-306 / PR #1463), so MusoraApp can fetch canonical plan rank from the API instead of hardcoding its own copy.
- This adds the matching `tier_key: string` and `rank: number | null` fields to MCS's `UpgradeProduct` TypeScript interface, so consumers (e.g. MusoraApp) can reference these fields without a type error.

## Testing

- How to verify: `npx tsc --noEmit` passes cleanly with the new fields added.
- Environment: local
- Expected outcome: no type errors; `product.tier_key`/`product.rank` are now valid, typed accesses wherever `UpgradeProduct` is consumed.
