### PR TITLE
fix(BEHSTP-476): correct createPendingAccount's response type

### DIFF
--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -115,6 +115,7 @@ export interface PendingAccountProps {
   previousEmail?: string
 }
 
+// Not AccountSetupResponse -- this is the permanent shape for this endpoint.
 export interface PendingAccountResponse {
   user_id: number
 }

--- a/src/services/user/account.ts
+++ b/src/services/user/account.ts
@@ -115,18 +115,22 @@ export interface PendingAccountProps {
   previousEmail?: string
 }
 
+export interface PendingAccountResponse {
+  user_id: number
+}
+
 /**
  * @param {Object} props - The parameters for creating the pending account.
  * @property {string} email - The email address for the account.
  * @property {string} [revenuecatAppUserId] - The RevenueCat App User ID for MA environments.
  * @property {string} [previousEmail] - The previous email address, if this account replaces an existing one.
  *
- * @returns {Promise<AccountSetupResponse>} - A promise that resolves when the pending account is created or an HttpError if the request fails.
+ * @returns {Promise<PendingAccountResponse>} - A promise that resolves when the pending account is created or an HttpError if the request fails.
  * @throws {HttpError} - Throws an HttpError if the HTTP request fails.
  */
-export async function createPendingAccount(props: PendingAccountProps): Promise<AccountSetupResponse> {
+export async function createPendingAccount(props: PendingAccountProps): Promise<PendingAccountResponse> {
   const httpClient = new HttpClient(globalConfig.baseUrl)
-  return await httpClient.post<AccountSetupResponse>(
+  return await httpClient.post<PendingAccountResponse>(
     `/api/user-management-system/v1/accounts/pending`,
     {
       email: props.email,


### PR DESCRIPTION
## Summary
- `createPendingAccount()` was typed to return `AccountSetupResponse` (`{auth, onboarding, product_brand}`), copied over from `setupAccount`, but the `/accounts/pending` endpoint only ever returns `{user_id}` -- a pending (password-less) account never gets an auth session issued.
- Adds a `PendingAccountResponse` interface matching the real shape and switches `createPendingAccount()` to return it.

## Backwards compatibility
- Type-only change, no runtime behavior touched (request body mapping and the actual HTTP call are unchanged).
- No current consumers found in MusoraApp, musora-platform-frontend, or musora-web-platform that reference `.auth`/`.onboarding` off this specific call.
- Safe to release under `latest`.

## Testing
- `npx tsc --noEmit` passes cleanly
- Verified live against staging3 via `mcs-cli` (`createPendingAccount`), confirmed backend response is exactly `{user_id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
