### PR TITLE
fix: password reset mobile token and sessionConfig access

### DIFF
--- a/.agent/decisions/2026-08-17-password-reset-mobile-token.md
+++ b/.agent/decisions/2026-08-17-password-reset-mobile-token.md
@@ -1,0 +1,27 @@
+---
+date: 2026-08-17
+branch: fix/password-reset-mobile-token
+pr: https://github.com/railroadmedia/musora-content-services/pull/1031
+status: open
+tags: [bug-fix]
+---
+
+# Password reset mobile token and sessionConfig access
+
+## Context
+Mobile app needed `resetPassword` to return an authenticated session directly (avoiding a separate login step after reset), and two OAuth session functions were reading `userId` from a stale top-level `globalConfig.userId` field instead of the current `globalConfig.sessionConfig.userId` shape.
+
+## Decision
+- `resetPassword` (`src/services/user/account.ts`) now accepts optional `deviceName`, `deviceToken`, `platform` on `PasswordResetProps` and returns `Promise<AuthResponse | null>` instead of `Promise<void>`, so mobile can pass device info and receive a session back from the reset call.
+- `listOAuthProviders` and `unlinkOAuthProvider` (`src/services/user/session.ts`) now read `userId` from `globalConfig.sessionConfig.userId`.
+
+## Alternatives Considered
+No alternatives considered.
+
+## Process Notes
+Initial implementation had a bug: the request body sent `token: props.password` instead of `token: props.token`, which would have sent the user's new password as the reset token. Caught and fixed before opening the PR.
+
+## Consequences
+- `resetPassword` callers must handle the new return type (`AuthResponse | null`) instead of `void`.
+- Mobile clients can now log in immediately after a password reset without a separate auth call.
+- OAuth provider list/unlink calls no longer resolve `userId` as `undefined`.

--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -166,7 +166,7 @@ export async function resetPassword(props: PasswordResetProps): Promise<AuthResp
     email: props.email,
     password: props.password,
     password_confirmation: props.passwordConfirmation,
-    token: props.password,
+    token: props.token,
     device_name: props.deviceName,
     device_token: props.deviceToken,
     platform: props.platform,

--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -124,7 +124,9 @@ export interface PendingAccountProps {
  * @returns {Promise<AccountSetupResponse>} - A promise that resolves when the pending account is created or an HttpError if the request fails.
  * @throws {HttpError} - Throws an HttpError if the HTTP request fails.
  */
-export async function createPendingAccount(props: PendingAccountProps): Promise<AccountSetupResponse> {
+export async function createPendingAccount(
+  props: PendingAccountProps
+): Promise<AccountSetupResponse> {
   const httpClient = new HttpClient(globalConfig.baseUrl)
   return await httpClient.post<AccountSetupResponse>(
     `/api/user-management-system/v1/accounts/pending`,
@@ -153,28 +155,21 @@ export interface PasswordResetProps {
   password: string
   passwordConfirmation: string
   token: string
+  deviceName?: string
+  deviceToken?: string
+  platform?: string
 }
-/**
- * @param {Object} params - The parameters for resetting the password.
- * @property {string} email - The email address for the account.
- * @property {string} password - The new password for the account.
- * @property {string} passwordConfirmation - The confirmation of the new password.
- * @property {string} token - The token sent to the user's email for verification.
- * @returns {Promise<void>} - A promise that resolves when the password reset is complete or an HttpError if the request fails.
- * @throws {HttpError} - Throws an HttpError if the HTTP request fails.
- */
-export async function resetPassword({
-  email,
-  password,
-  passwordConfirmation,
-  token,
-}: PasswordResetProps): Promise<void> {
+
+export async function resetPassword(props: PasswordResetProps): Promise<AuthResponse | null> {
   const httpClient = new HttpClient(globalConfig.baseUrl)
   return httpClient.post(`/api/user-management-system/v1/accounts/password/reset`, {
-    email,
-    password,
-    password_confirmation: passwordConfirmation,
-    token,
+    email: props.email,
+    password: props.password,
+    password_confirmation: props.passwordConfirmation,
+    token: props.password,
+    device_name: props.deviceName,
+    device_token: props.deviceToken,
+    platform: props.platform,
   })
 }
 

--- a/src/services/user/session.ts
+++ b/src/services/user/session.ts
@@ -40,13 +40,13 @@ export async function redirectToOAuthProvider(
 }
 
 export async function listOAuthProviders(): Promise<OAuthProvider[]> {
-  const userId = globalConfig.userId
+  const userId = globalConfig.sessionConfig.userId
   const apiUrl = `/api/user-management-system/v1/sessions/${encodeURIComponent(userId)}/oauth`
   return new HttpClient(globalConfig.baseUrl).get<OAuthProvider[]>(apiUrl)
 }
 
 export async function unlinkOAuthProvider(provider: OAuthProvider): Promise<void> {
-  const userId = globalConfig.userId
+  const userId = globalConfig.sessionConfig.userId
   const apiUrl = `/api/user-management-system/v1/sessions/${encodeURIComponent(userId)}/oauth/${encodeURIComponent(provider)}`
   return new HttpClient(globalConfig.baseUrl).delete(apiUrl)
 }


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- N/A

## Description/Design

- `resetPassword` now accepts optional `deviceName`, `deviceToken`, `platform` so mobile can exchange a reset token for an auth session in one call; also fixed a bug sending `password` as the `token` field.
- `listOAuthProviders`/`unlinkOAuthProvider` read `userId` from `globalConfig.sessionConfig` instead of a stale top-level `globalConfig.userId`, matching current config shape.

## Testing

- How to verify: call `resetPassword` with device fields set and confirm the mobile app receives an `AuthResponse` session back; call `listOAuthProviders`/`unlinkOAuthProvider` and confirm userId resolves correctly.
- Environment: local
- Expected outcome: password reset returns a valid session on mobile; OAuth provider list/unlink calls succeed instead of hitting `undefined` userId.