### PR TITLE
fix(BEH-1590): login as user on mobile app

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -494,6 +494,7 @@ import {
 
 import {
 	listOAuthProviders,
+	loginAsUser,
 	redirectToOAuthProvider,
 	unlinkOAuthProvider,
 	verifyOAuthToken
@@ -805,6 +806,7 @@ declare module 'musora-content-services' {
 		listOAuthProviders,
 		lockThread,
 		login,
+		loginAsUser,
 		logout,
 		mapContentToParent,
 		markAllNotificationsAsRead,

--- a/src/index.js
+++ b/src/index.js
@@ -498,6 +498,7 @@ import {
 
 import {
 	listOAuthProviders,
+	loginAsUser,
 	redirectToOAuthProvider,
 	unlinkOAuthProvider,
 	verifyOAuthToken
@@ -804,6 +805,7 @@ export {
 	listOAuthProviders,
 	lockThread,
 	login,
+	loginAsUser,
 	logout,
 	mapContentToParent,
 	markAllNotificationsAsRead,

--- a/src/services/user/session.ts
+++ b/src/services/user/session.ts
@@ -50,3 +50,11 @@ export async function unlinkOAuthProvider(provider: OAuthProvider): Promise<void
   const apiUrl = `/api/user-management-system/v1/sessions/${encodeURIComponent(userId)}/oauth/${encodeURIComponent(provider)}`
   return new HttpClient(globalConfig.baseUrl).delete(apiUrl)
 }
+
+export async function loginAsUser(userId: string): Promise<AuthResponse> {
+  const httpClient = new HttpClient(globalConfig.baseUrl)
+  return httpClient.post<AuthResponse>(
+    `/api/user-management-system/v1/sessions/${encodeURIComponent(userId)}`,
+    {}
+  )
+}


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- BEH-1590

## Description/Design

- Mobile app needs a "login as user" flow (admin impersonation) that the web platform already supports; `session.ts` had no client function to hit the sessions endpoint for a given userId.
- Added `loginAsUser` to mirror the existing session service pattern (`unlinkOAuthProvider` etc.) so MusoraApp can call it via musora-content-services.

## Testing

- How to verify: call `loginAsUser(userId)` from MusoraApp and confirm it posts to `/api/user-management-system/v1/sessions/:userId` and returns an `AuthResponse` usable to swap the active session.
- Environment: local / staging
- Expected outcome: admin can log in as the target user on mobile without errors.