### PR TITLE
chore(groq): add composite() for multi-key GROQ projections

### DIFF
--- a/src/lib/sanity/query.ts
+++ b/src/lib/sanity/query.ts
@@ -64,6 +64,11 @@ const project: Monoid<string> = {
 
 export const filterOps = { and, or }
 
+export const composite = (parts: Record<string, QueryBuilder | string>): string =>
+  `{ ${Object.entries(parts)
+    .map(([key, value]) => `"${key}": ${value}`)
+    .join(', ')} }`
+
 export const query = (selector?: string): QueryBuilder => {
   let state: QueryBuilderState = {
     filter: and.empty,

--- a/test/unit/lib/query.test.ts
+++ b/test/unit/lib/query.test.ts
@@ -1,4 +1,52 @@
-import { query } from '../../../src/lib/sanity/query'
+import { composite, query } from '../../../src/lib/sanity/query'
+import Filters from '../../../src/lib/sanity/filter'
+
+describe('Composite Projections', () => {
+  test('builds single key with builder value', () => {
+    const result = composite({ data: query().and('_type == "song"') })
+    expect(result).toBe('{ "data": *[_type == "song"] }')
+  })
+
+  test('preserves key order and separates without trailing comma', () => {
+    const result = composite({
+      first: query().and('_type == "song"'),
+      second: query().and('_type == "course"'),
+    })
+    expect(result).toBe('{ "first": *[_type == "song"], "second": *[_type == "course"] }')
+    expect(result).not.toMatch(/,\s*}$/)
+  })
+
+  test('passes string values through verbatim', () => {
+    const result = composite({ total: Filters.count('_type == "song"') })
+    expect(result).toBe('{ "total": count(*[_type == "song"]) }')
+  })
+
+  test('builds mixed builder and string values', () => {
+    const result = composite({
+      data: query().and('_type == "song"').slice(0, 10),
+      total: Filters.count('_type == "song"'),
+    })
+    expect(result).toBe(
+      '{ "data": *[_type == "song"]\n        \n        \n        \n        [0...10], "total": count(*[_type == "song"]) }'
+    )
+  })
+
+  test('quotes keys that are identifier safe', () => {
+    const result = composite({ data: query() })
+    expect(result).toContain('"data":')
+  })
+
+  test('builds empty object for empty parts', () => {
+    expect(composite({})).toBe('{  }')
+  })
+
+  test('stringifies builders eagerly so later mutation is ignored', () => {
+    const builder = query().and('_type == "song"')
+    const result = composite({ data: builder })
+    builder.and('brand == "drumeo"')
+    expect(result).toBe('{ "data": *[_type == "song"] }')
+  })
+})
 
 describe('Sanity Query Builder', () => {
   describe('Basic Query Building', () => {


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- N/A — planned in `.claude/docs/architecture/groq-composite-projections.md` (the doc is tracked as of the follow-up PR in this stack; `/docs` is gitignored, so it was untracked when this PR was opened)

## Description/Design

- The query builder has a single projection slot, so it can emit `*[...]{ a, b }` but not the `{ "data": *[...], "total": count(*[...]) }` wrapper that dominates `src/services/content/`. Seven call sites currently drop out of the builder and hand-write template literals to get it — the builder gets bypassed exactly where queries are most complex.
- `composite()` takes a record of builders or strings and emits that wrapper. It's a free function rather than a builder method because it composes builders rather than extending one, and `query()` has no meaningful "add a sibling query" operation.
- The `count(...)` half needed no new code (see below).
- Deliberate limits: one level (no nested composites), no `sort`/`slice` on the wrapper, keys always quoted to match every existing site. No call site wants otherwise.

### The whole addition

```ts
export const composite = (parts: Record<string, QueryBuilder | string>): string =>
  `{ ${Object.entries(parts)
    .map(([key, value]) => `"${key}": ${value}`)
    .join(', ')} }`
```

### What call sites look like today

```ts
// counts.ts:36-39
const q = `{
  "songs": count(${query().and(songsFilter)}),
  "lessons": count(${query().and(lessonsFilter)})
}`

// instructor.ts:156-159 (artist.ts and genre.ts identical in shape)
const q = `{
  "data": ${data},
  "total": count(${total})
}`
```

### What they become

```ts
// counts.ts
const q = composite({
  songs: f.count(songsFilter),
  lessons: f.count(lessonsFilter),
})

// instructor.ts / artist.ts / genre.ts
const q = composite({
  data: dataQuery,
  total: f.count(restrictions),
})
```

### Why `count()` needed no new code

`Filters.count` already produces the equivalent string, because `build()` trims the empty projection, post-filter, ordering and slice slots away:

```ts
count(`${query().and(filter)}`)  ===  count(*[filter])  ===  f.count(filter)
```

`test/unit/lib/query.test.ts:6` already asserts `query().build() === '*[]'`, which pins that trim. So `composite()` deliberately does **not** grow a `count()` wrapper of its own — count values arrive as plain strings from the existing helper, which keeps the new surface to the one thing genuinely missing: the object wrapper.

## Testing

- How to verify: `npm run test:unit -- test/unit/lib/query.test.ts`
- Environment: local
- Expected outcome: 164/164 pass — 157 pre-existing plus 7 new in the `Composite Projections` block. `npx tsc --noEmit` and `npx prettier --check` are both clean.

The 7 new cases cover single key, key order + separator + no trailing comma, verbatim string passthrough, mixed builder/string values, key quoting, empty input, and this one — the only non-obvious semantic:

```ts
test('stringifies builders eagerly so later mutation is ignored', () => {
  const builder = query().and('_type == "song"')
  const result = composite({ data: builder })
  builder.and('brand == "drumeo"')
  expect(result).toBe('{ "data": *[_type == "song"] }')
})
```

`${value}` hides the `.build()` call, so that test is what pins eager coercion — it would fail if anyone refactored `composite()` to a lazy or getter-based form.

## Additional Notes

- **Ships unused.** No service file is touched. Call sites migrate one at a time in later PRs, each verifiable on its own: `counts.ts` first (the only site already on `SanityClient`), then the `{data, total}` trio in `instructor.ts`/`artist.ts`/`genre.ts`, then the single-key `{data}` sites. Those last three currently emit a trailing comma before `}`; `join(', ')` never produces one, so their emitted string changes slightly when migrated. No test asserts those strings.
- The mixed builder+string test asserts `build()`'s raw internal whitespace, which looks odd but is exactly the string call sites already send today. It will break if anyone tidies `build()` — which ~1500 lines of exact-string assertions already forbid.
- **This PR is the base of a stack.** `feat/ads-coproduct` (Coproduct ADT) targets this branch, and `feat/groq-query-runner` (execution layer, `groq()`) targets that one. Review/merge bottom-up.
