### PR TITLE
feat: make built GROQ queries runnable with a typed result

### DIFF
--- a/.claude/docs/architecture/groq-composite-projections.md
+++ b/.claude/docs/architecture/groq-composite-projections.md
@@ -1,0 +1,223 @@
+# Plan: `composite()` — multi-key projections in the query builder (mcs)
+
+Status: proposed, not implemented.
+Scope: `src/lib/sanity/query.ts`.
+Related: `.claude/docs/architecture/groq-query-builder-execution.md` — independent of it; see "Relationship to the
+execution plan" below.
+
+## Context
+
+`src/lib/sanity/query.ts` has one projection slot. It can emit `*[...]{ a, b }` but it cannot
+emit a wrapper object whose values are themselves queries:
+
+```groq
+{ "data": *[...]{...}, "total": count(*[...]) }
+```
+
+That wrapper is the dominant idiom in `src/services/content/`. Because the builder can't express
+it, every such call site drops out of the builder and hand-writes a template literal, then calls
+the transport directly. Seven sites do this today.
+
+The cost is that the builder is bypassed exactly where queries are most complex, and its output
+gets spliced into strings by hand — including one site that relies on implicit `toString()`
+(`counts.ts:37`, `${query().and(songsFilter)}` with no `.build()`) while a sibling calls
+`.build()` explicitly (`artist.ts:88`). Same idiom, two spellings, no enforcement.
+
+Goal: let the builder express the wrapper, so those sites can use it.
+
+## What the call sites actually do
+
+Across all seven builder-based composite sites there are exactly **two** value forms:
+
+| form | sites |
+|---|---|
+| `"key": <builder>` | `artist.ts:55`, `genre.ts:55`, `instructor.ts:56`, plus the `"data"` half of the three below |
+| `"key": count(<builder>)` | `artist.ts:158-159`, `genre.ts:157-158`, `instructor.ts:157-158`, `counts.ts:37-38`, `counts.ts:62` |
+
+```ts
+// counts.ts:36-39 — the only builder → SanityClient path in the repo
+const q = `{
+  "songs": count(${query().and(songsFilter)}),
+  "lessons": count(${query().and(lessonsFilter)})
+}`
+
+// instructor.ts:156-159 (artist.ts:157-160 and genre.ts:156-159 identical in shape)
+const q = `{
+  "data": ${data},
+  "total": count(${total})
+}`
+```
+
+Two forms, one level deep, string keys. That is the entire requirement.
+
+## The `count(...)` half needs no new code
+
+`Filters.count` already exists (`src/lib/sanity/filter.ts:460`):
+
+```ts
+static count(filter: string): string {
+  return `count(*[${filter}])`
+}
+```
+
+It is exactly equivalent to what the call sites hand-roll. `build()` ends in `.trim()`
+(`query.ts:149`), and for a bare `query().and(x)` the projection, post-filter, ordering and slice
+slots are all empty — they collapse to whitespace-only trailing lines that `trim()` removes:
+
+```
+count(${query().and(songsFilter)})   ===   count(*[songsFilter])   ===   f.count(songsFilter)
+```
+
+So `composite()` must **not** grow a `count()` wrapper of its own. Count values arrive as plain
+strings from the existing helper. That collapses the new surface to the one thing genuinely
+missing: the object wrapper.
+
+## Design
+
+Seven lines, in `query.ts` beside `query()`, since this is query construction:
+
+```ts
+export type CompositeParts = Record<string, QueryBuilder | string>
+
+export const composite = (parts: CompositeParts): string => {
+  const entries = Object.entries(parts).map(
+    ([key, value]) => `"${key}": ${typeof value === 'string' ? value : value.build()}`
+  )
+
+  return `{ ${entries.join(', ')} }`
+}
+```
+
+A free function, not a builder method — it composes builders rather than extending one, and
+`query()` returns a mutable closure object that has no meaningful "add a sibling query" operation.
+
+Call sites become:
+
+```ts
+// counts.ts
+const q = composite({
+  songs: f.count(songsFilter),
+  lessons: f.count(lessonsFilter),
+})
+
+// instructor.ts / artist.ts / genre.ts
+const q = composite({
+  data: dataQuery,
+  total: f.count(restrictions),
+})
+```
+
+### Details that matter
+
+- **Keys are always quoted** (`"data"`), matching every existing site. GROQ permits unquoted
+  keys; quoting is what is already there and sidesteps keys colliding with GROQ syntax.
+- **No trailing comma.** Three sites currently emit `{"data": ${data},}` — a trailing comma
+  before `}` (`artist.ts:55`, `genre.ts:55`, `instructor.ts:56`). Sanity evidently tolerates it;
+  `join(', ')` simply never produces one. Migrating those sites therefore changes the emitted
+  string slightly. Safe — no test asserts those composite strings; `test/unit/lib/query.test.ts`
+  covers `build()` output only.
+- **Whitespace.** `build()` preserves its template-literal indentation internally
+  (`query.ts:143-149`), so composite values inherit multi-line formatting. Functionally
+  irrelevant, and identical to what the call sites already send. Do **not** tidy `build()` to fix
+  it — 1497 lines of exact-string assertions depend on its current output.
+- **Insertion order.** `Object.entries` preserves declaration order for string keys, so emitted
+  key order is predictable and testable.
+- **`_state()` is not involved.** Composite has no state of its own; it reads `build()` output at
+  call time, so it inherits whatever the builders hold at that moment. Given the builders are
+  mutable (`query.ts:79-159`), mutating one *after* passing it to `composite()` is a no-op,
+  because `composite()` already stringified it. That is the desirable behaviour; worth a test.
+
+### Deliberate limits
+
+- **One level, no nesting.** A `composite()` value cannot itself be a `composite()`. The nested
+  shapes in `services/sanity.js:1951-1956` (arrays of `{"type", "count"}` objects) are legacy
+  hand-written strings built from raw filter strings, not builders — not migration candidates,
+  and they should not drive this design.
+- **`f.count` hardcodes the `*` selector.** Correct for all five current count sites, wrong for a
+  count over a non-`*` selector. Mark the ceiling rather than generalising for a case nobody has:
+
+  ```ts
+  // ponytail: count values come from f.count(filter), which hardcodes the `*` selector.
+  // Pass a pre-built string if a count ever needs a different one.
+  ```
+
+- **No `sort`/`slice` on the wrapper.** GROQ allows it; no call site wants it.
+
+## Files
+
+| Action | Path |
+|---|---|
+| edit | `src/lib/sanity/query.ts` — add `CompositeParts` type and `composite()` export |
+
+Nothing else. No service file is modified by this plan — see below.
+
+## Migration
+
+Deliberately **not** part of this change. `composite()` ships unused, then call sites move one at
+a time in separate PRs, each verifiable on its own:
+
+1. `counts.ts:36` — simplest, and the only site already on `SanityClient` rather than
+   `fetchSanity`.
+2. `instructor.ts:156`, `artist.ts:157`, `genre.ts:156` — the `{data, total}` trio.
+3. `artist.ts:54`, `genre.ts:54`, `instructor.ts:55` — the single-key `{data}` sites, which are
+   the ones whose emitted string changes (trailing comma).
+
+Each migration is behaviour-preserving except for that comma, and none of them touches transport.
+
+## Tests
+
+Extend `test/unit/lib/query.test.ts` — same file, same pure-string-assertion style as the
+existing 1497 lines. No new transport, no mocking, no network (`test/setupNetworkGuard.js` is
+irrelevant here since `composite()` performs no IO).
+
+- single key with a builder value → `{ "data": *[...] }`
+- multiple keys → order preserved, `, ` separator, no trailing comma
+- string value passed through verbatim (the `f.count(...)` path)
+- mixed builder + string values in one call
+- key quoting is applied even for plain identifier-safe keys
+- empty object in → `{  }` (assert whatever it actually emits, and keep it stable)
+- mutating a builder after passing it to `composite()` does not change the emitted string
+
+Coverage floor is global 40/25/40/40 with a "do not lower these numbers" note
+(`jest.config.js:50-55`); a seven-line function with the above cases clears it comfortably.
+
+## Verification
+
+```bash
+r mcs npm run test:unit -- test/unit/lib/query.test.ts
+r mcs npx tsc --noEmit          # no build step exists; type-check only
+npx prettier --check src/lib/sanity/query.ts
+```
+
+Equivalence check against today's output, worth running once during implementation — this is the
+claim the whole plan rests on:
+
+```ts
+const filter = f.combine(f.type('artist'))
+console.log(`count(${query().and(filter)})` === f.count(filter))   // expect true
+```
+
+## Relationship to the execution plan
+
+`.claude/docs/architecture/groq-query-builder-execution.md` proposes making built queries runnable and returning a
+typed `Result`. The two are **independent and can ship in either order**:
+
+- `composite()` is pure string construction. It works today with `sanityClient.executeQuery(q)`
+  and `fetchSanity(q, ...)` exactly as the call sites already use them.
+- If the execution plan lands, it gains a one-line convenience in `runner.ts`:
+
+  ```ts
+  export const runComposite = <T>(parts: CompositeParts, runner: QueryRunner = defaultRunner()) =>
+    runner.run<T>(composite(parts))
+  ```
+
+That ordering matters: the execution plan's `run()` serves zero existing call sites on its own,
+because every builder-based site is composite. Landing `composite()` first is what gives it
+somewhere to land.
+
+## Divergence from the PHP plan
+
+No mpb counterpart. `Groq` has the identical single-projection-slot limitation, but zero call
+sites demanding a composite — `SanityGateway` builds its `{...}` wrappers as raw strings and does
+not use the builder at all. Building it there now would be speculative. Add it to mpb when a real
+query needs it.

--- a/.claude/docs/architecture/groq-query-builder-execution.md
+++ b/.claude/docs/architecture/groq-query-builder-execution.md
@@ -1,0 +1,468 @@
+# Plan: make built queries runnable, with a typed result (mcs)
+
+Status: implemented.
+Scope: `src/lib/sanity/runner.ts`, `src/lib/sanity/groq.ts`, `src/lib/sanity/examples.ts`,
+`src/lib/ads/either.ts`.
+Depends on: `Coproduct` in `src/lib/ads/` — ported from `chore/ads-structures`, already on this branch.
+Related: `.claude/docs/architecture/groq-composite-projections.md` — `composite()` shipped first; this plan builds on it.
+
+## Context
+
+`src/lib/sanity/query.ts` builds GROQ strings and stops there — `build()` returns a string and
+nothing runs it. Execution lives in `src/infrastructure/sanity/SanityClient.ts`, and the two are
+connected today only by string interpolation, never by a handoff.
+
+The error contract on that client is the specific thing worth fixing. All three public methods
+look like they return a null-ish fallback on failure:
+
+```ts
+} catch (error: any) {
+  this.handleError(error, query)
+  return null            // SanityClient.ts:37, :52 (`return []`), :67
+}
+```
+
+`handleError` is declared `: never` and throws unconditionally (`SanityClient.ts:84-96`), so
+**every one of those fallback returns is unreachable**. The real contract is "returns `null` when
+the query legitimately matched nothing, throws when the request failed" — two very different
+outcomes, one of which is invisible at the type level.
+`test/unit/infrastructure/sanity/SanityClient.test.ts:52` asserts the throw, confirming the
+intent; the dead code is what misleads readers.
+
+On top of that, the thrown value is an object literal cast to an interface
+(`SanityClient.ts:91`, `FetchQueryExecutor.ts:37`) — no stack, fails `instanceof Error`.
+
+Goal: a built query becomes runnable, and the outcome comes back as a value that distinguishes
+*matched nothing* from *request failed*, without callers writing `try/catch` around a function
+whose signature never mentions throwing.
+
+Settled up front:
+
+- **Additive only.** Existing exported service functions keep throwing / returning `null` exactly
+  as they do now. No breaking change for mpf or MusoraApp; mcs publishes to npm via
+  standard-version, so a major bump is a real cost and this avoids it.
+- **No call sites migrate.** `run()` ships unused, same as `composite()` did. Migration is its own
+  PR, one site at a time.
+
+## Design
+
+```
+filter.ts ──> query.ts <── groq.ts ──> runner.ts ──> SanityClient
+                                │                          │
+                                └──returns──> Either<SanityQueryError, T | null>
+```
+
+`query()` keeps knowing nothing about transport. The runner is the only place IO happens, and it
+is one function wide so tests inject a plain arrow. `groq.ts` is the composition root that joins
+them — it imports both, and neither imports the other.
+
+### 1. The result type already exists — use `Coproduct`
+
+`src/lib/ads/coproduct.ts` provides everything an execution result needs, so no `Result` type gets
+written:
+
+| what the result needs | `Coproduct<L, R>` |
+|---|---|
+| success / failure split | `Right` / `Left`, with error on the left |
+| narrowing without a cast | `isRight(): this is Right<L, R>` |
+| transform the value | `map`, `flatMap` |
+| transform the error | `mapLeft`, `flatMapLeft` |
+| collapse to one value | `fold(onLeft, onRight)` |
+| fall back on failure | `recover(defaultValue)` |
+| peek without changing | `tap`, `ltap` |
+| unwrap either side | `drop` |
+
+`Left.map()` already returns `new Left(this.value)` rather than `this`, which is the variance
+behaviour a hand-written `Result` would have had to guarantee — returning `this` types as
+`Left<T, E>` where the signature promises `Coproduct<L, U>`, forcing a cast.
+
+**`Either` is a synonym, not a subclass** (`src/lib/ads/either.ts`):
+
+```ts
+export type Either<L, R> = Coproduct<L, R>
+export const Either = { left: Coproduct.left, right: Coproduct.right }
+```
+
+Categorically the coproduct of `A` and `B` *is* `Either` — `Left`/`Right` are its canonical
+injections (`inl`/`inr`), which is why Haskell and Scala both declare them on `Either` directly
+with no more general sum type beneath. Making `Either extends Coproduct` would carve at the wrong
+joint: the types nearby differ by *algebra*, not shape. `Validation` has the identical two-case
+shape but is an applicative that accumulates errors rather than a monad that short-circuits, and
+`These` has three cases so it is not a binary coproduct at all. Neither would inherit anything
+useful from `Left`/`Right`. In FP shared behaviour comes from typeclasses, and this repo already
+has them — `Functor`, `Monad`, `Tappable`, `Foldable`, `Recoverable`, `Droppable` are where a
+future structure plugs in.
+
+The alias buys readability at construction (`Either.left(err)` / `Either.right(docs)`) and in
+signatures, for nine lines and zero duplication. Trade-off: no `instanceof Either` — use
+`isLeft()` / `isRight()`, which narrow properly — and no nominal distinction from `Coproduct`,
+correctly, because there isn't one.
+
+**Caveat to state plainly:** `tsconfig.json` has `"strict": false`, so `strictNullChecks` is off
+and `null` / `undefined` still flow into both slots unchecked. The ADT narrows what it can; it does
+not make the file null-safe. Flipping `strict` even for `src/lib/**` is a separate change with its
+own blast radius — out of scope here, worth doing.
+
+### 2. Error value
+
+Folded into `runner.ts` rather than its own module — one class, produced in exactly one place (the
+runner's catch), consumed only by callers of `run()`, who import `runner.ts` anyway.
+
+```ts
+export class SanityQueryError extends Error {
+  constructor(
+    message: string,
+    public readonly groq: string,
+    public readonly cause?: unknown
+  ) {
+    super(message)
+    this.name = 'SanityQueryError'
+  }
+}
+```
+
+A real `Error` subclass, deliberately — it fixes the `instanceof`-hostile object literals the
+Sanity infra throws today.
+
+Three deliberate omissions:
+
+- **No `kind` union, no `status`.** Neither is obtainable here. `createSanityError`
+  (`FetchQueryExecutor.ts:89-109`) formats the status into a *message string* and returns
+  `{ message, query, params }` with no status field — and when Sanity returns a JSON body with its
+  own `message`, the status text is overwritten entirely. Recovering a status would mean either
+  regex-parsing messages (fragile, already broken by that overwrite) or editing
+  `FetchQueryExecutor`, which this plan does not touch. `Left` vs `Right` already delivers the
+  stated goal; a three-way union nobody switches on does not. If a retry policy ever needs "was
+  this a 5xx", add `status?: number` to the `SanityError` interface and set it in
+  `createSanityError` — two additive lines, obvious at that point which values matter.
+- **`cause` is an own property**, not `Error`'s. `target` is `ES2020` with no `lib` override, so
+  the ES2022 `new Error(msg, { cause })` overload is not in the type library. A readonly field
+  works identically for debugging.
+- **No `Object.setPrototypeOf`.** At ES2020 `extends Error` gives working `instanceof` natively.
+  `SyncError` (`src/services/sync/errors/index.ts:17`) does it defensively for downlevel builds;
+  not needed here.
+
+`groq` is carried because the failing query is the most useful thing in a log line, and
+`SanityError` already threads `query` through today (`SanityClient.ts:92`) — nothing is lost
+relative to current behaviour.
+
+### 3. Runner — a function type, not an interface
+
+```ts
+export type QueryRunner<T = unknown> = (groq: string) => Promise<Either<SanityQueryError, T | null>>
+
+export const sanityRunner =
+  <T = unknown>(client: SanityClient = new SanityClient()): QueryRunner<T> =>
+  async (groq) => {
+    client.refreshConfig()
+    try {
+      return Either.right<SanityQueryError, T | null>(await client.executeQuery<T>(groq))
+    } catch (error: any) {
+      return Either.left<SanityQueryError, T | null>(
+        new SanityQueryError(error?.message ?? 'Sanity query failed', groq, error)
+      )
+    }
+  }
+```
+
+**The generic belongs on the type, not on the call.** The first cut wrote
+`QueryRunner = <T>(groq: string) => ...`, promising a runner that works for *every* `T`. No fake
+can satisfy that — a test double returns one concrete type — so every fake needed an `as any`, and
+three of them were written before anyone noticed. Parameterising the type instead makes a fake
+`const fake: QueryRunner<Song[]> = async () => Either.right([])` with no cast.
+
+This was caught by `examples.ts` failing to compile, not by review or tests — see "Why
+`examples.ts` exists" below.
+
+One cast survives, inside `defaultRunner`, and is justified: the cached closure never inspects `T`,
+it only forwards whatever Sanity returned, so one instance genuinely serves every result type.
+
+A one-method interface is a function type in TypeScript. `src/lib/sanity/` is closure-style —
+`query()` is a factory returning an object literal closing over `state`, no classes in the file —
+and this lands there, so it matches. It also collapses the testability story to its simplest form:
+a fake runner is `async () => Coproduct.right(fixture)`, not a class implementing an interface.
+
+**Target `SanityClient`, not `fetchSanity`.** Two independent transports exist and they are not
+interchangeable:
+
+| | `SanityClient` → `FetchQueryExecutor` | `fetchSanity` (`services/sanity.js:1590`) |
+|---|---|---|
+| host | `{projectId}.api\|apicdn.sanity.io` | `sanity.musora.com/{projectId}/...` |
+| errors | throws | `console.error` + `return null` (:1648) |
+| decorators | none | applies `needsAccess` / `lifetimeUpgrade` / `pageType` (:1638-1641) |
+| DI seam | clean, constructor-injected | none |
+
+`SanityClient` is the one already under test with hand-rolled interface fakes. The consequence to
+record: **the decoration step that every `fetchSanity` call site depends on has no equivalent on
+this path**, so results from `run()` are undecorated. Any future migration of a `fetchSanity` call
+site has to solve that first.
+
+Do **not** add a new executor interface at the infrastructure layer — `QueryExecutor`
+(`src/infrastructure/sanity/interfaces/QueryExecutor.ts`) already exists and `SanityClient` already
+takes it constructor-injected. The new type belongs in `src/lib/sanity/` because it is about
+*results*, not about transport.
+
+### 4. Entry points — a free function, plus `groq()` as a composition root
+
+```ts
+let cachedRunner: QueryRunner | undefined
+const defaultRunner = (): QueryRunner => (cachedRunner ??= sanityRunner())
+
+export const run = <T>(groq: string, runner: QueryRunner = defaultRunner()) => runner<T>(groq)
+```
+
+`run()` deliberately does **not** go on `QueryBuilder`. `query.ts` today imports exactly two
+things, `Monoid` and `FieldAccess`, and stays pure string construction. A `run()` method with a
+default runner would make `query.ts` statically import the runner → `SanityClient` →
+`FetchQueryExecutor`, so every consumer of the builder drags the transport in — and `filter.ts`
+imports `query.ts` for `filterOps`, so even importing `Filters` alone would pull it. That matters
+for MusoraApp, which imports MCS by subpath specifically to keep its bundle tight.
+
+The fluency is recovered without paying that cost, by putting the join in a **third module**
+(`src/lib/sanity/groq.ts`) that imports both while neither imports the other:
+
+```ts
+const groqBuilder = (selector?: string): GroqBuilder => {
+  const builder = query(selector)
+  return Object.assign(builder, {
+    run: <T>(runner?: QueryRunner<T>) => run<T>(builder.build(), runner),
+  }) as GroqBuilder
+}
+```
+
+No forwarding methods are needed: every `QueryBuilder` method ends in `return builder` — the same
+object reference — so augmenting that object yields a chain that already carries `run()`.
+
+The cost is types, not runtime. `QueryBuilder.and()` is declared to return `QueryBuilder`, so
+without help the static type loses `run` after the first call. `GroqBuilder` therefore redeclares
+the chainable signatures with narrowed returns — about ten lines, types only, zero runtime effect.
+This is the same F-bounded limitation that ruled out subclassing `Either`; here it is worth paying
+because there is exactly one subtype, not an open family.
+
+`groq()` also inherits the `first()`/`this` quirk (`query.ts:112`) unchanged, since it augments the
+very same object rather than wrapping it.
+
+**Composite queries get the same treatment.** `composite()` still returns a plain string, so
+`run(composite({...}))` keeps working. `groq.composite(parts)` wraps it into a `RunnableQuery`:
+
+```ts
+export interface RunnableQuery {
+  build(): string
+  toString(): string
+  run<T>(runner?: QueryRunner<T>): Promise<Either<SanityQueryError, T | null>>
+}
+
+export interface GroqBuilder extends QueryBuilder, RunnableQuery { /* chainables */ }
+```
+
+`RunnableQuery` is deliberately **not** chainable. A composite is terminal — `.and()` on
+`{ "data": ..., "total": ... }` is not valid GROQ — so the compiler now rejects what the bare-string
+return could never express. Sharing one contract also lets a function accept "anything runnable"
+without caring which kind it got.
+
+The two differ in *when* they build, and both tests say so explicitly: `groq()` builds at `.run()`
+time, while `groq.composite()` snapshots at call time because `composite()` stringifies its parts
+eagerly — shipped behaviour from `.claude/docs/architecture/groq-composite-projections.md`, not introduced here.
+
+A `runComposite` free function was rejected: it would have been a pure alias for
+`run(composite(parts))` — one call saved, a second spelling for the same operation, which is
+exactly the "same idiom, two spellings, no enforcement" complaint that motivated `composite()`.
+`groq.composite()` earns its place instead by returning a different *type*, not just a shorter
+spelling.
+
+**No `params` argument.** The builder bakes values in through `and` / `or` / `Filters`, so the
+string is complete by the time `run()` sees it. Nothing can supply a param bag, so the argument
+would be permanently unused.
+
+> Recorded while deciding this, out of scope but real: `Filters.titleMatch` (`filter.ts:183`) and
+> `Filters.searchMatch` (`filter.ts:193`) interpolate caller-supplied text straight into GROQ with
+> no escaping — `` `title match "${term}*"` ``. A term containing a double quote closes the literal
+> and can widen the filter beyond its intended scope. A `params` argument would not have fixed it,
+> because `Filters` builds the string long before `run()` is called; the fix belongs in `Filters`.
+> Needs its own investigation into whether user-supplied search text reaches either helper.
+
+### 5. Config freshness
+
+The default runner is a lazy module singleton that calls `refreshConfig()` before every query.
+
+That combination is load-bearing. `initializeService` **mutates** `globalConfig` in place
+(`config.js:91`), while `DefaultConfigProvider.getConfig()` returns a **fresh copy**
+(`DefaultConfigProvider.ts:28-36`) that `SanityClient` then caches in `this.config`. A long-lived
+client without the refresh therefore serves a snapshot taken at its first query — stale after any
+re-initialisation, which `initializeTestService()` does between test cases. That is the same class
+of bug as the module-level client at `counts.ts:7`.
+
+Refreshing costs a `this.config = null` and a re-read on next use: one object literal and four
+truthiness checks. Cheaper than the three allocations a fresh-client-per-call would make, and it
+keeps freshness guaranteed.
+
+```ts
+// ponytail: refresh per query because initializeService mutates globalConfig in place;
+// SanityClient's cached copy would go stale. Drop this if config becomes immutable.
+```
+
+Config errors surface as `Left`, not as a throw: `getConfig()` is called *inside* `executeQuery`'s
+try block, so "Sanity token is missing in configuration" arrives as a failed result. Consistent —
+`run()` never throws — though it does mean a setup bug wears the costume of a query failure. The
+message is unambiguous enough to diagnose.
+
+### 6. Empty results are `Right(null)`
+
+`executeQuery` returns `response.result`, which is `null` when nothing matched
+(`SanityClient.ts:64`). That is a **success**. `Left` stays reserved for failure, which is the
+distinction this plan exists to draw; collapsing them would reinstate the ambiguity. It also
+matches the transport, where `fetchList` returns `[]` and `fetchSingle` returns `null` on empty.
+
+The surprise to document in the JSDoc:
+
+```ts
+const result = await run<Song[]>(groq)
+result.recover([])   // → null when nothing matched, NOT []
+```
+
+`recover` only replaces a `Left`. A caller wanting "empty list when nothing matched" writes
+`.map(docs => docs ?? []).recover([])`, or folds. Layering `Maybe` on top of `Coproduct` to model
+this is not worth it for zero consumers.
+
+### 7. Public API surface
+
+`tools/generate-index.cjs` scrapes **`src/services/**` only**, so nothing added under `src/lib/`
+reaches `src/index.js` automatically. Consumers reach it through the subpath export —
+`"./*": "./src/*"` in package.json already permits
+`musora-content-services/src/lib/sanity/runner`, which is how MusoraApp already imports the sync
+system. Subpath only, at least until something in `src/services/` uses it.
+
+## Files
+
+| Action | Path |
+|---|---|
+| new | `src/lib/ads/either.ts` — `Either` type alias and constructors over `Coproduct` |
+| new | `src/lib/sanity/runner.ts` — `SanityQueryError`, `QueryRunner`, `sanityRunner`, `run` |
+| new | `src/lib/sanity/groq.ts` — `RunnableQuery`, `GroqBuilder`, `groq`, `groq.composite` |
+| new | `src/lib/sanity/examples.ts` — compile-checked usage of the whole pipeline |
+| new | `test/unit/lib/ads/either.test.ts` |
+| new | `test/unit/lib/sanity/runner.test.ts` |
+| new | `test/unit/lib/sanity/groq.test.ts` |
+
+`query.ts`, `filter.ts`, `SanityClient.ts`, `FetchQueryExecutor.ts`, `services/sanity.js` and every
+existing service function are **not** modified.
+
+## Tests
+
+Fakes are built by constructing a **real** `SanityClient` with fake collaborators, not by mocking
+the client itself:
+
+```ts
+const throwingExecutor: QueryExecutor = {
+  execute: async () => { throw new Error('network down') },
+}
+const client = new SanityClient(stubConfigProvider, throwingExecutor)
+```
+
+Both constructor dependencies are already one-method interfaces. This exercises the *real*
+`handleError` path — the executor throws, `SanityClient` converts it to the
+`{ message, query, originalError }` object literal, and the runner has to turn that into a
+`SanityQueryError`. That conversion is the thing being built; mocking `executeQuery` directly would
+test nothing. It also documents honestly that what arrives in the catch is a non-`Error` object
+literal, which is why the error wraps rather than rethrows.
+
+Cases:
+
+- executor resolves `{ result: [...] }` → `Right` carrying the docs
+- executor resolves `{ result: null }` → `Right(null)`, not `Left`
+- executor throws → `Left`, `instanceof SanityQueryError`, `groq` preserved, `cause` carries the
+  original
+- config provider throws → `Left`, no exception escapes
+- `run(groq, fakeRunner)` forwards the string and returns the runner's value untouched
+- `refreshConfig` is called before each query
+
+`test/setupNetworkGuard.js` blocks real network calls in unit tests, so injection is required, not
+optional. Coverage has a global floor of 40/25/40/40 with a "do not lower these numbers" note
+(`jest.config.js:50-55`).
+
+`test/unit/lib/ads/coproduct.test.ts` already covers the result type (23 cases);
+`either.test.ts` adds 3 confirming the alias produces real `Left`/`Right` and keeps the full
+behaviour.
+
+`groq.test.ts` covers the composition root (11 cases). Two carry the design rather than the code:
+
+- `run` is still callable after `.and().order().slice().select()` — without the `GroqBuilder`
+  signature redeclarations this fails to compile, so the test is what keeps them honest.
+- `groq()` builds at run time, `groq.composite()` snapshots at call time — asserted as a matched
+  pair so the difference is pinned rather than folklore.
+
+## Why `examples.ts` exists
+
+`src/infrastructure/sanity/examples/usage.ts` and `src/lib/sanity/decorators/examples.ts` set the
+precedent: exported, type-checked, untested usage files that document an API by compiling against
+it.
+
+For this work it was not decoration. Writing it broke the build, and that break was the
+`QueryRunner` variance flaw in §3 — an API that could not be faked without `as any`. Unit tests had
+already been written *around* the flaw with casts. JSDoc `@example` blocks would not have caught it
+either, since they are not compiled.
+
+For an API with zero production call sites, a compile-checked example is the only thing that
+exercises its ergonomics. It covers: single query with `fold` error handling, `groq.composite()`
+pagination with `recover`, chained `map` for count aggregation, `isRight()` narrowing, a shared
+injected runner, a test-runner factory, and the free-function `run(composite({...}))` path retained
+to prove it still works.
+
+## Verification
+
+```bash
+r mcs npx jest test/unit/lib
+r mcs npx tsc --noEmit          # no build step exists; this is a type-check only
+npx prettier --check src/lib
+```
+
+Then one real round-trip, in an app that has `initializeService({ sanityConfig })` already called
+(mcs has no standalone runtime entrypoint):
+
+```ts
+const result = await groq()
+  .and(Filters.type('song'))
+  .select('_id', 'title')
+  .slice(0, 3)
+  .run<Song[]>()
+
+result.fold(
+  (err) => console.error(`${err.name}: ${err.message}`),
+  (docs) => console.log(docs?.length ?? 0)
+)
+```
+
+Result as implemented: `npm test` passes 1223 across 75 suites, `tsc --noEmit` is clean, and
+`prettier --check` is clean on every new file.
+
+## Divergence from the PHP plan
+
+`musora-platform-backend` has **no** counterpart implemented — `app/Structure/Algebraic/` holds
+only `Monoid.php` and `Semigroup.php`, and `app/Modules/Content/QueryBuilder/` has `Groq.php`,
+`Filters.php`, monoids and enums but no execution layer, no `Result`, no executor contract. Any
+"mirror the PHP structure" argument is therefore mirroring an unimplemented proposal, not shipped
+code. This plan follows what mcs already has instead; if mpb ever lands its own version, parity can
+be argued then with two real implementations in view.
+
+## Out of scope
+
+- **Flipping `tsconfig` `strict`** — noted above; the ADT is weaker without it.
+- **GROQ params (`$foo`).** `SanityQuery { query, params }` is already threaded through and
+  `FetchQueryExecutor.ts:64` already forces POST when params are present. Nothing passes params
+  today and the builder has no param bag; adding one is a separate change.
+- **Escaping in `Filters.titleMatch` / `Filters.searchMatch`** — flagged in §4, needs its own
+  investigation and fix.
+- **Migrating existing call sites** off interpolation, and the missing decorator behaviour that
+  such a migration would first have to solve.
+- **Retries / caching** — neither exists on the `SanityClient` path today.
+- **Deleting the unreachable `return null` / `return []`** in `SanityClient.ts:37,52,67`. Real dead
+  code and worth removing, but a separate cleanup with its own test implications.
+- **`either.ts` and `maybe.ts`**, left behind on `chore/ads-structures`: `Either`'s inherited
+  statics return `Coproduct`, so no `Either` can be constructed; `Maybe.of` is truthiness-based, so
+  `Maybe.of(0)` yields `None`. Both need fixing before they are worth porting.
+- **Dead dependencies** `@sanity/client@^5.4.2` and `groqd@^0.15.12` — in `dependencies`, zero
+  imports anywhere in `src/` or `test/`. Flagged because `groqd` is literally a GROQ query builder
+  that someone once intended to use.
+- Pre-existing builder defects left alone: `first()` uses `this` (`query.ts:112`), the `order`
+  monoid re-wraps rather than accumulating (`query.ts:52`), `_state()` returns the live mutable
+  state with no defensive copy (`query.ts:156`), and the builder is mutable so it cannot be forked.

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,6 +38,8 @@ export default {
     '!src/services/user/interests.js',
     '!src/services/user/payments.ts',
     '!src/services/user/chat.js',
+    '!src/**/examples.ts',
+    '!src/**/examples/**',
   ],
 
   // The directory where Jest should output its coverage files
@@ -165,9 +167,8 @@ export default {
     'dotenv/config',
     '<rootDir>/test/setupConsole.js',
     '<rootDir>/test/setupNetworkGuard.js',
-    '<rootDir>/test/setupTimers.js'
+    '<rootDir>/test/setupTimers.js',
   ],
-
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/src/lib/ads/coproduct.ts
+++ b/src/lib/ads/coproduct.ts
@@ -1,0 +1,171 @@
+import { Droppable } from './interfaces/droppable'
+import { DisjointFoldable2 } from './interfaces/foldable'
+import { Recoverable } from './interfaces/recoverable'
+import { Tappable } from './interfaces/tappable'
+import { Monad } from './monad'
+
+/** A monadic container that represents a value that can be either a left or a right value. */
+export abstract class Coproduct<L, R>
+  implements
+    Tappable<L | R>,
+    DisjointFoldable2<L, R>,
+    Droppable<L | R>,
+    Recoverable<R>,
+    Monad<L | R>
+{
+  static left<L, R>(value: L): Coproduct<L, R> {
+    return new Left(value)
+  }
+
+  static right<L, R>(value: R): Coproduct<L, R> {
+    return new Right(value)
+  }
+
+  abstract isLeft(): this is Left<L, R>
+  abstract isRight(): this is Right<L, R>
+
+  /**
+   * @extends Functor
+   * Maps the right value of the Coproduct.
+   */
+  abstract map<T>(fn: (r: R) => T): Coproduct<L, T>
+  /**
+   * @extends Monad
+   * Applies a function to the right value of the Coproduct, returning a new Coproduct.
+   */
+  abstract flatMap<T>(fn: (r: R) => Coproduct<L, T>): Coproduct<L, T>
+
+  /** Maps the left value of the Coproduct to a new type. */
+  abstract mapLeft<T>(fn: (l: L) => T): Coproduct<T, R>
+
+  /** Applies a function to the left value of the Coproduct, returning a new Coproduct. */
+  abstract flatMapLeft<T>(fn: (l: L) => Coproduct<T, R>): Coproduct<T, R>
+
+  abstract fold<T, U>(onLeft: (l: L) => T, onRight: (r: R) => U): T | U
+  foldMap<T>(initial: T, fn: (acc: T, value: L | R) => T): T {
+    return this.fold(
+      (l) => fn(initial, l),
+      (r) => fn(initial, r)
+    )
+  }
+
+  /**
+   * Visits the value inside the container if right and applies a function to it without modifying
+   * @implements Tappable
+   */
+  abstract tap(fn: (r: R) => void): this
+
+  /** Visits the value inside the container if left and applies a function to it without modifying */
+  abstract ltap(fn: (l: L) => void): Coproduct<L, R>
+  abstract drop(): R | L
+  /**
+   * Returns the right value if it exists, otherwise returns the provided default value.
+   * @implements Recoverable
+   */
+  abstract recover(defaultValue: R): R
+}
+
+export class Left<L, R> extends Coproduct<L, R> {
+  constructor(private readonly value: L) {
+    super()
+  }
+
+  isLeft(): this is Left<L, R> {
+    return true
+  }
+
+  isRight(): this is Right<L, R> {
+    return false
+  }
+
+  map<T>(_fn: (r: R) => T): Coproduct<L, T> {
+    return new Left(this.value)
+  }
+
+  flatMap<T>(_fn: (r: R) => Coproduct<L, T>): Coproduct<L, T> {
+    return new Left(this.value)
+  }
+
+  mapLeft<T>(fn: (l: L) => T): Coproduct<T, R> {
+    return new Left(fn(this.value))
+  }
+
+  flatMapLeft<T>(fn: (l: L) => Coproduct<T, R>): Coproduct<T, R> {
+    return fn(this.value)
+  }
+
+  fold<T, U>(onLeft: (l: L) => T, _onRight: (r: R) => U): T | U {
+    return onLeft(this.value)
+  }
+
+  tap(_fn: (l: R) => void): this {
+    return this
+  }
+
+  ltap(fn: (l: L) => void): Coproduct<L, R> {
+    const valueToTap = this.value
+    fn(valueToTap)
+    return this
+  }
+
+  drop(): L | R {
+    return this.value
+  }
+
+  recover(defaultValue: R): R {
+    return defaultValue
+  }
+}
+
+/** A right value in an Coproduct, usually representing a success or valid result. */
+export class Right<L, R> extends Coproduct<L, R> {
+  constructor(private readonly value: R) {
+    super()
+  }
+
+  isLeft(): this is Left<L, R> {
+    return false
+  }
+
+  isRight(): this is Right<L, R> {
+    return true
+  }
+
+  map<T>(fn: (r: R) => T): Coproduct<L, T> {
+    return new Right(fn(this.value))
+  }
+
+  flatMap<T>(fn: (r: R) => Coproduct<L, T>): Coproduct<L, T> {
+    return fn(this.value)
+  }
+
+  mapLeft<T>(_fn: (l: L) => T): Coproduct<T, R> {
+    return new Right(this.value)
+  }
+
+  flatMapLeft<T>(_fn: (l: L) => Coproduct<T, R>): Coproduct<T, R> {
+    return new Right(this.value)
+  }
+
+  fold<T, U>(_onLeft: (l: L) => T, onRight: (r: R) => U): T | U {
+    return onRight(this.value)
+  }
+
+  tap(fn: (r: R) => void): this {
+    const valueToTap = this.value
+    fn(valueToTap)
+    return this
+  }
+
+  ltap(_fn: (l: L) => void): Coproduct<L, R> {
+    return this
+  }
+
+  drop(): L | R {
+    return this.value
+  }
+
+  recover(_defaultValue: R): R {
+    return this.drop() as R
+  }
+}

--- a/src/lib/ads/coproduct.ts
+++ b/src/lib/ads/coproduct.ts
@@ -30,6 +30,11 @@ export abstract class Coproduct<L, R>
    */
   abstract map<T>(fn: (r: R) => T): Coproduct<L, T>
   /**
+   * Maps the right value of the Coproduct with an asynchronous function.
+   * A rejection propagates: there is no way to build an L from it.
+   */
+  abstract mapAsync<T>(fn: (r: R) => Promise<T>): Promise<Coproduct<L, T>>
+  /**
    * @extends Monad
    * Applies a function to the right value of the Coproduct, returning a new Coproduct.
    */
@@ -79,6 +84,10 @@ export class Left<L, R> extends Coproduct<L, R> {
   }
 
   map<T>(_fn: (r: R) => T): Coproduct<L, T> {
+    return new Left(this.value)
+  }
+
+  async mapAsync<T>(_fn: (r: R) => Promise<T>): Promise<Coproduct<L, T>> {
     return new Left(this.value)
   }
 
@@ -133,6 +142,10 @@ export class Right<L, R> extends Coproduct<L, R> {
 
   map<T>(fn: (r: R) => T): Coproduct<L, T> {
     return new Right(fn(this.value))
+  }
+
+  async mapAsync<T>(fn: (r: R) => Promise<T>): Promise<Coproduct<L, T>> {
+    return new Right(await fn(this.value))
   }
 
   flatMap<T>(fn: (r: R) => Coproduct<L, T>): Coproduct<L, T> {

--- a/src/lib/ads/either.ts
+++ b/src/lib/ads/either.ts
@@ -1,0 +1,9 @@
+import { Coproduct } from './coproduct'
+
+/** A Coproduct under the convention that left carries the error and right carries the success value. */
+export type Either<L, R> = Coproduct<L, R>
+
+export const Either = {
+  left: Coproduct.left,
+  right: Coproduct.right,
+}

--- a/src/lib/ads/functor.ts
+++ b/src/lib/ads/functor.ts
@@ -1,0 +1,9 @@
+export abstract class Functor<T> {
+  /** Applies a function to the value inside the functor */
+  abstract map<U>(fn: (value: T) => U): Functor<U>
+
+  /** Lifts a value into a Functor*/
+  static of<T>(_value: T): Functor<T> {
+    throw new Error('Method not implemented. Use a subclass of Functor.')
+  }
+}

--- a/src/lib/ads/interfaces/droppable.ts
+++ b/src/lib/ads/interfaces/droppable.ts
@@ -1,0 +1,4 @@
+export interface Droppable<T> {
+  /** Drops the value out of the container and returns it. */
+  drop(): T
+}

--- a/src/lib/ads/interfaces/foldable.ts
+++ b/src/lib/ads/interfaces/foldable.ts
@@ -1,0 +1,24 @@
+export interface Foldable<A> {
+  /**
+   * Folds the values in the container using the provided function.
+   * Similar to reduce for collections (arrays/lists/trees)
+   */
+  foldMap<T>(initial: T, fn: (acc: T, value: A) => T): T
+}
+
+/** FoldableProduct is a specialized Foldable for containers that hold two values, like a tuple. */
+export interface FoldableProduct<F, S> extends Foldable<F | S> {
+  fold<T>(fn: (first: F, second: S) => T): T
+}
+
+/** DisjointFoldable is a specialized Foldable for containers that can hold either a single value or none, like Maybe. */
+export interface DisjointFoldable1<A> extends Foldable<A> {
+  /** Folds the values in the container using the provided function. */
+  fold<T>(onNone: () => T, onSome: (a: A) => T): T
+}
+
+/** DisjointFoldable2 is a specialized Foldable for containers that can hold either a left or right value, like Either. */
+export interface DisjointFoldable2<L, R> extends Foldable<L | R> {
+  /** Folds the values in the container using the provided functions for left and right. */
+  fold<T>(onLeft: (l: L) => T, onRight: (r: R) => T): T
+}

--- a/src/lib/ads/interfaces/recoverable.ts
+++ b/src/lib/ads/interfaces/recoverable.ts
@@ -1,0 +1,4 @@
+export interface Recoverable<T> {
+  /** Recovers the value from the container, providing a default value if the container is empty or contains lefty values. */
+  recover(defaultValue: T): T
+}

--- a/src/lib/ads/interfaces/tappable.ts
+++ b/src/lib/ads/interfaces/tappable.ts
@@ -1,0 +1,4 @@
+export interface Tappable<V> {
+  /** Visits the value inside the container and applies a function to it without modifying. */
+  tap(fn: (value: V) => void): this
+}

--- a/src/lib/ads/monad.ts
+++ b/src/lib/ads/monad.ts
@@ -1,0 +1,6 @@
+import { Functor } from './functor'
+
+export abstract class Monad<T> extends Functor<T> {
+  /** Applies a function to the value inside the monad, returning a new monad. */
+  abstract flatMap<U>(fn: (value: T) => Monad<U>): Monad<U>
+}

--- a/src/lib/sanity/examples.ts
+++ b/src/lib/sanity/examples.ts
@@ -1,4 +1,10 @@
 import { Filters as f } from './filter'
+import { decorateAll, type FieldDecorator } from './decorators/base'
+import { accessDecorator, decorateAccess } from './decorators/need-access'
+import { lifetimeUpgradeDecorator } from './decorators/need-lifetime-upgrade'
+import { pageTypeDecorator } from './decorators/page-type'
+import { decorateNavigateTo } from './decorators/navigate-to'
+import { fetchUserPermissions, type UserPermissions } from '../../services/permissions'
 import { groq } from './groq'
 import { composite, query } from './query'
 import { run, sanityRunner, QueryRunner, SanityQueryError } from './runner'
@@ -85,3 +91,114 @@ export function buildRunnerForTests(): QueryRunner<Song[]> {
 }
 
 export const productionRunner = sanityRunner()
+
+interface Lesson {
+  id: number
+  type: string
+  brand: string
+  thumbnail: string
+  published_on: string | null
+  status: string
+  permission_id?: number[]
+  children?: Lesson[]
+  [key: string]: unknown
+}
+
+export async function fetchLessonsWithoutPermissions(brand: string) {
+  const result = await groq().and(f.brand(brand)).slice(0, 10).run<Lesson[]>()
+
+  return result
+    .map((lessons) =>
+      decorateAll<Lesson>(lessons ?? [], [pageTypeDecorator as FieldDecorator<Lesson>])
+    )
+    .recover([])
+}
+
+export async function fetchDecoratedLessons(brand: string) {
+  const [result, permissions] = await Promise.all([
+    groq()
+      .and(f.combine(f.typeIn(['course']), f.brand(brand)))
+      .slice(0, 10)
+      .run<Lesson[]>(),
+    fetchUserPermissions(),
+  ])
+
+  return result
+    .map((lessons) =>
+      decorateAll<Lesson>(lessons ?? [], [
+        accessDecorator(permissions) as FieldDecorator<Lesson>,
+        lifetimeUpgradeDecorator(permissions) as FieldDecorator<Lesson>,
+        pageTypeDecorator as FieldDecorator<Lesson>,
+      ])
+    )
+    .recover([])
+}
+
+export async function fetchLessonsWithNavigation(brand: string) {
+  const [result, permissions] = await Promise.all([
+    groq().and(f.brand(brand)).slice(0, 10).run<Lesson[]>(),
+    fetchUserPermissions(),
+  ])
+
+  const decorated = await result
+    .map((lessons) =>
+      decorateAll<Lesson>(lessons ?? [], [accessDecorator(permissions) as FieldDecorator<Lesson>])
+    )
+    .mapAsync((lessons) => decorateNavigateTo(lessons) as Promise<Lesson[]>)
+
+  return decorated.recover([])
+}
+
+export async function fetchWithACustomDecorator(brand: string) {
+  const isFree: FieldDecorator<Lesson> = {
+    field: 'is_free',
+    compute: (lesson) => lesson.permission_id === undefined,
+  }
+
+  const result = await groq().and(f.brand(brand)).run<Lesson[]>()
+
+  return result.map((lessons) => decorateAll<Lesson>(lessons ?? [], [isFree])).recover([])
+}
+
+export async function fetchWhenPermissionsMayBeUnavailable(brand: string) {
+  const queryError = (error: unknown) =>
+    Either.left<SanityQueryError, UserPermissions>(
+      new SanityQueryError('Failed to fetch user permissions', '', error)
+    )
+
+  const [result, permissions] = await Promise.all([
+    groq().and(f.brand(brand)).run<Lesson[]>(),
+    fetchUserPermissions()
+      .then(Either.right<SanityQueryError, UserPermissions>)
+      .catch(queryError),
+  ])
+
+  return result
+    .flatMap((lessons) =>
+      permissions.map((userPermissions) =>
+        decorateAll<Lesson>(lessons ?? [], [
+          accessDecorator(userPermissions) as FieldDecorator<Lesson>,
+        ])
+      )
+    )
+    .fold(
+      (error) => `undecorated: ${error.message}`,
+      (lessons) => `${lessons.length} lessons`
+    )
+}
+
+export async function decorateManuallyForPreciseTypes(brand: string) {
+  const [result, permissions] = await Promise.all([
+    groq().and(f.brand(brand)).slice(0, 10).run<Lesson[]>(),
+    fetchUserPermissions(),
+  ])
+
+  const decorated = await result
+    .map((lessons) => decorateAccess(lessons ?? [], permissions))
+    .mapAsync((lessons) => decorateNavigateTo(lessons))
+
+  return decorated.fold(
+    () => [],
+    (lessons) => lessons.map((lesson) => [lesson.need_access, lesson.navigateTo] as const)
+  )
+}

--- a/src/lib/sanity/examples.ts
+++ b/src/lib/sanity/examples.ts
@@ -1,0 +1,87 @@
+import { Filters as f } from './filter'
+import { groq } from './groq'
+import { composite, query } from './query'
+import { run, sanityRunner, QueryRunner, SanityQueryError } from './runner'
+import { Either } from '../ads/either'
+
+interface Song {
+  _id: string
+  title: string
+  railcontent_id: number
+}
+
+interface SongPage {
+  data: Song[]
+  total: number
+}
+
+const publishedSongs = (brand: string) =>
+  f.combine(f.type('song'), f.statusIn(['published']), f.defined('railcontent_id'), f.brand(brand))
+
+export async function fetchSongTitles(brand: string) {
+  const result = await groq()
+    .and(publishedSongs(brand))
+    .order('published_on desc')
+    .slice(0, 10)
+    .select('_id', 'title', 'railcontent_id')
+    .run<Song[]>()
+
+  return result.fold(
+    (error) => {
+      console.error(`${error.name}: ${error.message}`, error.groq)
+      return []
+    },
+    (songs) => songs ?? []
+  )
+}
+
+export async function fetchSongPage(brand: string, offset: number, limit: number) {
+  const restrictions = publishedSongs(brand)
+
+  const result = await groq
+    .composite({
+      data: query()
+        .and(restrictions)
+        .order('published_on desc')
+        .slice(offset, limit)
+        .select('_id', 'title', 'railcontent_id'),
+      total: f.count(restrictions),
+    })
+    .run<SongPage>()
+
+  return result.recover({ data: [], total: 0 })
+}
+
+export async function countSongsAndLessons(brand: string) {
+  const result = await run<{ songs: number; lessons: number }>(
+    composite({
+      songs: f.count(f.combine(f.type('song'), f.brand(brand))),
+      lessons: f.count(f.combine(f.typeIn(['course', 'quick-tips']), f.brand(brand))),
+    })
+  )
+
+  return result
+    .map((counts) => counts ?? { songs: 0, lessons: 0 })
+    .map((counts) => ({ ...counts, total: counts.songs + counts.lessons }))
+    .recover({ songs: 0, lessons: 0, total: 0 })
+}
+
+export async function reportMissingSongs(brand: string) {
+  const result = await groq().and(publishedSongs(brand)).run<Song[]>()
+
+  if (result.isRight()) {
+    return result.drop()
+  }
+
+  return null
+}
+
+export async function fetchWithSharedClient(groqQueries: string[], runner: QueryRunner<Song[]>) {
+  return Promise.all(groqQueries.map((groq) => run<Song[]>(groq, runner)))
+}
+
+export function buildRunnerForTests(): QueryRunner<Song[]> {
+  return async () => Either.right<SanityQueryError, Song[]>([])
+}
+
+export const productionRunner = sanityRunner()

--- a/src/lib/sanity/groq.ts
+++ b/src/lib/sanity/groq.ts
@@ -1,0 +1,65 @@
+import { Either } from '../ads/either'
+import { FieldAccess } from './field-access'
+import { composite, query, QueryBuilder } from './query'
+import { QueryRunner, run, SanityQueryError } from './runner'
+
+export interface RunnableQuery {
+  build(): string
+  toString(): string
+  run<T>(runner?: QueryRunner<T>): Promise<Either<SanityQueryError, T | null>>
+}
+
+export interface GroqBuilder extends QueryBuilder, RunnableQuery {
+  selector(selector: string): GroqBuilder
+  and(expr: string): GroqBuilder
+  or(...exprs: string[]): GroqBuilder
+  order(expr: string): GroqBuilder
+  slice(offset: number, limit?: number): GroqBuilder
+  first(): GroqBuilder
+  select(...fields: string[]): GroqBuilder
+  access(field: string, fieldAccess?: FieldAccess): GroqBuilder
+  dereference(): GroqBuilder
+  postFilter(expr: string): GroqBuilder
+}
+
+/**
+ * @param {string} selector
+ * @returns {GroqBuilder}
+ * @example
+ * const result = await groq()
+ *   .and(f.type('song'))
+ *   .order('published_on desc')
+ *   .slice(0, 10)
+ *   .select('_id', 'title')
+ *   .run<Song[]>()
+ */
+const groqBuilder = (selector?: string): GroqBuilder => {
+  const builder = query(selector)
+
+  return Object.assign(builder, {
+    run: <T>(runner?: QueryRunner<T>) => run<T>(builder.build(), runner),
+  }) as GroqBuilder
+}
+
+/**
+ * @param {Record<string, QueryBuilder | string>} parts
+ * @returns {RunnableQuery}
+ * @example
+ * const result = await groq
+ *   .composite({
+ *     data: groq().and(restrictions).slice(0, 10).select('_id', 'title'),
+ *     total: f.count(restrictions),
+ *   })
+ *   .run<SongPage>()
+ */
+const compositeQuery = (parts: Record<string, QueryBuilder | string>): RunnableQuery => {
+  const built = composite(parts)
+
+  return {
+    build: () => built,
+    toString: () => built,
+    run: <T>(runner?: QueryRunner<T>) => run<T>(built, runner),
+  }
+}
+
+export const groq = Object.assign(groqBuilder, { composite: compositeQuery })

--- a/src/lib/sanity/runner.ts
+++ b/src/lib/sanity/runner.ts
@@ -1,0 +1,64 @@
+import { Either } from '../ads/either'
+import { SanityClient } from '../../infrastructure/sanity/SanityClient'
+
+export class SanityQueryError extends Error {
+  constructor(
+    message: string,
+    public readonly groq: string,
+    public readonly cause?: unknown
+  ) {
+    super(message)
+    this.name = 'SanityQueryError'
+  }
+}
+
+export type QueryRunner<T = unknown> = (groq: string) => Promise<Either<SanityQueryError, T | null>>
+
+/**
+ * @param {SanityClient} client
+ * @returns {QueryRunner<T>}
+ */
+export const sanityRunner =
+  <T = unknown>(client: SanityClient = new SanityClient()): QueryRunner<T> =>
+  async (groq: string) => {
+    // ponytail: refresh per query because initializeService mutates globalConfig in place;
+    // SanityClient's cached copy would go stale. Drop this if config becomes immutable.
+    client.refreshConfig()
+
+    try {
+      return Either.right<SanityQueryError, T | null>(await client.executeQuery<T>(groq))
+    } catch (error: any) {
+      return Either.left<SanityQueryError, T | null>(
+        new SanityQueryError(error?.message ?? 'Sanity query failed', groq, error)
+      )
+    }
+  }
+
+let cachedRunner: QueryRunner<unknown> | undefined
+
+// ponytail: the cast is safe because the runner never inspects T, it only forwards
+// whatever Sanity returns. One cached closure serves every result type.
+const defaultRunner = <T>(): QueryRunner<T> =>
+  (cachedRunner ??= sanityRunner<unknown>()) as QueryRunner<T>
+
+/**
+ * @param {string} groq
+ * @param {QueryRunner<T>} runner
+ * @returns {Promise<Either<SanityQueryError, T | null>>}
+ * @example
+ * const result = await run<Song[]>(query().and(f.type('song')).build())
+ * result.fold(
+ *   (error) => console.error(error.message),
+ *   (songs) => console.log(songs?.length ?? 0)
+ * )
+ * @example
+ * // a query that matches nothing is a Right holding null, not a Left,
+ * // so recover() does not replace it
+ * const empty = await run<Song[]>(groq)
+ * empty.recover([]) // null when nothing matched
+ * empty.map((songs) => songs ?? []).recover([]) // []
+ */
+export const run = <T>(
+  groq: string,
+  runner: QueryRunner<T> = defaultRunner<T>()
+): Promise<Either<SanityQueryError, T | null>> => runner(groq)

--- a/test/unit/lib/ads/coproduct.test.ts
+++ b/test/unit/lib/ads/coproduct.test.ts
@@ -1,0 +1,179 @@
+import { Coproduct, Left, Right } from '../../../../src/lib/ads/coproduct'
+
+describe('Coproduct', () => {
+  describe('construction and narrowing', () => {
+    test('left is a Left', () => {
+      const result = Coproduct.left<string, number>('boom')
+      expect(result.isLeft()).toBe(true)
+      expect(result.isRight()).toBe(false)
+      expect(result).toBeInstanceOf(Left)
+    })
+
+    test('right is a Right', () => {
+      const result = Coproduct.right<string, number>(42)
+      expect(result.isRight()).toBe(true)
+      expect(result.isLeft()).toBe(false)
+      expect(result).toBeInstanceOf(Right)
+    })
+  })
+
+  describe('map', () => {
+    test('applies the function to a right value', () => {
+      const result = Coproduct.right<string, number>(2).map((n) => n * 3)
+      expect(result.drop()).toBe(6)
+    })
+
+    test('does not call the function on a left and preserves the error', () => {
+      const fn = jest.fn()
+      const result = Coproduct.left<string, number>('boom').map(fn)
+      expect(fn).not.toHaveBeenCalled()
+      expect(result.isLeft()).toBe(true)
+      expect(result.drop()).toBe('boom')
+    })
+  })
+
+  describe('flatMap', () => {
+    test('replaces a right with the returned coproduct', () => {
+      const result = Coproduct.right<string, number>(2).flatMap((n) =>
+        Coproduct.right<string, number>(n + 1)
+      )
+      expect(result.drop()).toBe(3)
+    })
+
+    test('lets the inner function fail the chain', () => {
+      const result = Coproduct.right<string, number>(2).flatMap(() =>
+        Coproduct.left<string, number>('inner')
+      )
+      expect(result.isLeft()).toBe(true)
+      expect(result.drop()).toBe('inner')
+    })
+
+    test('does not call the function on a left', () => {
+      const fn = jest.fn()
+      const result = Coproduct.left<string, number>('boom').flatMap(fn)
+      expect(fn).not.toHaveBeenCalled()
+      expect(result.drop()).toBe('boom')
+    })
+  })
+
+  describe('mapLeft and flatMapLeft', () => {
+    test('mapLeft transforms a left value', () => {
+      const result = Coproduct.left<string, number>('boom').mapLeft((e) => e.toUpperCase())
+      expect(result.drop()).toBe('BOOM')
+    })
+
+    test('mapLeft leaves a right untouched', () => {
+      const fn = jest.fn()
+      const result = Coproduct.right<string, number>(42).mapLeft(fn)
+      expect(fn).not.toHaveBeenCalled()
+      expect(result.drop()).toBe(42)
+    })
+
+    test('flatMapLeft can recover a left into a right', () => {
+      const result = Coproduct.left<string, number>('boom').flatMapLeft(() =>
+        Coproduct.right<string, number>(0)
+      )
+      expect(result.isRight()).toBe(true)
+      expect(result.drop()).toBe(0)
+    })
+  })
+
+  describe('fold', () => {
+    test('runs the left branch for a left', () => {
+      const result = Coproduct.left<string, number>('boom').fold(
+        (e) => `error: ${e}`,
+        (n) => `value: ${n}`
+      )
+      expect(result).toBe('error: boom')
+    })
+
+    test('runs the right branch for a right', () => {
+      const result = Coproduct.right<string, number>(42).fold(
+        (e) => `error: ${e}`,
+        (n) => `value: ${n}`
+      )
+      expect(result).toBe('value: 42')
+    })
+  })
+
+  describe('foldMap', () => {
+    test('folds the left value into the accumulator', () => {
+      const result = Coproduct.left<string, number>('boom').foldMap(
+        'seen:',
+        (acc, value) => `${acc}${value}`
+      )
+      expect(result).toBe('seen:boom')
+    })
+
+    test('folds the right value into the accumulator', () => {
+      const result = Coproduct.right<string, number>(42).foldMap(
+        'seen:',
+        (acc, value) => `${acc}${value}`
+      )
+      expect(result).toBe('seen:42')
+    })
+  })
+
+  describe('recover', () => {
+    test('returns the fallback for a left', () => {
+      expect(Coproduct.left<string, number>('boom').recover(0)).toBe(0)
+    })
+
+    test('returns the value for a right and ignores the fallback', () => {
+      expect(Coproduct.right<string, number>(42).recover(0)).toBe(42)
+    })
+  })
+
+  describe('tap and ltap', () => {
+    test('tap visits a right value and returns the same instance', () => {
+      const seen: number[] = []
+      const right = Coproduct.right<string, number>(42)
+      const result = right.tap((n) => seen.push(n))
+      expect(seen).toEqual([42])
+      expect(result).toBe(right)
+    })
+
+    test('tap does not visit a left', () => {
+      const fn = jest.fn()
+      Coproduct.left<string, number>('boom').tap(fn)
+      expect(fn).not.toHaveBeenCalled()
+    })
+
+    test('ltap visits a left value and returns the same instance', () => {
+      const seen: string[] = []
+      const left = Coproduct.left<string, number>('boom')
+      const result = left.ltap((e) => seen.push(e))
+      expect(seen).toEqual(['boom'])
+      expect(result).toBe(left)
+    })
+
+    test('ltap does not visit a right', () => {
+      const fn = jest.fn()
+      Coproduct.right<string, number>(42).ltap(fn)
+      expect(fn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('drop', () => {
+    test('unwraps either side', () => {
+      expect(Coproduct.left<string, number>('boom').drop()).toBe('boom')
+      expect(Coproduct.right<string, number>(42).drop()).toBe(42)
+    })
+  })
+
+  describe('immutability', () => {
+    test('map returns a new instance rather than mutating', () => {
+      const original = Coproduct.right<string, number>(2)
+      const mapped = original.map((n) => n * 2)
+      expect(mapped).not.toBe(original)
+      expect(original.drop()).toBe(2)
+    })
+
+    test('mapping a left returns a new Left carrying the same error', () => {
+      const original = Coproduct.left<string, number>('boom')
+      const mapped = original.map((n) => n * 2)
+      expect(mapped).not.toBe(original)
+      expect(mapped.drop()).toBe('boom')
+    })
+  })
+})

--- a/test/unit/lib/ads/coproduct.test.ts
+++ b/test/unit/lib/ads/coproduct.test.ts
@@ -56,6 +56,38 @@ describe('Coproduct', () => {
     })
   })
 
+  describe('mapAsync', () => {
+    test('awaits the function and wraps the resolved value for a right', async () => {
+      const result = await Coproduct.right<string, number>(2).mapAsync(async (n) => n * 3)
+      expect(result.isRight()).toBe(true)
+      expect(result.drop()).toBe(6)
+    })
+
+    test('does not call the function on a left and preserves the error', async () => {
+      const fn = jest.fn()
+      const result = await Coproduct.left<string, number>('boom').mapAsync(fn)
+      expect(fn).not.toHaveBeenCalled()
+      expect(result.isLeft()).toBe(true)
+      expect(result.drop()).toBe('boom')
+    })
+
+    test('returns a new instance rather than mutating', async () => {
+      const original = Coproduct.right<string, number>(2)
+      const mapped = await original.mapAsync(async (n) => n * 2)
+      expect(mapped).not.toBe(original)
+      expect(original.drop()).toBe(2)
+    })
+
+    test('propagates a rejection instead of converting it to a left', async () => {
+      const failure = new Error('async boom')
+      await expect(
+        Coproduct.right<string, number>(2).mapAsync(async () => {
+          throw failure
+        })
+      ).rejects.toBe(failure)
+    })
+  })
+
   describe('mapLeft and flatMapLeft', () => {
     test('mapLeft transforms a left value', () => {
       const result = Coproduct.left<string, number>('boom').mapLeft((e) => e.toUpperCase())

--- a/test/unit/lib/ads/either.test.ts
+++ b/test/unit/lib/ads/either.test.ts
@@ -1,0 +1,28 @@
+import { Either } from '../../../../src/lib/ads/either'
+import { Left, Right } from '../../../../src/lib/ads/coproduct'
+
+describe('Either', () => {
+  test('left builds a Left carrying the error', () => {
+    const result = Either.left<string, number>('boom')
+    expect(result).toBeInstanceOf(Left)
+    expect(result.isLeft()).toBe(true)
+    expect(result.drop()).toBe('boom')
+  })
+
+  test('right builds a Right carrying the value', () => {
+    const result = Either.right<string, number>(42)
+    expect(result).toBeInstanceOf(Right)
+    expect(result.isRight()).toBe(true)
+    expect(result.drop()).toBe(42)
+  })
+
+  test('keeps the full Coproduct behaviour', () => {
+    const result = Either.right<string, number>(2)
+      .map((n) => n * 3)
+      .fold(
+        (error) => `error: ${error}`,
+        (n) => `value: ${n}`
+      )
+    expect(result).toBe('value: 6')
+  })
+})

--- a/test/unit/lib/sanity/groq.test.ts
+++ b/test/unit/lib/sanity/groq.test.ts
@@ -1,0 +1,117 @@
+import { groq } from '../../../../src/lib/sanity/groq'
+import { QueryRunner, SanityQueryError } from '../../../../src/lib/sanity/runner'
+import { Either } from '../../../../src/lib/ads/either'
+
+const recordingRunner =
+  (seen: string[]): QueryRunner<string[]> =>
+  async (executed) => {
+    seen.push(executed)
+    return Either.right(['ok'])
+  }
+
+describe('groq', () => {
+  test('builds the same string as the plain query builder', () => {
+    const result = groq().and('_type == "song"').build()
+    expect(result).toBe('*[_type == "song"]')
+  })
+
+  test('keeps run available after every chained call', async () => {
+    const seen: string[] = []
+
+    await groq()
+      .and('_type == "song"')
+      .order('published_on desc')
+      .slice(0, 10)
+      .select('_id', 'title')
+      .run(recordingRunner(seen))
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toContain('*[_type == "song"]')
+    expect(seen[0]).toContain('{ _id, title }')
+    expect(seen[0]).toContain('| order(published_on desc)')
+    expect(seen[0]).toContain('[0...10]')
+  })
+
+  test('returns the runner result', async () => {
+    const result = await groq().and('_type == "song"').run(recordingRunner([]))
+
+    expect(result.isRight()).toBe(true)
+    expect(result.drop()).toEqual(['ok'])
+  })
+
+  test('passes a failure through untouched', async () => {
+    const error = new SanityQueryError('boom', '*[]')
+    const failingRunner: QueryRunner<string[]> = async () => Either.left(error)
+
+    const result = await groq().and('_type == "song"').run(failingRunner)
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.drop()).toBe(error)
+  })
+
+  test('runs the query as built at call time', async () => {
+    const seen: string[] = []
+    const builder = groq().and('_type == "song"')
+
+    await builder.run(recordingRunner(seen))
+    builder.and('brand == "drumeo"')
+    await builder.run(recordingRunner(seen))
+
+    expect(seen[0]).toBe('*[_type == "song"]')
+    expect(seen[1]).toBe('*[_type == "song" && brand == "drumeo"]')
+  })
+
+  test('accepts a custom selector', () => {
+    const result = groq('*[_type == "song"]').and('brand == "drumeo"').build()
+    expect(result).toBe('*[_type == "song"][brand == "drumeo"]')
+  })
+})
+
+describe('groq.composite', () => {
+  test('builds the wrapper object from builders and strings', () => {
+    const result = groq
+      .composite({
+        data: groq().and('_type == "song"'),
+        total: 'count(*[_type == "song"])',
+      })
+      .build()
+
+    expect(result).toBe('{ "data": *[_type == "song"], "total": count(*[_type == "song"]) }')
+  })
+
+  test('runs the composed query', async () => {
+    const seen: string[] = []
+
+    await groq.composite({ songs: 'count(*[_type == "song"])' }).run(recordingRunner(seen))
+
+    expect(seen).toEqual(['{ "songs": count(*[_type == "song"]) }'])
+  })
+
+  test('stringifies its parts eagerly, unlike a groq() chain', async () => {
+    const seen: string[] = []
+    const inner = groq().and('_type == "song"')
+    const composed = groq.composite({ data: inner })
+
+    inner.and('brand == "drumeo"')
+    await composed.run(recordingRunner(seen))
+
+    expect(seen).toEqual(['{ "data": *[_type == "song"] }'])
+  })
+
+  test('returns the runner result', async () => {
+    const result = await groq.composite({ songs: 'count(*[])' }).run(recordingRunner([]))
+
+    expect(result.isRight()).toBe(true)
+    expect(result.drop()).toEqual(['ok'])
+  })
+
+  test('passes a failure through untouched', async () => {
+    const error = new SanityQueryError('boom', '{}')
+    const failingRunner: QueryRunner<string[]> = async () => Either.left(error)
+
+    const result = await groq.composite({ songs: 'count(*[])' }).run(failingRunner)
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.drop()).toBe(error)
+  })
+})

--- a/test/unit/lib/sanity/runner.test.ts
+++ b/test/unit/lib/sanity/runner.test.ts
@@ -1,0 +1,162 @@
+import { run, sanityRunner, SanityQueryError, QueryRunner } from '../../../../src/lib/sanity/runner'
+import { Either } from '../../../../src/lib/ads/either'
+import { SanityClient } from '../../../../src/infrastructure/sanity/SanityClient'
+import { ConfigProvider } from '../../../../src/infrastructure/sanity/interfaces/ConfigProvider'
+import { QueryExecutor } from '../../../../src/infrastructure/sanity/interfaces/QueryExecutor'
+import { SanityConfig } from '../../../../src/infrastructure/sanity/interfaces/SanityConfig'
+
+const stubConfig: SanityConfig = {
+  projectId: 'test-project',
+  dataset: 'test-dataset',
+  version: '2021-06-07',
+  token: 'test-token',
+}
+
+const stubConfigProvider: ConfigProvider = {
+  getConfig: () => stubConfig,
+}
+
+const resolvingExecutor = (result: unknown): QueryExecutor => ({
+  execute: async () => ({ result, ms: 1, query: 'irrelevant' }) as any,
+})
+
+const throwingExecutor = (error: unknown): QueryExecutor => ({
+  execute: async () => {
+    throw error
+  },
+})
+
+const clientWith = (executor: QueryExecutor, configProvider = stubConfigProvider) =>
+  new SanityClient(configProvider, executor)
+
+describe('sanityRunner', () => {
+  test('wraps a resolved result in a Right', async () => {
+    const documents = [{ _id: 'song-1' }, { _id: 'song-2' }]
+    const runner = sanityRunner(clientWith(resolvingExecutor(documents)))
+
+    const result = await runner('*[_type == "song"]')
+
+    expect(result.isRight()).toBe(true)
+    expect(result.drop()).toEqual(documents)
+  })
+
+  test('treats a query that matched nothing as a Right holding null', async () => {
+    const runner = sanityRunner(clientWith(resolvingExecutor(null)))
+
+    const result = await runner('*[_type == "nope"]')
+
+    expect(result.isRight()).toBe(true)
+    expect(result.drop()).toBeNull()
+  })
+
+  test('wraps a transport failure in a Left carrying a SanityQueryError', async () => {
+    const runner = sanityRunner(clientWith(throwingExecutor(new Error('network down'))))
+
+    const result = await runner('*[_type == "song"]')
+
+    expect(result.isLeft()).toBe(true)
+    const error = result.drop() as SanityQueryError
+    expect(error).toBeInstanceOf(SanityQueryError)
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toBe('network down')
+  })
+
+  test('preserves the failing query on the error', async () => {
+    const groq = '*[_type == "song" && brand == "drumeo"]'
+    const runner = sanityRunner(clientWith(throwingExecutor(new Error('boom'))))
+
+    const result = await runner(groq)
+
+    expect((result.drop() as SanityQueryError).groq).toBe(groq)
+  })
+
+  test('carries the original thrown value as the cause', async () => {
+    const original = { message: 'Sanity API error: 500', query: '*[]' }
+    const runner = sanityRunner(clientWith(throwingExecutor(original)))
+
+    const result = await runner('*[]')
+
+    expect((result.drop() as SanityQueryError).cause).toBe(original)
+  })
+
+  test('reports a missing configuration as a Left instead of throwing', async () => {
+    const failingConfigProvider: ConfigProvider = {
+      getConfig: () => {
+        throw new Error('Sanity token is missing in configuration')
+      },
+    }
+    const runner = sanityRunner(clientWith(resolvingExecutor([]), failingConfigProvider))
+
+    const result = await runner('*[]')
+
+    expect(result.isLeft()).toBe(true)
+    expect((result.drop() as SanityQueryError).message).toBe(
+      'Sanity token is missing in configuration'
+    )
+  })
+
+  test('refreshes the client configuration before every query', async () => {
+    const client = clientWith(resolvingExecutor([]))
+    const refreshSpy = jest.spyOn(client, 'refreshConfig')
+    const runner = sanityRunner(client)
+
+    await runner('*[]')
+    await runner('*[]')
+
+    expect(refreshSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('reads the configuration again after globalConfig changes', async () => {
+    let projectId = 'first-project'
+    const seenProjectIds: string[] = []
+    const mutableConfigProvider: ConfigProvider = {
+      getConfig: () => ({ ...stubConfig, projectId }),
+    }
+    const recordingExecutor: QueryExecutor = {
+      execute: async (_query, config) => {
+        seenProjectIds.push(config.projectId)
+        return { result: [], ms: 1, query: '*[]' } as any
+      },
+    }
+    const runner = sanityRunner(clientWith(recordingExecutor, mutableConfigProvider))
+
+    await runner('*[]')
+    projectId = 'second-project'
+    await runner('*[]')
+
+    expect(seenProjectIds).toEqual(['first-project', 'second-project'])
+  })
+})
+
+describe('run', () => {
+  test('forwards the query to the injected runner', async () => {
+    const seen: string[] = []
+    const fakeRunner: QueryRunner<string[]> = async (groq) => {
+      seen.push(groq)
+      return Either.right(null)
+    }
+
+    await run('*[_type == "song"]', fakeRunner)
+
+    expect(seen).toEqual(['*[_type == "song"]'])
+  })
+
+  test('returns the runner result untouched', async () => {
+    const expected = Either.right<SanityQueryError, string[]>(['a'])
+    const fakeRunner: QueryRunner<string[]> = async () => expected
+
+    const result = await run<string[]>('*[]', fakeRunner)
+
+    expect(result).toBe(expected)
+  })
+
+  test('returns a Left untouched when the runner fails', async () => {
+    const error = new SanityQueryError('boom', '*[]')
+    const fakeRunner: QueryRunner<string[]> = async () => Either.left(error)
+
+    const result = await run('*[]', fakeRunner)
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.drop()).toBe(error)
+  })
+})


### PR DESCRIPTION
## Jira Ticket(s)/RelatedPR(s)

- Builds on #1034 (`composite()`), already merged
- Plan: `.claude/docs/architecture/groq-query-builder-execution.md` (tracked by this PR)

## Description/Design

The query builder built GROQ strings and stopped there — `build()` returned a string and nothing ran it. Execution lived in `SanityClient`, connected only by string interpolation.

The error contract was the thing worth fixing. All three `SanityClient` methods *look* like they return a null-ish fallback on failure:

```ts
} catch (error: any) {
  this.handleError(error, query)
  return null            // SanityClient.ts:37, :52 (`return []`), :67
}
```

`handleError` is declared `: never` and throws unconditionally, so **all three fallback returns are unreachable**. The real contract is "`null` when the query matched nothing, throws when the request failed" — two very different outcomes, one invisible at the type level.

### What this adds

```ts
const result = await groq()
  .and(f.type('song'))
  .order('published_on desc')
  .slice(0, 10)
  .run<Song[]>()

result.fold(
  (error) => console.error(`${error.name}: ${error.message}`, error.groq),
  (songs) => songs ?? []
)
```

- **`run()` returns `Either<SanityQueryError, T | null>`** instead of throwing. A query that matched nothing is `Right(null)`; a failed request is `Left`. That distinction is the entire point, so empty is deliberately *not* folded into `Left`.
- **`SanityQueryError` is a real `Error` subclass**, replacing the object literals cast to an interface that the Sanity infrastructure throws today — those carry no stack and fail `instanceof Error`.
- **`groq()` is a composition root**, in its own module. It is *not* a method on `QueryBuilder`: `filter.ts` imports `query.ts`, so a `run()` method there would drag the transport into every consumer of `Filters`. `groq.ts` imports both `query` and `runner`; neither imports the other.
- **`groq.composite()`** wraps the merged `composite()` into a `RunnableQuery` that is deliberately **not** chainable — `.and()` on a composite isn't valid GROQ, and the type now says so.
- **`mapAsync` on `Coproduct`**, so the existing typed decorators compose with query results (see below).

### Decorators compose through the ADT

The decorators in `src/lib/sanity/decorators/` are `(items) => items` transforms, so the sync ones already compose with `map`. `decorateNavigateTo` is async, and `map` with an async function yields `Either<E, Promise<T>>` — a promise trapped inside the container. Nothing in the repo offered `mapAsync`/`traverse`/`sequence`, so a caller had to abandon the ADT exactly where it should help.

```ts
const decorated = await result
  .map((lessons) => decorateAccess(lessons ?? [], permissions))   // WithNeedAccess<Lesson>[]
  .mapAsync((lessons) => decorateNavigateTo(lessons))             // + WithNavigateTo
```

A rejection propagates rather than becoming a `Left` — there is no way to build an `L` from it, and the never-throws guarantee belongs to the boundary, not to the functor. A test asserts the propagation so it isn't later mistaken for an oversight and swallowed.

**No decorator file is modified.** `git diff --name-only main...HEAD -- src/lib/sanity/decorators/ src/services/` is empty for this PR.

### Deliberate omissions

- **No `kind`/`status` on the error.** `createSanityError` (`FetchQueryExecutor.ts:89-109`) formats the HTTP status into a message string and returns an object without it — and overwrites that string entirely when Sanity returns a JSON body. Neither is obtainable without editing the transport, which this PR doesn't touch.
- **No `params` argument.** `Filters` bakes values in before `run()` is called, so nothing could supply one.
- **No `runComposite`.** It would be a pure alias for `run(composite(parts))`.
- **No decorate-and-run helper.** One was written and removed: it serves no call site yet, and shaping it without one produced an API whose options were guesses. The two things it encoded — fetching permissions alongside the query, and catching a rejected permissions fetch into an `Either` before `Promise.all` sees it — are demonstrated in `examples.ts` instead. Worth revisiting when a real migration needs it.

### `Either` is an alias, not a subclass

```ts
export type Either<L, R> = Coproduct<L, R>
export const Either = { left: Coproduct.left, right: Coproduct.right }
```

Categorically the binary coproduct **is** `Either` — `Left`/`Right` are its canonical injections, which is why Haskell and Scala declare them on `Either` directly. Subclassing would carve at the wrong joint: neighbouring types differ by *algebra*, not shape (`Validation` accumulates errors applicatively; `These` has three cases). Shared behaviour belongs on the existing typeclasses — `Functor`, `Monad`, `Tappable`, `Foldable`, `Recoverable`, `Droppable`.

`Coproduct` itself is ported forward from the long-lived `chore/ads-structures` branch, which sits 1331 commits behind main and has no `src/lib/sanity`, so nothing on it was usable as-is.

## Testing

- How to verify: `npm test`
- Environment: local
- Expected outcome: 1227 pass across 75 suites. `tsc --noEmit` and `prettier --check` clean.

The tests carrying design rather than code:

```ts
// runner.test.ts — the lazy singleton must not pin stale config
test('reads the configuration again after globalConfig changes', ...)

// groq.test.ts — opposite build semantics, pinned as a matched pair
test('runs the query as built at call time', ...)                 // groq()
test('stringifies its parts eagerly, unlike a groq() chain', ...) // groq.composite()

// coproduct.test.ts — the documented contract, so nobody "fixes" it into a swallow
test('propagates a rejection instead of converting it to a left', ...)
```

Fakes construct a **real** `SanityClient` with fake `QueryExecutor`/`ConfigProvider` rather than mocking `executeQuery`, so the actual `handleError` conversion is exercised — that conversion is the thing being built.

## Additional Notes

- **Ships unused.** No service file is modified; `query.ts`, `filter.ts`, `SanityClient.ts`, `FetchQueryExecutor.ts`, everything under `decorators/`, and `services/sanity.js` are untouched. Call sites migrate one at a time in later PRs.
- **`examples.ts` earned its place twice.** It's compile-checked usage (precedent: `infrastructure/sanity/examples/usage.ts`, `lib/sanity/decorators/examples.ts`). Writing it surfaced (1) that `QueryRunner` put its generic on the *call* rather than the type, making the runner impossible to fake without `as any` — which three unit tests had already silently done; and (2) that `WithNeedAccess<T>` degrades the recursive `children` type when `T` has an index signature, breaking a `decorateAccess` → `decorateNavigateTo` chain. JSDoc `@example` blocks would have caught neither; they aren't compiled.
- Example files are now excluded from coverage collection — no business logic, not exported from the package index, so counting them as uncovered production code was noise. This *raises* the reported percentage rather than lowering the thresholds.
- **Config freshness.** The default runner is a lazy singleton calling `refreshConfig()` per query, because `initializeService` mutates `globalConfig` in place while `DefaultConfigProvider` hands back a copy that `SanityClient` caches — otherwise it serves a snapshot taken at first query, which breaks between test cases.
- **Known migration blockers**, recorded for whoever moves a `fetchSanity` call site: results from `run()` are undecorated by default; `decorateAll` only walks `children`, whereas the legacy `contentResultsDecorator` also walks `result.content[]` and `results.entity[].lessons`; and `fetchUserPermissions` memoizes *rejected* promises for up to 10s, so one blip can produce a run of failures.
- Includes the Coproduct port that was on `feat/ads-coproduct`; that branch gets no separate PR.
